### PR TITLE
Fix debug asset error

### DIFF
--- a/acj/__init__.py
+++ b/acj/__init__.py
@@ -74,8 +74,9 @@ def create_app(conf=config, settings_override=None, skip_endpoints=False, skip_a
     celery.conf.update(app.config)
 
     if not skip_assets:
-        assets = get_asset_names(app)
-        app.config.update(assets)
+        if not app.debug:
+            assets = get_asset_names(app)
+            app.config.update(assets)
 
         create_persistent_dirs(app.config, app.logger)
 


### PR DESCRIPTION
get_asset_names throws unless gulp prod has been run at least once (requires manifest.json to exist). get_asset_names shouldn't be called in debug mode as it doesn't use the minified assets.