### PR TITLE
Improve class list import/export

### DIFF
--- a/compair/api/dataformat/__init__.py
+++ b/compair/api/dataformat/__init__.py
@@ -62,6 +62,7 @@ def get_users_in_course(restrict_user=True):
     users['group_name'] = fields.String
     if not restrict_user:
         users['course_role'] = UnwrapCourseRole(attribute='course_role')
+        users['cas_username'] = fields.String
     return users
 
 


### PR DESCRIPTION
- Enforce required passwords on ComPAIR account class list imports for new users (existing users will be overwritten if not logged in yet or skipped if password is blank or equal to *)
- Add groups to both ComPAIR as CAS account class list imports. All users groups will be updated on import (regardless of role or if new or existing)
- Add group_name and cas_username to class list exports (will use the first CAS third_part_user unique_identifier if there are multiple CAS authentication methods for the user)

Completes #382