### PR TITLE
Apply static backdrop to editable modals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ addons:
 
 before_script:
   - if [ '$DB' = 'mysql' ]; then mysql -e 'create database IF NOT EXISTS compair;'; fi
-  - if [ "$INTEGRATION_TEST" = "true" ]; then gulp prod; fi
+  - if [ "$INTEGRATION_TEST" = "true" ]; then node_modules/gulp/bin/gulp.js prod; fi
 
 before_install:
   - if [ "$DOCKER" != "true" ]; then nvm install 6.4; fi

--- a/compair/static/modules/assignment/assignment-module.js
+++ b/compair/static/modules/assignment/assignment-module.js
@@ -566,6 +566,7 @@ module.controller("AssignmentViewController",
 
             $scope.modalInstance = $modal.open({
                 animation: true,
+                backdrop: 'static',
                 controller: "AnswerEditModalController",
                 templateUrl: 'modules/answer/answer-modal-partial.html',
                 scope: modalScope
@@ -596,6 +597,7 @@ module.controller("AssignmentViewController",
 
             $scope.modalInstance = $modal.open({
                 animation: true,
+                backdrop: 'static',
                 controller: "AnswerCommentModalController",
                 templateUrl: 'modules/comment/comment-answer-modal-partial.html',
                 scope: modalScope
@@ -627,6 +629,7 @@ module.controller("AssignmentViewController",
 
             $scope.modalInstance = $modal.open({
                 animation: true,
+                backdrop: 'static',
                 controller: "AnswerCommentModalController",
                 templateUrl: 'modules/comment/comment-answer-modal-partial.html',
                 scope: modalScope
@@ -666,6 +669,7 @@ module.controller("AssignmentViewController",
 
             $scope.modalInstance = $modal.open({
                 animation: true,
+                backdrop: 'static',
                 controller: "AssignmentCommentModalController",
                 templateUrl: 'modules/comment/comment-assignment-modal-partial.html',
                 scope: modalScope
@@ -689,6 +693,7 @@ module.controller("AssignmentViewController",
 
             $scope.modalInstance = $modal.open({
                 animation: true,
+                backdrop: 'static',
                 controller: "AssignmentCommentModalController",
                 templateUrl: 'modules/comment/comment-assignment-modal-partial.html',
                 scope: modalScope
@@ -1033,6 +1038,7 @@ module.controller("AssignmentWriteController",
             });
             modalInstance = $modal.open({
                 animation: true,
+                backdrop: 'static',
                 template: '<criterion-form criterion=criterion editor-options=editorOptions></criterion-form>',
                 scope: modalScope
             });
@@ -1059,6 +1065,7 @@ module.controller("AssignmentWriteController",
 
             $scope.modalInstance = $modal.open({
                 animation: true,
+                backdrop: 'static',
                 controller: "ComparisonExampleModalController",
                 templateUrl: 'modules/answer/answer-modal-partial.html',
                 scope: modalScope

--- a/compair/static/modules/assignment/assignment-module_spec.js
+++ b/compair/static/modules/assignment/assignment-module_spec.js
@@ -1155,6 +1155,7 @@ describe('assignment-module', function () {
                 it('should open a modal dialog', function() {
                     expect($modal.open).toHaveBeenCalledWith({
                         animation: true,
+                        backdrop: 'static',
                         template: '<criterion-form criterion=criterion editor-options=editorOptions></criterion-form>',
                         scope: jasmine.any(Object)
                     })
@@ -1211,6 +1212,7 @@ describe('assignment-module', function () {
                 it('should open a modal dialog', function() {
                     expect($modal.open).toHaveBeenCalledWith({
                         animation: true,
+                        backdrop: 'static',
                         controller: "ComparisonExampleModalController",
                         templateUrl: 'modules/answer/answer-modal-partial.html',
                         scope: jasmine.any(Object)
@@ -1445,6 +1447,7 @@ describe('assignment-module', function () {
                 it('should open a modal dialog', function() {
                     expect($modal.open).toHaveBeenCalledWith({
                         animation: true,
+                        backdrop: 'static',
                         template: '<criterion-form criterion=criterion editor-options=editorOptions></criterion-form>',
                         scope: jasmine.any(Object)
                     })
@@ -1500,6 +1503,7 @@ describe('assignment-module', function () {
                 it('should open a modal dialog', function() {
                     expect($modal.open).toHaveBeenCalledWith({
                         animation: true,
+                        backdrop: 'static',
                         controller: "ComparisonExampleModalController",
                         templateUrl: 'modules/answer/answer-modal-partial.html',
                         scope: jasmine.any(Object)

--- a/compair/static/modules/classlist/classlist-module.js
+++ b/compair/static/modules/classlist/classlist-module.js
@@ -142,6 +142,7 @@ module.controller(
         $scope.addUsersToNewGroup = function() {
             var modalInstance = $modal.open({
                 animation: true,
+                backdrop: 'static',
                 controller: "AddGroupModalController",
                 templateUrl: 'modules/group/group-form-partial.html'
             })

--- a/compair/static/modules/home/home-module.js
+++ b/compair/static/modules/home/home-module.js
@@ -96,6 +96,7 @@ module.controller(
 
             $scope.modalInstance = $modal.open({
                 animation: true,
+                backdrop: 'static',
                 controller: "CourseDuplicateModalController",
                 templateUrl: 'modules/course/course-duplicate-partial.html',
                 scope: modalScope


### PR DESCRIPTION
Editable modals will no longer close when clicking outside of them.

Assignment comparison preview and pdf attachment modals are the only none editable modals and can still be closed by clicking outside of the modal.

Related to #432