### PR TITLE
Fix criteria issues

### DIFF
--- a/compair/api/criterion.py
+++ b/compair/api/criterion.py
@@ -35,23 +35,16 @@ on_criterion_create = event.signal('CRITERION_CREATE')
 class CriteriaAPI(Resource):
     @login_required
     def get(self):
-        if allow(MANAGE, Criterion):
-            # TODO: revisit at some point (might retrieve to much in the future)
-            criteria = Criterion.query \
-                .filter_by(active=True) \
-                .order_by(Criterion.public.desc(), Criterion.created) \
-                .all()
-        else:
-            criteria = Criterion.query \
-                .filter(or_(
-                    and_(
-                        Criterion.user_id == current_user.id,
-                        Criterion.default == True
-                    ),
-                    Criterion.public == True
-                )) \
-                .order_by(Criterion.public.desc(), Criterion.created) \
-                .all()
+        criteria = Criterion.query \
+            .filter(or_(
+                and_(
+                    Criterion.user_id == current_user.id,
+                    Criterion.default == True
+                ),
+                Criterion.public == True
+            )) \
+            .order_by(Criterion.public.desc(), Criterion.created) \
+            .all()
 
         on_criterion_list_get.send(
             self,

--- a/compair/static/modules/assignment/assignment-module.js
+++ b/compair/static/modules/assignment/assignment-module.js
@@ -927,6 +927,7 @@ module.controller("AssignmentWriteController",
                             Toaster.reqerror("Assignment Practice Answers not Found", "No practice answers found for assignment with id "+$scope.assignmentId);
                         }
                     );
+                    removeAssignmentCriteriaFromAvailable();
                 },
                 function () {
                     Toaster.reqerror("Assignment Not Found", "No assignment found for id "+$scope.assignmentId);
@@ -982,11 +983,14 @@ module.controller("AssignmentWriteController",
                 // if we don't have any criterion, e.g. new assignment, add a default one automatically
                 $scope.assignment.criteria.push(_.find($scope.availableCriteria, {public: true}));
             }
+            removeAssignmentCriteriaFromAvailable();
+        });
+        var removeAssignmentCriteriaFromAvailable = function() {
             // we need to remove the existing assignment criteria from available list
             $scope.availableCriteria = _.filter($scope.availableCriteria, function(c) {
                 return !_($scope.assignment.criteria).pluck('id').includes(c.id);
             });
-        });
+        };
 
         $scope.add = function(key) {
             // not proceed if empty option is being added
@@ -1000,7 +1004,7 @@ module.controller("AssignmentWriteController",
         $scope.remove = function(key) {
             var criterion = $scope.assignment.criteria[key];
             $scope.assignment.criteria.splice(key, 1);
-            if (criterion.default == true) {
+            if (criterion.default) {
                 $scope.availableCriteria.push(criterion);
             }
         };

--- a/compair/tests/api/test_criteria.py
+++ b/compair/tests/api/test_criteria.py
@@ -172,7 +172,5 @@ class CriterionAPITests(ComPAIRAPITestCase):
             rv = self.client.get(criterion_api_url)
             self.assert200(rv)
             # return all
-            self.assertEqual(len(rv.json['objects']), 4)
+            self.assertEqual(len(rv.json['objects']), 1)
             self._verify_critera(self.data.get_default_criterion(), rv.json['objects'][0])
-            self._verify_critera(self.data.get_criterion(), rv.json['objects'][1])
-            self._verify_critera(self.data.get_secondary_criterion(), rv.json['objects'][2])


### PR DESCRIPTION
System administrators will receive to many criteria when using the criteria list endpoint. Instead treat them like other users and only fetch their own criterion (if there is a need for admin to manage criteria, it should be a separate endpoint and interface).

Default criteria already included in an assignment will no longer appear in the availableCriteria list. This was caused by api etc result timing.