### PR TITLE
Add assignments to course duplicate

### DIFF
--- a/acj/api/assignment.py
+++ b/acj/api/assignment.py
@@ -223,7 +223,7 @@ class AssignmentRootAPI(Resource):
         assignment = Assignment(course_id=course.id)
         restrict_user = not allow(MANAGE, assignment)
 
-        # Get all assignments for this course, default order is most recent first
+        # Get all assignments for this course, order by answer_start date
         base_query = Assignment.query \
             .options(joinedload("assignment_criteria").joinedload("criterion")) \
             .options(undefer_group('counts')) \
@@ -231,7 +231,7 @@ class AssignmentRootAPI(Resource):
                 Assignment.course_id == course.id,
                 Assignment.active == True
             ) \
-            .order_by(desc(Assignment.created))
+            .order_by(desc(Assignment.answer_start))
 
         if restrict_user:
             now = datetime.datetime.utcnow()

--- a/acj/api/dataformat/__init__.py
+++ b/acj/api/dataformat/__init__.py
@@ -107,8 +107,8 @@ def get_assignment(restrict_user=True):
 
         'answer_start': fields.DateTime(dt_format='iso8601'),
         'answer_end': fields.DateTime(dt_format='iso8601'),
-        'compare_start': fields.DateTime(dt_format='iso8601'),
-        'compare_end': fields.DateTime(dt_format='iso8601'),
+        'compare_start': fields.DateTime(dt_format='iso8601', default=None),
+        'compare_end': fields.DateTime(dt_format='iso8601', default=None),
         'available': fields.Boolean,
 
         'students_can_reply': fields.Boolean,

--- a/acj/static/modules/course/course-duplicate-partial.html
+++ b/acj/static/modules/course/course-duplicate-partial.html
@@ -6,17 +6,165 @@
 
     <fieldset>
         <legend>Course Details</legend>
-        <acj-field-with-feedback form-control="duplicateCourseForm.courseYear">
-            <label for="courseYear" class="required-star">Year</label>
-            <input id="courseYear" name="courseYear" ng-model="duplicateCourse.year"
+        <div class="row">
+            <div class="col-md-6 form-group">
+                <acj-field-with-feedback form-control="duplicateCourseForm.courseYear">
+                    <label for="courseYear" class="required-star">Year</label>
+                    <input id="courseYear" name="courseYear" ng-model="duplicateCourse.year"
                     type="number" class="form-control" required min="1900" />
-        </acj-field-with-feedback>
-
-        <acj-field-with-feedback form-control="duplicateCourseForm.courseTerm">
-            <label for="courseTerm" class="required-star">Term/Semester</label>
-            <input id="courseTerm" name="courseTerm" ng-model="duplicateCourse.term"
+                </acj-field-with-feedback>
+            </div>
+            <div class="col-md-6 form-group">
+                <acj-field-with-feedback form-control="duplicateCourseForm.courseTerm">
+                    <label for="courseTerm" class="required-star">Term/Semester</label>
+                    <input id="courseTerm" name="courseTerm" ng-model="duplicateCourse.term"
                     type="text" class="form-control" required maxlength="255" />
-        </acj-field-with-feedback>
+                </acj-field-with-feedback>
+            </div>
+        </div>
+    </fieldset>
+
+    <fieldset>
+        <legend>Schedule</legend>
+        <div class="row">
+            <div class="col-md-6 form-group">
+                <label>Course Begins</label><br />
+                <div class="assignment-date">
+                    <span class="input-group">
+                        <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="duplicateCourse.date.course_start.date" is-open="duplicateCourse.date.course_start.opened" />
+                        <span class="input-group-btn">
+                            <button type="button" class="btn btn-default" ng-click="duplicateCourse.date.course_start.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                        </span>
+                    </span>
+                </div>
+                <div class="assignment-date">
+                    <timepicker ng-model="duplicateCourse.date.course_start.time" minute-step="1" mousewheel="false"></timepicker>
+                </div>
+            </div>
+            <div class="col-md-6 form-group">
+                <label>Course Ends</label><br />
+                <div class="assignment-date">
+                    <span class="input-group">
+                        <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="duplicateCourse.date.course_end.date" is-open="duplicateCourse.date.course_end.opened" />
+                        <span class="input-group-btn">
+                            <button type="button" class="btn btn-default" ng-click="duplicateCourse.date.course_end.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                        </span>
+                    </span>
+                </div>
+                <div class="assignment-date">
+                    <timepicker ng-model="duplicateCourse.date.course_end.time" minute-step="1" mousewheel="false"></timepicker>
+                </div>
+            </div>
+        </div>
+    </fieldset>
+
+    <fieldset ng-show="duplicateAssignments.length">
+        <legend>Assignment Schedule ({{duplicateAssignments.length}} Assignments)</legend>
+
+        <div class="form-group">
+            <a class="btn btn-default" ng-click="adjustDuplicateAssignmentDates()">
+                Adjust Assignment Dates
+            </a>
+            <label>Automatically adjust assignment answer and comparison dates based on the new course start date.</label>
+        </div>
+
+        <!-- Assignments List -->
+        <div class="each-assignment" ng-class="{'first-child': $first}"
+            ng-repeat="assignment in duplicateAssignments">
+
+            <hr />
+
+            <h3 class="media-heading">
+                {{assignment.name}}
+            </h3>
+            <div class="form-group">
+                <input id="availableCheck-{{assignment.id}}" type="checkbox" ng-model="assignment.availableCheck">
+                <label for="availableCheck-{{assignment.id}}">Set comparison period</label>
+            </div>
+
+            <div class="row">
+                <div class="col-md-6 form-group">
+                    <label class="required-star">
+                        Answering Begins
+                        <span ng-if="duplicateCourse.date.course_start.date">
+                            (week #{{assignment.date.astart.date | amDifference : duplicateCourse.date.course_start.date : 'weeks' }})
+                        </span>
+                    </label><br />
+                    <div class="assignment-date">
+                        <span class="input-group">
+                            <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="assignment.date.astart.date" is-open="assignment.date.astart.opened" required />
+                            <span class="input-group-btn">
+                                <button type="button" class="btn btn-default" ng-click="assignment.date.astart.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                            </span>
+                        </span>
+                    </div>
+                    <div class="assignment-date">
+                        <timepicker ng-model="assignment.date.astart.time" minute-step="1" mousewheel="false"></timepicker>
+                    </div>
+                </div>
+                <div class="col-md-6 form-group">
+                    <label class="required-star">
+                        Answering Ends
+                        <span ng-if="duplicateCourse.date.course_start.date">
+                            (week #{{assignment.date.aend.date | amDifference : duplicateCourse.date.course_start.date : 'weeks' }})
+                        </span>
+                    </label><br />
+                    <div class="assignment-date">
+                        <span class="input-group">
+                            <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="assignment.date.aend.date" is-open="assignment.date.aend.opened" required />
+                            <span class="input-group-btn">
+                                <button type="button" class="btn btn-default" ng-click="assignment.date.aend.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                            </span>
+                        </span>
+                    </div>
+                    <div class="assignment-date">
+                        <timepicker ng-model="assignment.date.aend.time" minute-step="1" mousewheel="false"></timepicker>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row" ng-show="assignment.availableCheck">
+                <div class="col-md-6 form-group">
+                    <label class="required-star">
+                        Comparing Begins
+                        <span ng-if="duplicateCourse.date.course_start.date">
+                            (week #{{assignment.date.cstart.date | amDifference : duplicateCourse.date.course_start.date : 'weeks' }})
+                        </span>
+                    </label><br />
+                    <div class="assignment-date">
+                        <span class="input-group">
+                            <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="assignment.date.cstart.date" is-open="assignment.date.cstart.opened" ng-required="assignment.availableCheck" />
+                            <span class="input-group-btn">
+                                <button type="button" class="btn btn-default" ng-click="assignment.date.cstart.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                            </span>
+                        </span>
+                    </div>
+                    <div class="assignment-date">
+                        <timepicker ng-model="assignment.date.cstart.time" minute-step="1" mousewheel="false"></timepicker>
+                    </div>
+                </div>
+                <div class="col-md-6 form-group">
+                    <label class="required-star">
+                        Comparing Ends
+                        <span ng-if="duplicateCourse.date.course_start.date">
+                            (week #{{assignment.date.cend.date | amDifference : duplicateCourse.date.course_start.date : 'weeks' }})
+                        </span>
+                    </label><br />
+                    <div class="assignment-date">
+                        <span class="input-group">
+                            <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="assignment.date.cend.date" is-open="assignment.date.cend.opened" ng-required="assignment.availableCheck" />
+                            <span class="input-group-btn">
+                                <button type="button" class="btn btn-default" ng-click="assignment.date.cend.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                            </span>
+                        </span>
+                    </div>
+                    <div class="assignment-date">
+                        <timepicker ng-model="assignment.date.cend.time" minute-step="1" mousewheel="false"></timepicker>
+                    </div>
+                </div>
+            </div>
+
+        </div>
     </fieldset>
 
     <input type="submit" class="btn btn-success btn-lg center-block" value="Duplicate Course"

--- a/acj/static/modules/course/course-module_spec.js
+++ b/acj/static/modules/course/course-module_spec.js
@@ -131,7 +131,7 @@ describe('course-module', function () {
                 it('should be able to save new course', function () {
                     $rootScope.course = angular.copy(course);
                     $rootScope.course.id = undefined;
-                    $httpBackend.expectPOST('/api/courses', $rootScope.course).respond(angular.merge({}, course, {id: "2abcABC123-abcABC123_Z",}));
+                    $httpBackend.expectPOST('/api/courses', $rootScope.course).respond(angular.merge({}, course, {id: "2abcABC123-abcABC123_Z"}));
                     $rootScope.save();
                     expect($rootScope.submitted).toBe(true);
                     $httpBackend.flush();
@@ -197,6 +197,439 @@ describe('course-module', function () {
                     expect($rootScope.submitted).toBe(true);
                     $httpBackend.flush();
                     expect($rootScope.submitted).toBe(false);
+                });
+            });
+        });
+    });
+
+    describe('CourseSelectModalController', function () {
+        var $rootScope, createController, $location, $modal, $q;
+
+        beforeEach(inject(function ($controller, _$rootScope_, _$location_, _$modal_, _$q_) {
+            $rootScope = _$rootScope_;
+            $location = _$location_;
+            $modal = _$modal_;
+            $q = _$q_;
+            modalInstance = {
+                close: jasmine.createSpy('modalInstance.close'),
+                dismiss: jasmine.createSpy('modalInstance.dismiss'),
+                result: {
+                    then: jasmine.createSpy('modalInstance.result.then')
+                }
+            };
+            createController = function (route, params) {
+                return $controller('CourseSelectModalController', {
+                    $scope: $rootScope,
+                    $modalInstance: modalInstance,
+                    $routeParams: params || {}
+                });
+            }
+        }));
+
+        describe('view:', function () {
+            var controller;
+            var toaster;
+            var courses = [
+                {
+                    "available": false,
+                    "created": "2016-07-29T19:34:40",
+                    "description": null,
+                    "end_date": "2017-04-28T23:00:00",
+                    "id": "1abcABC123-abcABC123_Z",
+                    "lti_linked": false,
+                    "modified": "2016-08-18T16:44:39",
+                    "name": "Another course",
+                    "start_date": "2017-01-02T23:00:00",
+                    "term": "Summer",
+                    "year": 2016
+                },
+                {
+                    "available": true,
+                    "created": "2016-10-04T21:32:54",
+                    "description": "<p>This is the test course</p>\n",
+                    "end_date": "2017-02-11T07:59:00",
+                    "id": "2abcABC123-abcABC123_Z",
+                    "lti_linked": false,
+                    "modified": "2016-10-04T21:32:54",
+                    "name": "test course",
+                    "start_date": "2016-10-03T07:00:00",
+                    "term": "asdasdasd",
+                    "year": 2016
+                }
+            ]
+            beforeEach(inject(function (_Toaster_) {
+                toaster = _Toaster_;
+                spyOn(toaster, 'error');
+            }));
+
+            beforeEach(function () {
+                controller = createController();
+                $httpBackend.expectGET('/api/users/courses?page=1&perPage=10').respond({
+                    'objects': courses,
+                    'page': 1,
+                    'pages': 1,
+                    'per_page': 10,
+                    'total': 2
+                });
+                $httpBackend.flush();
+            });
+
+            it('should have correct initial states', function () {
+                expect($rootScope.loggedInUserId).toEqual(id);
+                expect($rootScope.submitted).toBe(false);
+                expect($rootScope.totalNumCourses).toEqual(courses.length);
+                expect($rootScope.courseFilters).toEqual({
+                    page: 1,
+                    perPage: 10
+                });
+                expect($rootScope.courses).toEqual(courses);
+                expect($rootScope.showDuplicateForm).toBe(false);
+                expect($rootScope.course).toEqual({
+                    year: new Date().getFullYear(),
+                    name: ""
+                });
+                expect($rootScope.format).toEqual('dd-MMMM-yyyy');
+                expect($rootScope.originalCourse).toEqual({});
+                expect($rootScope.duplicateCourse).toEqual({});
+            });
+
+            describe('select existing:', function () {
+                it('should close dialog when existing course selected', function() {
+                    $rootScope.selectCourse(courses[0]);
+                    expect(modalInstance.close).toHaveBeenCalledWith(courses[0].id);
+                });
+            });
+
+            describe('select new:', function () {
+                var course = {
+                    "name": "Test111",
+                    "year": 2015,
+                    "term": "Winter",
+                    "start_date": null,
+                    "end_date": null,
+                    "descriptionCheck": true,
+                    "description": "<p>Description</p>\n"
+                };
+
+                it('should error when start date is not before end date', function () {
+                    $rootScope.course = angular.copy(course);
+                    $rootScope.course.id = undefined;
+                    $rootScope.date.course_start.date = new Date();
+                    $rootScope.date.course_start.time = new Date();
+                    $rootScope.date.course_end.date = new Date();
+                    $rootScope.date.course_end.time = new Date();
+                    $rootScope.date.course_end.date.setDate($rootScope.date.course_end.date.getDate()-1);
+
+                    $rootScope.save();
+                    expect($rootScope.submitted).toBe(false);
+                    expect(toaster.error).toHaveBeenCalledWith('Course Period Conflict', 'Course end date/time must be after course start date/time.');
+                    expect(modalInstance.close.calls.count()).toEqual(0);
+                });
+
+                it('should be able to save new course', function () {
+                    $rootScope.course = angular.copy(course);
+                    var newCourseId = "3abcABC123-abcABC123_Z"
+                    $rootScope.course.id = undefined;
+                    $httpBackend.expectPOST('/api/courses', $rootScope.course).respond(angular.merge({}, course, {id: newCourseId}));
+                    $rootScope.save();
+                    expect($rootScope.submitted).toBe(true);
+                    $httpBackend.flush();
+                    expect($rootScope.submitted).toBe(false);
+                    expect(modalInstance.close).toHaveBeenCalledWith(newCourseId);
+                });
+            });
+
+            describe('duplicate existing:', function () {
+                var assignments = [
+                    {
+                        "after_comparing": true,
+                        "answer_count": 2,
+                        "answer_end": "2017-04-09T13:59:00",
+                        "answer_period": false,
+                        "answer_start": "2017-03-25T14:00:00",
+                        "available": false,
+                        "comment_count": 0,
+                        "compare_end": null,
+                        "compare_period": false,
+                        "compare_start": null,
+                        "compared": false,
+                        "course_id": "oMtDpqO7Qu-0m-wYCWRE1A",
+                        "created": "2016-10-04T21:32:54",
+                        "criteria": [
+                            {
+                                "compared": true,
+                                "created": "2016-06-06T19:50:47",
+                                "default": true,
+                                "description": "<p>Choose the response that you think is the better of the two.</p>",
+                                "id": "1abcABC123-abcABC123_Z",
+                                "modified": "2016-06-06T19:50:47",
+                                "name": "Which is better?",
+                                "public": true,
+                                "user_id": "hJYTzpyVQcCnSN3raYtxGQ"
+                            }
+                        ],
+                        "description": "",
+                        "educators_can_compare": false,
+                        "enable_self_evaluation": false,
+                        "evaluation_count": 0,
+                        "file": null,
+                        "id": "1abcABC123-abcABC123_Z",
+                        "lti_linkable": false,
+                        "modified": "2016-10-04T21:32:54",
+                        "name": "1234567",
+                        "number_of_comparisons": 3,
+                        "pairing_algorithm": "random",
+                        "rank_display_limit": null,
+                        "self_evaluation_count": 0,
+                        "students_can_reply": false,
+                        "total_comparisons_required": 4,
+                        "total_steps_required": 4,
+                        "user": {
+                            "avatar": "831fdab66736a3de4671777adf80908c",
+                            "displayname": "root",
+                            "fullname": "thkx UeNV",
+                            "id": "hJYTzpyVQcCnSN3raYtxGQ"
+                        },
+                        "user_id": "hJYTzpyVQcCnSN3raYtxGQ"
+                    },
+                    {
+                        "after_comparing": true,
+                        "answer_count": 2,
+                        "answer_end": "2017-03-16T13:59:00",
+                        "answer_period": false,
+                        "answer_start": "2017-03-06T15:00:00",
+                        "available": false,
+                        "comment_count": 0,
+                        "compare_end": "2017-03-25T13:59:00",
+                        "compare_period": false,
+                        "compare_start": "2017-03-17T15:00:00",
+                        "compared": false,
+                        "course_id": "oMtDpqO7Qu-0m-wYCWRE1A",
+                        "created": "2016-10-04T21:32:54",
+                        "criteria": [
+                            {
+                                "compared": true,
+                                "created": "2016-06-06T19:50:47",
+                                "default": true,
+                                "description": "<p>Choose the response that you think is the better of the two.</p>",
+                                "id": "1abcABC123-abcABC123_Z",
+                                "modified": "2016-06-06T19:50:47",
+                                "name": "Which is better?",
+                                "public": true,
+                                "user_id": "hJYTzpyVQcCnSN3raYtxGQ"
+                            }
+                        ],
+                        "description": "",
+                        "educators_can_compare": false,
+                        "enable_self_evaluation": false,
+                        "evaluation_count": 0,
+                        "file": null,
+                        "id": "2abcABC123-abcABC123_Z",
+                        "lti_linkable": false,
+                        "modified": "2016-10-04T21:32:54",
+                        "name": "1234567890",
+                        "number_of_comparisons": 3,
+                        "pairing_algorithm": "random",
+                        "rank_display_limit": null,
+                        "self_evaluation_count": 0,
+                        "students_can_reply": false,
+                        "total_comparisons_required": 4,
+                        "total_steps_required": 4,
+                        "user": {
+                            "avatar": "831fdab66736a3de4671777adf80908c",
+                            "displayname": "root",
+                            "fullname": "thkx UeNV",
+                            "id": "hJYTzpyVQcCnSN3raYtxGQ"
+                        },
+                        "user_id": "hJYTzpyVQcCnSN3raYtxGQ"
+                    }
+                ];
+
+                it('should switch to the duplicate course screen when button pressed', function () {
+                    $rootScope.selectDuplicateCourse(courses[0]);
+                    $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z/assignments').respond({
+                        'objects': assignments
+                    });
+                    $httpBackend.flush();
+                    expect($rootScope.showDuplicateForm).toBe(true);
+                });
+
+                describe('adjust assignment times', function () {
+                    beforeEach(function () {
+                        $rootScope.selectDuplicateCourse(courses[0]);
+                        $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z/assignments').respond({
+                            'objects': assignments
+                        });
+                        $httpBackend.flush();
+                    });
+                });
+
+
+                describe('select', function () {
+                    beforeEach(function () {
+                        $rootScope.selectDuplicateCourse(courses[0]);
+                        $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z/assignments').respond({
+                            'objects': assignments
+                        });
+                        $httpBackend.flush();
+                    });
+
+                    it('should set duplicate assignment answer/comparison dates', function () {
+                        // course[0].start_date = "2017-01-02T23:00:00" which is a Monday
+                        // removing time component for easier comparisons
+                        var originalStartDate = new Date(courses[0].start_date);
+
+                        var now = new Date();
+                        var past = new Date('2016-10-05T19:10:13.283Z');
+                        var present = new Date(courses[0].start_date)
+                        var future = new Date('2018-10-05T19:10:13.283Z');
+
+                        // check course start date automatic generation
+                        var startOfWeek = new Date();
+                        // +1 for converting to ISO 8601 first day of week (monday)
+                        startOfWeek.setDate(startOfWeek.getDate() - startOfWeek.getDay() + 1);
+
+                        expect($rootScope.duplicateCourse.date.course_start.date.toDateString()).toEqual(startOfWeek.toDateString());
+
+                        // course[0].end_date = "2017-04-28T23:00:00" which is +18 weeks and +4 days ahead of start date
+                        var endDateDayDiff = (16 * 7) + 4;
+
+                        // assignments[0].answer_start = "2017-03-25T14:00:00" which is +13 weeks and +5 days ahead of start date
+                        var assignment0AnswerStartDayDiff = (11 * 7) + 5;
+                        // assignments[0].answer_end = "2017-04-09T13:59:00" which is +15 weeks and +6 days ahead of start date
+                        var assignment0AnswerEndDayDiff = (13 * 7) + 6;
+
+                        // assignments[1].answer_start = "2017-03-06T15:00:00" which is +11 weeks and +0 days ahead of start date
+                        var assignment1AnswerStartDayDiff = (9 * 7) + 0;
+                        // assignments[1].answer_end = "2017-03-16T13:59:00" which is +12 weeks and +3 days ahead of start date
+                        var assignment1AnswerEndDayDiff = (10 * 7) + 3;
+
+                        // assignments[1].compare_start = "2017-03-17T15:00:00" which is +12 weeks and +4 days ahead of start date
+                        var assignment1CompareStartDayDiff = (10 * 7) + 4;
+                        // assignments[1].compare_end = "2017-03-25T13:59:00" which is +13 weeks and +5 days ahead of start date
+                        var assignment1CompareEndDayDiff = (11 * 7) + 5;
+
+                        // check course end date automatic generation
+                        var expectedDay = new Date(startOfWeek);
+                        expectedDay.setDate(startOfWeek.getDate() + endDateDayDiff);
+                        expect($rootScope.duplicateCourse.date.course_end.date.toDateString()).toEqual(expectedDay.toDateString());
+
+                        // check assignment
+                        var testDates = [now, past, present, future];
+                        angular.forEach(testDates, function(testDate) {
+                            startOfWeek = testDate;
+                            // +1 for converting to ISO 8601 first day of week (monday)
+                            startOfWeek.setDate(startOfWeek.getDate() - startOfWeek.getDay() + 1);
+
+                            for (var dayIndex = 0; dayIndex < 1; dayIndex++) {
+                                var day = new Date(startOfWeek);
+                                day.setDate(startOfWeek.getDate() + dayIndex);
+
+                                $rootScope.duplicateCourse.date.course_start.date = day;
+                                $rootScope.adjustDuplicateAssignmentDates(true);
+
+                                // check assignment 0 dates
+                                expectedDay = new Date(startOfWeek);
+                                expectedDay.setDate(startOfWeek.getDate() + assignment0AnswerStartDayDiff);
+                                expect($rootScope.duplicateAssignments[0].date.astart.date.toDateString()).toEqual(expectedDay.toDateString());
+
+                                expectedDay = new Date(startOfWeek);
+                                expectedDay.setDate(startOfWeek.getDate() + assignment0AnswerEndDayDiff);
+                                expect($rootScope.duplicateAssignments[0].date.aend.date.toDateString()).toEqual(expectedDay.toDateString());
+
+                                expect($rootScope.duplicateAssignments[0].availableCheck).toBe(undefined);
+                                expect($rootScope.duplicateAssignments[0].date.cstart.date).toEqual(null);
+                                expect($rootScope.duplicateAssignments[0].date.cend.date).toEqual(null);
+
+                                // check assignment 1 dates
+                                expectedDay = new Date(startOfWeek);
+                                expectedDay.setDate(startOfWeek.getDate() + assignment1AnswerStartDayDiff);
+                                expect($rootScope.duplicateAssignments[1].date.astart.date.toDateString()).toEqual(expectedDay.toDateString());
+
+                                expectedDay = new Date(startOfWeek);
+                                expectedDay.setDate(startOfWeek.getDate() + assignment1AnswerEndDayDiff);
+                                expect($rootScope.duplicateAssignments[1].date.aend.date.toDateString()).toEqual(expectedDay.toDateString());
+
+                                expect($rootScope.duplicateAssignments[1].availableCheck).toBe(true);
+
+                                expectedDay = new Date(startOfWeek);
+                                expectedDay.setDate(startOfWeek.getDate() + assignment1CompareStartDayDiff);
+                                expect($rootScope.duplicateAssignments[1].date.cstart.date.toDateString()).toEqual(expectedDay.toDateString());
+
+                                expectedDay = new Date(startOfWeek);
+                                expectedDay.setDate(startOfWeek.getDate() + assignment1CompareEndDayDiff);
+                                expect($rootScope.duplicateAssignments[1].date.cend.date.toDateString()).toEqual(expectedDay.toDateString());
+                            }
+                        })
+                    });
+
+                    it('should error when course start date is not before end date', function () {
+                        $rootScope.duplicateCourse.date.course_start.date = new Date();
+                        $rootScope.duplicateCourse.date.course_start.time = new Date();
+                        $rootScope.duplicateCourse.date.course_end.date = new Date();
+                        $rootScope.duplicateCourse.date.course_end.time = new Date();
+                        $rootScope.duplicateCourse.date.course_end.date.setDate($rootScope.duplicateCourse.date.course_end.date.getDate()-1);
+
+                        $rootScope.duplicate();
+                        expect($rootScope.submitted).toBe(false);
+                        expect(toaster.error).toHaveBeenCalledWith('Course Period Conflict', 'Course end date/time must be after course start date/time.');
+                        expect(modalInstance.close.calls.count()).toEqual(0);
+                    });
+
+                    it('should error when assignment answer start date is not before end date', function () {
+                        $rootScope.duplicateAssignments[0].date.astart.date = new Date();
+                        $rootScope.duplicateAssignments[0].date.astart.time = new Date();
+                        $rootScope.duplicateAssignments[0].date.aend.date = new Date();
+                        $rootScope.duplicateAssignments[0].date.aend.time = new Date();
+                        $rootScope.duplicateAssignments[0].date.aend.date.setDate($rootScope.duplicateAssignments[0].date.aend.date.getDate()-1);
+
+                        $rootScope.duplicate();
+                        expect($rootScope.submitted).toBe(false);
+                        expect(toaster.error).toHaveBeenCalledWith(
+                            'Answer Period Error for '+$rootScope.duplicateAssignments[0].name,
+                            'Answer end time must be after answer start time.');
+                        expect(modalInstance.close.calls.count()).toEqual(0);
+                    });
+
+                    it('should error when answer start is not before compare start', function () {
+                        $rootScope.duplicateAssignments[0].availableCheck = true;
+                        $rootScope.duplicateAssignments[0].date.cstart.date = angular.copy($rootScope.duplicateAssignments[0].date.astart.date);
+                        $rootScope.duplicateAssignments[0].date.cstart.date.setDate($rootScope.duplicateAssignments[0].date.cstart.date.getDate()-1);
+
+                        $rootScope.duplicate();
+                        expect($rootScope.submitted).toBe(false);
+                        expect(toaster.error).toHaveBeenCalledWith(
+                            'Time Period Error for '+$rootScope.duplicateAssignments[0].name,
+                            'Please double-check the answer and comparison period start and end times.');
+                        expect(modalInstance.close.calls.count()).toEqual(0);
+                    });
+
+                    it('should error when compare start is not before compare end', function () {
+                        $rootScope.duplicateAssignments[0].availableCheck = true;
+                        $rootScope.duplicateAssignments[0].date.cstart.date = angular.copy($rootScope.duplicateAssignments[0].date.astart.date);
+                        $rootScope.duplicateAssignments[0].date.cstart.date.setDate($rootScope.duplicateAssignments[0].date.cstart.date.getDate()+1);
+                        $rootScope.duplicateAssignments[0].date.cend.date = $rootScope.duplicateAssignments[0].date.cstart.date;
+                        $rootScope.duplicateAssignments[0].date.cend.time = $rootScope.duplicateAssignments[0].date.cstart.time;
+
+                        $rootScope.duplicate();
+                        expect($rootScope.submitted).toBe(false);
+                        expect(toaster.error).toHaveBeenCalledWith(
+                            'Time Period Error for '+$rootScope.duplicateAssignments[0].name,
+                            'comparison end time must be after comparison start time.');
+                        expect(modalInstance.close.calls.count()).toEqual(0);
+                    });
+
+                    it('should be able to save new course', function () {
+                        var newCourseId = "3abcABC123-abcABC123_Z"
+                        $httpBackend.expectPOST('/api/courses/1abcABC123-abcABC123_Z/duplicate', $rootScope.duplicateCourse).respond(
+                            angular.merge({}, courses[0], $rootScope.duplicateCourse, {id: newCourseId})
+                        );
+                        $rootScope.duplicate();
+                        expect($rootScope.submitted).toBe(true);
+                        $httpBackend.flush();
+                        expect($rootScope.submitted).toBe(false);
+                        expect(modalInstance.close).toHaveBeenCalledWith(newCourseId);
+                    });
                 });
             });
         });

--- a/acj/static/modules/course/course-partial.html
+++ b/acj/static/modules/course/course-partial.html
@@ -11,22 +11,22 @@
                 <input id="courseName" name="courseName" ng-model="course.name"
                        type="text" class="form-control" required maxlength="255" placeholder="e.g. BIOL 112 - Biology of the Cell" ng-model="course.name" auto-focus />
             </acj-field-with-feedback>
-        <div class="row">
-        <div class="col-md-6 form-group">
-            <acj-field-with-feedback form-control="courseForm.courseYear">
-                <label for="courseYear" class="required-star">Year</label>
-                <input id="courseYear" name="courseYear" ng-model="course.year"
-                   type="number" class="form-control" required min="1900" />
-            </acj-field-with-feedback>
-        </div>
-        <div class="col-md-6 form-group">
-            <acj-field-with-feedback form-control="courseForm.courseTerm">
-                <label for="courseTerm" class="required-star">Term/Semester</label>
-                <input id="courseTerm" name="courseTerm" ng-model="course.term"
-                   type="text" class="form-control" required maxlength="255" />
-            </acj-field-with-feedback>
-        </div>
-        </div>
+            <div class="row">
+                <div class="col-md-6 form-group">
+                    <acj-field-with-feedback form-control="courseForm.courseYear">
+                        <label for="courseYear" class="required-star">Year</label>
+                        <input id="courseYear" name="courseYear" ng-model="course.year"
+                        type="number" class="form-control" required min="1900" />
+                    </acj-field-with-feedback>
+                </div>
+                <div class="col-md-6 form-group">
+                    <acj-field-with-feedback form-control="courseForm.courseTerm">
+                        <label for="courseTerm" class="required-star">Term/Semester</label>
+                        <input id="courseTerm" name="courseTerm" ng-model="course.term"
+                        type="text" class="form-control" required maxlength="255" />
+                    </acj-field-with-feedback>
+                </div>
+            </div>
             <input id="descriptionCheck" type="checkbox" ng-model="course.descriptionCheck" ng-checked="course.descriptionCheck || course.description" ng-disabled="course.description">
             <label for="descriptionCheck">Add a course description (optional)<span ng-show="course.descriptionCheck || course.description">:</span></label>
             <br />

--- a/acj/static/modules/course/course-select-partial.html
+++ b/acj/static/modules/course/course-select-partial.html
@@ -29,10 +29,9 @@
                                         Use This
                                     </a>
 
-                                    <!-- TODO: eneable once course duplication feature is complete -->
-                                    <!--<a class="btn btn-default" ng-click="selectDuplicateCourse(course)">
+                                    <a class="btn btn-default" ng-click="selectDuplicateCourse(course)">
                                         Duplicate This
-                                    </a>-->
+                                    </a>
                                 </div>
                             </td>
                         </tr>

--- a/acj/static/modules/home/home-module.js
+++ b/acj/static/modules/home/home-module.js
@@ -51,7 +51,6 @@ module.controller(
                 function(ret) {
                     $scope.courses = ret.objects;
                     $scope.totalNumCourses = ret.total;
-                    angular.forEach($scope.courses, function(event){ event.start_date = new Date(event.start_date); });
                 },
                 function (ret) {
                     Toaster.reqerror("Unable to retrieve your courses.", ret);

--- a/acj/static/modules/lti/lti-module.js
+++ b/acj/static/modules/lti/lti-module.js
@@ -76,7 +76,7 @@ module.factory('LTI',
         },
         getCourseName: function() {
             this._check_cookies();
-            return this._lti_status.course.name
+            return this._lti_status ? this._lti_status.course.name : "";
         }
     };
 }]);
@@ -107,9 +107,6 @@ module.controller("LTIController",
             } else if (!status.course.exists) {
                 if (status.course.course_role == CourseRole.instructor) {
                     var modalScope = $scope.$new();
-                    modalScope.course = {
-                        name: status.course.name,
-                    };
                     var modalInstance = $modal.open({
                         animation: true,
                         backdrop: 'static',


### PR DESCRIPTION
Assignments answer/compare start and end dates will now be imported into duplicated courses.

Added UI elements to duplicate course form for displaying assignment dates and a button for automatically adjusting dates based on new course start date (needs to be looked over).

Includes unit test for both back-end and front-end

Related to #318 