### PR TITLE
Edit default criterion for new assignments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ clean:
 	find . -name '*.pyc' -exec rm -f {} \;
 	find . -name '*.pyo' -exec rm -f {} \;
 	find . -name '*~' -exec rm -f {} \;
+	find . -name '__pycache__' -exec rm -fR {} \;
 	rm -rf bower_components node_modules
 	rm -rf compair/static/dist compair/static/build
 

--- a/compair/api/assignment.py
+++ b/compair/api/assignment.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import joinedload, undefer_group, load_only
 from . import dataformat
 from compair.core import db, event
 from compair.authorization import allow, require
-from compair.models import Assignment, Course, AssignmentCriterion, Answer, Comparison, \
+from compair.models import Assignment, Course, Criterion, AssignmentCriterion, Answer, Comparison, \
     AnswerComment, AnswerCommentType, PairingAlgorithm, Criterion, File
 from .util import new_restful_api, get_model_changes
 
@@ -324,17 +324,21 @@ class AssignmentRootAPI(Resource):
 
         criterion_uuids = [c['id'] for c in params.criteria]
         if len(criterion_uuids) == 0:
-            msg = 'You must add at least one criterion to the assignment '
-            return {"error": msg}, 403
+            msg = 'You must add at least one criterion to the assignment'
+            return {"error": msg}, 400
 
-        new_criteria = Criterion.query \
+        criteria = Criterion.query \
             .filter(Criterion.uuid.in_(criterion_uuids)) \
             .all()
 
-        for criterion in new_criteria:
+        if len(criterion_uuids) != len(criteria):
+            msg = 'You select an invalid criterion'
+            return {"error": msg}, 400
+
+        for criterion in criteria:
             assignment_criterion = AssignmentCriterion(
                 assignment=new_assignment,
-                criterion_id=criterion.id
+                criterion=criterion
             )
             db.session.add(assignment_criterion)
 

--- a/compair/api/assignment_criterion.py
+++ b/compair/api/assignment_criterion.py
@@ -33,11 +33,6 @@ class AssignmentCriterionRootAPI(Resource):
             ) \
             .all()
 
-        assignment_criteria = AssignmentCriterion.query \
-            .filter_by(assignment_id=assignment.id, active=True) \
-            .order_by(AssignmentCriterion.id) \
-            .all()
-
         on_assignment_criterion_get.send(
             self,
             event_name=on_assignment_criterion_get.name,

--- a/compair/static/modules/assignment/assignment-module_spec.js
+++ b/compair/static/modules/assignment/assignment-module_spec.js
@@ -1197,6 +1197,21 @@ describe('course-module', function () {
                 var toaster;
                 var mockPracticeAnswer1 = {content: "content A"};
                 var mockPracticeAnswer2 = {content: "content B"};
+                var expectedCriterion = angular.copy(mockAssignment.criteria[0]);
+                expectedCriterion.id = null;
+                expectedCriterion.default = false;
+                expectedCriterion.public = false;
+                var mockNewCriterion = {
+                    "compared": false,
+                    "created": "Mon, 06 Jun 2016 19:50:47 -0000",
+                    "default": false,
+                    "public": false,
+                    "description": "<p>Choose the response that you think is the better of the two.</p>",
+                    "id": "1abcABC123-abcABC123_Z",
+                    "modified": "Mon, 06 Jun 2016 19:50:47 -0000",
+                    "name": "Which is better?",
+                    "user_id": "9abcABC123-abcABC123_Z"
+                }
                 beforeEach(inject(function (_Toaster_) {
                     toaster = _Toaster_;
                     spyOn(toaster, 'error');
@@ -1247,6 +1262,7 @@ describe('course-module', function () {
                     $rootScope.assignment = angular.copy(mockAssignment);
                     $rootScope.assignment.id = undefined;
 
+                    $httpBackend.expectPOST('/api/criteria', expectedCriterion).respond(200, mockNewCriterion);
                     $httpBackend.expectPOST('/api/courses/1abcABC123-abcABC123_Z/assignments', $rootScope.assignment)
                         .respond(400, '');
                     $rootScope.assignmentSubmit();
@@ -1291,6 +1307,7 @@ describe('course-module', function () {
                     $rootScope.assignment = angular.copy(mockAssignment);
                     $rootScope.assignment.id = undefined;
 
+                    $httpBackend.expectPOST('/api/criteria', expectedCriterion).respond(200, mockNewCriterion);
                     $httpBackend.expectPOST('/api/courses/1abcABC123-abcABC123_Z/assignments', $rootScope.assignment)
                         .respond(angular.merge({}, mockAssignment, {id: "2abcABC123-abcABC123_Z"}));
                     $rootScope.assignmentSubmit();
@@ -1308,6 +1325,7 @@ describe('course-module', function () {
                         answer1: mockPracticeAnswer1,
                         answer2: mockPracticeAnswer2
                     };
+                    $httpBackend.expectPOST('/api/criteria', expectedCriterion).respond(200, mockNewCriterion);
                     $httpBackend.expectPOST('/api/courses/1abcABC123-abcABC123_Z/assignments', $rootScope.assignment)
                         .respond(angular.merge({}, mockAssignment, {id: "2abcABC123-abcABC123_Z"}));
                     $httpBackend.expectPOST('/api/courses/1abcABC123-abcABC123_Z/assignments/2abcABC123-abcABC123_Z/answers', $rootScope.comparison_example.answer1)

--- a/compair/static/modules/criterion/criterion-assignment-partial.html
+++ b/compair/static/modules/criterion/criterion-assignment-partial.html
@@ -8,10 +8,10 @@
             <p>
                 <a href=""
                    ng-click="changeCriterion(criterion)"
-                   ng-if="(canManageCriteriaAssignment || criterion.user_id==loggedInUserId) && criterion.public == false">
+                   ng-if="(canManageCriteriaAssignment || criterion.user_id==loggedInUserId) && (criterion.public == false || !assignment.id)">
                 Edit
                 </a>
-                <span ng-if="criterion.public == true" class="text-muted">
+                <span ng-if="criterion.public == true && assignment.id" class="text-muted">
                     (not editable)
                 </span>
             </p>

--- a/compair/static/modules/criterion/criterion-form-directive.js
+++ b/compair/static/modules/criterion/criterion-form-directive.js
@@ -20,7 +20,13 @@
 
                     scope.criterionSubmit = function () {
                         scope.criterionSubmitted = true;
-                        CriterionResource.save({}, scope.criterion, function (ret) {
+                        // never edit a public criterion. Create a new copy of it instead
+                        var criterion = angular.copy(scope.criterion);
+                        if (criterion.public) {
+                            criterion.id = null;
+                            criterion.public = false;
+                        }
+                        CriterionResource.save({}, criterion, function (ret) {
                             if (scope.criterion.id) {
                                 scope.$emit('CRITERION_UPDATED', ret);
                             } else {


### PR DESCRIPTION
Public criterion are still added to the criteria list in a new assignment. If the user selects to edit it, they will generate a new criterion instead. When saving a new assignment, duplicates are automatically generated for public criterion still in the list. This allows users to later freely edit the text of criterion based on public criterion

Existing assignments using default criterion are still not be editable them

Fixes: #431