### PR TITLE
Fix assignment criteria order

### DIFF
--- a/alembic/versions/12167f268066_add_position_to_assignment_criterion.py
+++ b/alembic/versions/12167f268066_add_position_to_assignment_criterion.py
@@ -1,0 +1,22 @@
+"""Add position to assignment_criterion
+
+Revision ID: 12167f268066
+Revises: 31fc9a032aa8
+Create Date: 2016-11-30 23:49:11.830461
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '12167f268066'
+down_revision = '31fc9a032aa8'
+
+from alembic import op
+import sqlalchemy as sa
+from compair.models import convention
+
+def upgrade():
+    op.add_column('assignment_criterion', sa.Column('position', sa.Integer(), nullable=True))
+
+def downgrade():
+    with op.batch_alter_table('assignment_criterion', naming_convention=convention) as batch_op:
+        batch_op.drop_column('position')

--- a/compair/models/assignment.py
+++ b/compair/models/assignment.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import column_property
 from sqlalchemy import func, select, and_, or_
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy_enum34 import EnumType
+from sqlalchemy.ext.orderinglist import ordering_list
 
 from . import *
 
@@ -49,7 +50,8 @@ class Assignment(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
     # file via File Model
 
     # assignment many-to-many criterion with association assignment_criteria
-    assignment_criteria = db.relationship("AssignmentCriterion", back_populates="assignment")
+    assignment_criteria = db.relationship("AssignmentCriterion", back_populates="assignment",
+        order_by=AssignmentCriterion.position.asc(), collection_class=ordering_list('position', count_from=0))
 
     answers = db.relationship("Answer", backref="assignment", lazy="dynamic",
         order_by=Answer.created.desc())

--- a/compair/models/assignment_criterion.py
+++ b/compair/models/assignment_criterion.py
@@ -13,8 +13,9 @@ class AssignmentCriterion(DefaultTableMixin, ActiveMixin, WriteTrackingMixin):
     # table columns
     assignment_id = db.Column(db.Integer, db.ForeignKey("assignment.id", ondelete="CASCADE"),
         nullable=False)
-    criterion_id = db.Column(db.Integer,  db.ForeignKey("criterion.id", ondelete="CASCADE"),
+    criterion_id = db.Column(db.Integer, db.ForeignKey("criterion.id", ondelete="CASCADE"),
         nullable=False)
+    position = db.Column(db.Integer)
 
     # relationships
     # assignment many-to-many criterion with association assignment_criteria


### PR DESCRIPTION
Assignment criteria will now appear in the order added to the assignment consistently

Fixes #443