### PR TITLE
Add user management screens

### DIFF
--- a/compair/api/dataformat/__init__.py
+++ b/compair/api/dataformat/__init__.py
@@ -84,6 +84,13 @@ def get_course():
         'created': fields.DateTime(dt_format='iso8601', attribute=lambda x: replace_tzinfo(x.created))
     }
 
+
+def get_user_courses():
+    courses = get_course()
+    courses['group_name'] = fields.String
+    courses['course_role'] = UnwrapCourseRole(attribute='course_role')
+    return courses
+
 def get_criterion():
     return {
         'id': fields.String(attribute="uuid"),

--- a/compair/static/compair-config.js
+++ b/compair/static/compair-config.js
@@ -222,7 +222,7 @@ myApp.config(['$routeProvider', '$logProvider', '$httpProvider', '$locationProvi
         .when('/user/:userId/edit',
             {
                 templateUrl: 'modules/user/user-edit-partial.html',
-                label: "User Profile",
+                label: "Edit Account",
                 controller: 'UserController',
                 method: 'edit'
             })
@@ -232,6 +232,16 @@ myApp.config(['$routeProvider', '$logProvider', '$httpProvider', '$locationProvi
                 label: "User Profile",
                 controller: 'UserController',
                 method: 'view'
+            })
+        .when('/users',
+            {
+                templateUrl: 'modules/user/user-list-partial.html',
+                label: "Users"
+            })
+        .when('/users/:userId/course',
+            {
+                templateUrl: 'modules/user/user-course-partial.html',
+                label: "Manage User Courses",
             })
         .when('/lti',
             {

--- a/compair/static/less/compair.less
+++ b/compair/static/less/compair.less
@@ -15,6 +15,12 @@
 // HOME SCREEN
 @import 'home.less';
 
+// USERS SCREEN
+@import 'users.less';
+
+// USER COURSES SCREEN
+@import 'user_courses.less';
+
 // COURSE SCREEN
 @import 'course.less';
 

--- a/compair/static/less/user_courses.less
+++ b/compair/static/less/user_courses.less
@@ -1,0 +1,11 @@
+
+/***** USER COURSES SCREEN *****/
+
+.user-courses-screen {
+
+  .search-courses {
+    margin-top: 1.7em;
+  }
+
+}//closes user-courses-screen
+

--- a/compair/static/less/users.less
+++ b/compair/static/less/users.less
@@ -1,0 +1,11 @@
+
+/***** USERS SCREEN *****/
+
+.users-screen {
+
+  .search-users {
+    margin-top: 1.7em;
+  }
+
+}//closes users-screen
+

--- a/compair/static/modules/classlist/classlist-module.js
+++ b/compair/static/modules/classlist/classlist-module.js
@@ -225,7 +225,7 @@ module.controller(
             if (groupName) {
                 GroupResource.enrol({'courseId': courseId, 'userId': userId, 'groupName': groupName}, {},
                     function (ret) {
-                        Toaster.success("Update Complete", "Successfully enrolled the user into " + ret.group_name);
+                        Toaster.success("Update Complete", "Successfully added the user to group " + ret.group_name);
                     },
                     function (ret) {
                         Toaster.reqerror("Update Not Completed", ret);
@@ -249,7 +249,7 @@ module.controller(
                     Toaster.success("User Added", 'Successfully changed '+ ret.fullname +'\'s course role to ' + ret.course_role);
                 },
                 function (ret) {
-                    Toaster.reqerror("User Add Failed", "Promblem encountered For ID " + user.id, ret);
+                    Toaster.reqerror("User Add Failed", "Problem encountered For ID " + user.id, ret);
                 }
             );
         };

--- a/compair/static/modules/classlist/classlist-view-partial.html
+++ b/compair/static/modules/classlist/classlist-view-partial.html
@@ -128,17 +128,13 @@
             <tbody>
                 <tr ng-class="{'success': user.selected}" ng-repeat="user in classlist | orderBy:[predicate, 'firstname', 'lastname'] | emptyToEnd:predicate | orderBy:'':reverse">
                     <td class="nowrap">
-                        <a href="#/user/{{user.id}}/edit" target="_blank">
-                            Edit
-                        </a>
+                        <a href="#/user/{{user.id}}/edit" target="_blank">Edit</a>
                         <span>&nbsp;|&nbsp;</span>
-                        <a href="" confirmation-needed="unenrol(user.id)" keyword="user" ng-if="loggedInUserId != user.id || canManageUsers">
-                            Drop
-                        </a>
+                        <a href="" confirmation-needed="unenrol(user.id)" keyword="user" ng-if="loggedInUserId != user.id || canManageUsers">Drop</a>
                         <span ng-if="loggedInUserId == user.id && !canManageUsers" class="text-muted">&mdash;  &nbsp; &nbsp;</span>
-			<span>&nbsp;|&nbsp;</span>
-		    </td>
-		    <td>
+                        <span>&nbsp;|&nbsp;</span>
+                    </td>
+                    <td>
                         <input ng-click="user.selected = !user.selected; checkIfAllSelected()" type="checkbox" ng-checked="user.selected">
                     </td>
                     <td>{{user.firstname}}</td>

--- a/compair/static/modules/common/http-interceptor-service.js
+++ b/compair/static/modules/common/http-interceptor-service.js
@@ -27,6 +27,11 @@ module.service('Interceptors', ['$q', '$cacheFactory', 'AnswerResource', functio
                 var url = response.config.url.match(/\/api\/courses\/[A-Za-z0-9_-]{22}/g);
                 cache.remove(url[0] + '/users');
             }
+            cache = $cacheFactory.get('$http');
+            if(cache) {
+                var url = response.config.url.match(/\/api\/courses\/[A-Za-z0-9_-]{22}/g);
+                cache.remove(url[0] + '/groups');
+            }
             return response.data;
         }
     };

--- a/compair/static/modules/common/xapi-module.js
+++ b/compair/static/modules/common/xapi-module.js
@@ -895,8 +895,6 @@ module.service('xAPI',
 module.service('xAPIStatementHelper',
     ["$location", "xAPI",
     function($location, xAPI) {
-
-
         // verb_answer_solution
         this.interacted_answer_solution = function(answer, registration, duration) {
             // skip if not yet loaded

--- a/compair/static/modules/group/group-module.js
+++ b/compair/static/modules/group/group-module.js
@@ -26,7 +26,8 @@ module.factory(
         var unenrolUrl = '/api/courses/:courseId/users/:userId/groups';
         var ret = $resource(url, {groupName: '@groupName'},
             {
-                getAllFromSession: {method: 'GET', url: url, interceptor: Interceptors.groupSessionInterceptor},
+                get: {cache: true, url: url},
+                getAllFromSession: {url: url, interceptor: Interceptors.groupSessionInterceptor},
                 updateUsersGroup: {method: 'POST', url: '/api/courses/:courseId/users/groups/:groupName', interceptor: Interceptors.enrolCache},
                 removeUsersGroup: {method: 'POST', url: '/api/courses/:courseId/users/groups', interceptor: Interceptors.enrolCache},
                 enrol: {method: 'POST', url: unenrolUrl+'/:groupName', interceptor: Interceptors.enrolCache},

--- a/compair/static/modules/login/login-module.js
+++ b/compair/static/modules/login/login-module.js
@@ -107,8 +107,6 @@ module.run(
             Toaster.error('Login Failed!', rejection.data.message);
             $rootScope.$broadcast(AuthenticationService.LOGIN_REQUIRED_EVENT);
         }
-        // invalid session cache, looks like we don't need it. I'll just leave it here in case we need it in the future
-        //$cacheFactory.get('$http').removeAll();
     });
     $rootScope.$on(AuthenticationService.LOGOUT_EVENT, function () {
         $cacheFactory.get('$http').removeAll();

--- a/compair/static/modules/navbar/navbar-module.js
+++ b/compair/static/modules/navbar/navbar-module.js
@@ -34,6 +34,9 @@ module.controller(
             Authorize.can(Authorize.CREATE, UserResource.MODEL).then(function (result) {
                 $scope.canCreateUsers = result;
             });
+            Authorize.can(Authorize.MANAGE, UserResource.MODEL).then(function (result) {
+                $scope.canManageUsers = result;
+            });
             Authorize.can(Authorize.CREATE, CourseResource.MODEL).then(function (result) {
                 $scope.canCreateCourses = result;
             });

--- a/compair/static/modules/navbar/navbar-partial.html
+++ b/compair/static/modules/navbar/navbar-partial.html
@@ -47,6 +47,12 @@
                             Add Course
                         </a>
                     </li>
+                    <li ng-if="canManageUsers">
+                        <a ng-href="#/users" id="view-users-btn">
+                            <i class="fa fa-users"></i>
+                            Manage Users
+                        </a>
+                    </li>
                     <li ng-if="canCreateUsers">
                         <a ng-href="#/user/create" id="create-user-btn">
                             <i class="fa fa-user"></i>

--- a/compair/static/modules/user/user-course-partial.html
+++ b/compair/static/modules/user/user-course-partial.html
@@ -1,0 +1,80 @@
+<div ng-controller="UserCourseController" class="user-courses-screen">
+
+    <div class="row">
+        <h1 class="col-sm-8">Manage {{ user.displayname }}'s courses</h1>
+
+        <form class="col-sm-4 search-courses text-right" role="search" ng-show="courses.length || courseFilters.search">
+            <div class="form-group">
+                <input class="form-control" type="text" name="search" placeholder="Filter courses by keyword"
+                       ng-model="courseFilters.search">
+            </div>
+        </form>
+    </div>
+
+    <div class="table-responsive" ng-if="courses.length">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Actions</th>
+                    <th>
+                        <a href="" ng-click="updateTableOrderBy('name')">Name</a>
+                    </th>
+                    <th>
+                        <a href="" ng-click="updateTableOrderBy('year')">Year</a>
+                    </th>
+                    <th>
+                        <a href="" ng-click="updateTableOrderBy('term')">Term</a>
+                    </th>
+                    <th>Course Status</th>
+                    <th>
+                        <a href="" ng-click="updateTableOrderBy('course_role')">Course Role</a>
+                    </th>
+                    <th>
+                        <a href="" ng-click="updateTableOrderBy('group_name')">Group</a>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="course in courses">
+                    <td class="nowrap">
+                        <a href="" confirmation-needed="dropCourse(course)" keyword="user" ng-if="loggedInUserId != user.id || canManageUsers">Drop</a>
+                    </td>
+                    <td><a ng-href="#/course/{{course.id}}">{{course.name}}</a></td>
+                    <td>{{course.year}}</td>
+                    <td>{{course.term}}</td>
+                    <td>
+                        <span ng-if="course.before_start">Not yet started</span>
+                        <span ng-if="course.completed">Completed</span>
+                        <span ng-if="course.in_progress">Currently in progress</span>
+                    <td>
+                        <select ng-model="course.course_role"
+                                ng-options="course_role as course_role for course_role in course_roles"
+                                ng-change="updateRole(course)"></select>
+                    </td>
+                    <td>
+                        <select ng-model="course.group_name"
+                                ng-options="g as g for g in course.groups"
+                                ng-change="updateGroup(course)"
+                                ng-if="course.groups.length">
+                            <option value="">- None -</option>
+                        </select>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="text-center" ng-if="courses.length">
+        <pagination total-items="totalNumCourses" ng-model="courseFilters.page"
+                    max-size="10" class="pagination-sm" boundary-links="true"
+                    direction-links="false" items-per-page="courseFilters.perPage"
+                    num-pages="numPages" ng-hide="numPages == 1"></pagination>
+    </div>
+
+    <div ng-if="!courses.length">
+        <hr />
+        <p ng-if="!courseFilters.search">No courses found. Select <a href="#/users">another user</a>.</p>
+        <p ng-if="courseFilters.search">No courses found for this search. Please try another search term above.</p>
+    </div>
+
+</div>

--- a/compair/static/modules/user/user-list-partial.html
+++ b/compair/static/modules/user/user-list-partial.html
@@ -1,0 +1,77 @@
+<div ng-controller="UserListController" class="users-screen">
+    <div class="row">
+        <h1 class="col-sm-8"><i class="fa fa-users"></i> Manage Users</h1>
+
+        <form class="col-sm-4 search-users text-right" role="search" ng-show="canManageUsers && (users.length || userFilters.search)">
+            <div class="form-group">
+                <input class="form-control" type="text" name="search" placeholder="Filter users by keyword"
+                       ng-model="userFilters.search">
+            </div>
+        </form>
+    </div>
+
+    <div class="table-responsive" ng-if="users.length">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Actions</th>
+                    <th>
+                        <a href="" ng-click="updateTableOrderBy('firstname')">First Name</a>
+                    </th>
+                    <th>
+                        <a href="" ng-click="updateTableOrderBy('lastname')">Last Name</a>
+                    </th>
+                    <th>
+                        <a href="" ng-click="updateTableOrderBy('student_number')">Student Number</a>
+                    </th>
+                    <th>
+                        <a href="" ng-click="updateTableOrderBy('displayname')">Display Name</a>
+                    </th>
+                    <th>
+                        <a href="" ng-click="updateTableOrderBy('email')">Email</a>
+                    </th>
+                    <th>
+                        <a href="" ng-click="updateTableOrderBy('system_role')">System Role</a>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="user in users">
+                    <td class="nowrap">
+                        <a href="#/user/{{user.id}}/edit" target="_blank">Edit</a>
+                        <span>&nbsp;|&nbsp;</span>
+                        <a href="#/users/{{user.id}}/course">Manage Courses</a>
+                    </td>
+                    <td>{{user.firstname}}</td>
+                    <td>{{user.lastname}}</td>
+                    <td>{{user.student_number}}</td>
+                    <td><a ng-href="#/user/{{user.id}}">{{user.displayname}}</a></td>
+                    <td>{{user.email}}</td>
+                    <td>
+                        {{ user.system_role }}
+                        <!--
+                        <select ng-if="user.system_role != SystemRole.sys_admin" ng-model="user.system_role"
+                                ng-options="system_role as system_role for system_role in system_roles"
+                                ng-change="updateUser(user)"></select>
+                        <span ng-if="user.system_role == SystemRole.sys_admin">{{ user.system_role }}</span>
+                        -->
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="text-center" ng-if="users.length">
+        <pagination total-items="totalNumUsers" ng-model="userFilters.page"
+                    max-size="10" class="pagination-sm" boundary-links="true"
+                    direction-links="false" items-per-page="userFilters.perPage"
+                    num-pages="numPages" ng-hide="numPages == 1"></pagination>
+    </div>
+
+    <div ng-if="!users.length">
+        <hr />
+        <p ng-if="!userFilters.search">No users found.</p>
+        <p ng-if="userFilters.search">No users found for this search. Please try another search term above.</p>
+    </div>
+
+</div>

--- a/compair/static/test/features/edit_course_user.feature
+++ b/compair/static/test/features/edit_course_user.feature
@@ -53,6 +53,12 @@ Feature: Edit Course Users
   Scenario: Changing user's group in course as instructor
     Given I'm an Instructor
     And I'm on 'edit course user' page for course with id '1abcABC123-abcABC123_Z'
+    When I select the Instructor role for the second user
+    Then I should see a success message
+
+  Scenario: Changing user's group in course as instructor
+    Given I'm an Instructor
+    And I'm on 'edit course user' page for course with id '1abcABC123-abcABC123_Z'
     When I set the second user's group to 'Second Group'
     Then I should see a success message
 

--- a/compair/static/test/features/step_definitions/common.js
+++ b/compair/static/test/features/step_definitions/common.js
@@ -92,7 +92,9 @@ var commonStepDefinitionsWrapper = function() {
             'edit course': /.*\/course\/[A-Za-z0-9_-]{22}\/configure$/,
             'profile': /.*\/user\/[A-Za-z0-9_-]{22}$/,
             'create user': /.*\/user\/create$/,
-            'edit profile': /.*\/user\/[A-Za-z0-9_-]{22}\/edit$/
+            'edit profile': /.*\/user\/[A-Za-z0-9_-]{22}\/edit$/,
+            'users': /.*\/users(\?.+)?$/,
+            'user courses': /.*\/users\/[A-Za-z0-9_-]{22}\/course(\?.+)?$/
         };
         return expect(browser.getCurrentUrl()).to.eventually.match(page_regex[page]);
     });

--- a/compair/static/test/features/step_definitions/edit_course_user.js
+++ b/compair/static/test/features/step_definitions/edit_course_user.js
@@ -45,6 +45,19 @@ var editCourseUserStepDefinitionsWrapper = function () {
         return element(by.cssContainingText("table th a", "Display Name")).click().click();
     });
 
+    this.When("I select the Instructor role for the second user", function () {
+        var roleSelect = element.all(by.exactRepeater("user in classlist"))
+            .get(1)
+            .element(by.model('user.course_role'));
+        if (browser.browserName == "firefox") {
+            roleSelect.click();
+        }
+
+        roleSelect.sendKeys('Instructor');
+        // force blur
+        return element(by.css("body")).click();
+    });
+
     this.When("I set the second user's group to '$groupname'", function (groupname) {
         var groupSelect = element.all(by.exactRepeater("user in classlist"))
             .get(1)

--- a/compair/static/test/features/step_definitions/view_navbar.js
+++ b/compair/static/test/features/step_definitions/view_navbar.js
@@ -12,7 +12,7 @@ var viewNavbarStepDefinitionsWrapper = function () {
     });
 
     this.Then("I should see the admin navigation items", function () {
-        return expect(element.all(by.css("#logged-in-nav-options li a")).getText()).to.eventually.eql(["Download Reports", "Add Course", "Create Account"]);
+        return expect(element.all(by.css("#logged-in-nav-options li a")).getText()).to.eventually.eql(["Download Reports", "Add Course", "Manage Users", "Create Account"]);
     });
 
     this.Then("I should see the instructor navigation items", function () {

--- a/compair/static/test/features/step_definitions/view_user_courses.js
+++ b/compair/static/test/features/step_definitions/view_user_courses.js
@@ -1,0 +1,71 @@
+// Use the external Chai As Promised to deal with resolving promises in
+// expectations
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+
+var expect = chai.expect;
+
+var viewUserCoursesStepDefinitionsWrapper = function () {
+
+    this.Then("I should see '$count' courses listed", function (count) {
+        browser.waitForAngular();
+        return expect(element.all(by.exactRepeater("course in courses"))
+            .count()).to.eventually.eql(parseInt(count));
+    });
+
+    this.Then("I should see courses with names:", function (data) {
+        browser.waitForAngular();
+        var list = data.hashes().map(function(item) {
+            return item.name;
+        });
+
+        return expect(element.all(by.exactRepeater("course in courses")
+            .column('course.name')).getText()).to.eventually.eql(list);
+    });
+
+    this.When("I filter user courses page by '$filter'", function (filter) {
+        element(by.css("form.search-courses input")).sendKeys(filter);
+        // force blur
+        return element(by.css("body")).click();
+    });
+
+    this.When("I select drop for the first course listed", function () {
+        element.all(by.exactRepeater("course in courses")).get(0)
+            .element(by.cssContainingText('a', 'Drop')).click();
+
+        browser.wait(protractor.ExpectedConditions.alertIsPresent(), 1000);
+
+        browser.driver.switchTo().alert().accept();
+        browser.driver.switchTo().defaultContent();
+        return element(by.css("body")).click();
+    });
+
+    this.When("I select the Student role for the first course", function () {
+        var roleSelect = element.all(by.exactRepeater("course in courses"))
+            .get(0)
+            .element(by.model('course.course_role'));
+        if (browser.browserName == "firefox") {
+            roleSelect.click();
+        }
+
+        roleSelect.sendKeys('Student');
+        // force blur
+        return element(by.css("body")).click();
+    });
+
+    this.When("I set the first course's group to '$groupname'", function (groupname) {
+        var groupSelect = element.all(by.exactRepeater("course in courses"))
+            .get(0)
+            .element(by.model('course.group_name'));
+        if (browser.browserName == "firefox") {
+            groupSelect.click();
+        }
+
+        groupSelect.sendKeys(groupname);
+        // force blur
+        return element(by.css("body")).click();
+    });
+};
+
+module.exports = viewUserCoursesStepDefinitionsWrapper;

--- a/compair/static/test/features/step_definitions/view_users.js
+++ b/compair/static/test/features/step_definitions/view_users.js
@@ -1,0 +1,41 @@
+// Use the external Chai As Promised to deal with resolving promises in
+// expectations
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+
+var expect = chai.expect;
+
+var viewUsersStepDefinitionsWrapper = function () {
+
+    this.Then("I should see '$count' users listed", function (count) {
+        browser.waitForAngular();
+        return expect(element.all(by.exactRepeater("user in users"))
+            .count()).to.eventually.eql(parseInt(count));
+    });
+
+    this.Then("I should users with displaynames:", function (data) {
+        browser.waitForAngular();
+        var list = data.hashes().map(function(item) {
+            return item.displayname;
+        });
+
+        return expect(element.all(by.exactRepeater("user in users")
+            .column('user.displayname')).getText()).to.eventually.eql(list);
+    });
+
+    this.When("I select the root's Manage Courses link", function () {
+        // ignore target="_blank" for link (slows down tests to much)
+        browser.executeScript("$('a').attr('target','_self');");
+        return element.all(by.exactRepeater("user in users")).get(2)
+            .element(by.cssContainingText('a', 'Manage Courses')).click();
+    });
+
+    this.When("I filter users page by '$filter'", function (filter) {
+        element(by.css("form.search-users input")).sendKeys(filter);
+        // force blur
+        return element(by.css("body")).click();
+    });
+};
+
+module.exports = viewUsersStepDefinitionsWrapper;

--- a/compair/static/test/features/view_user_courses.feature
+++ b/compair/static/test/features/view_user_courses.feature
@@ -1,0 +1,49 @@
+Feature: Manage User Courses
+  As user, I want to manage user courses
+
+  Scenario: Loading view user courses page by Manage Courses link as admin
+    Given I'm a System Administrator
+    And I'm on 'users' page
+    When I select the root's Manage Courses link
+    Then I should be on the 'user courses' page
+    And I should see '2' courses listed
+    And I should see courses with names:
+      | name     |
+      | CHEM 111 |
+      | PHYS 101 |
+
+  Scenario: Filter user courses page as admin
+    Given I'm a System Administrator
+    And I'm on 'user courses' page for user with id '1abcABC123-abcABC123_Z'
+    When I filter user courses page by 'CHEM'
+    Then I should see '1' courses listed
+    And I should see courses with names:
+      | name     |
+      | CHEM 111 |
+
+  Scenario: Drop user from course as admin
+    Given I'm a System Administrator
+    And I'm on 'user courses' page for user with id '1abcABC123-abcABC123_Z'
+    When I select drop for the first course listed
+    Then I should see '1' courses listed
+    And I should see courses with names:
+      | name     |
+      | PHYS 101 |
+
+  Scenario: Change user's course role as admin
+    Given I'm a System Administrator
+    And I'm on 'user courses' page for user with id '1abcABC123-abcABC123_Z'
+    When I select the Student role for the first course
+    Then I should see a success message
+
+  Scenario: Changing user's group in course as instructor
+    Given I'm a System Administrator
+    And I'm on 'user courses' page for user with id '1abcABC123-abcABC123_Z'
+    When I set the first course's group to 'Second Group'
+    Then I should see a success message
+
+  Scenario: Removing user from group in course as instructor
+    Given I'm a System Administrator
+    And I'm on 'user courses' page for user with id '1abcABC123-abcABC123_Z'
+    When I set the first course's group to '- None -'
+    Then I should see a success message

--- a/compair/static/test/features/view_users.feature
+++ b/compair/static/test/features/view_users.feature
@@ -1,0 +1,24 @@
+Feature: Manage Users
+  As user, I want to manage accounts
+
+  Scenario: Loading view users page by Manage Users button as admin
+    Given I'm a System Administrator
+    And I'm on 'home' page
+    When I select 'Manage Users' button
+    Then I should be on the 'users' page
+    And I should see '4' users listed
+    And I should users with displaynames:
+      | displayname           |
+      | First Instructor      |
+      | First Student         |
+      | root                  |
+      | Second Student        |
+
+  Scenario: Filter users page as admin
+    Given I'm a System Administrator
+    And I'm on 'users' page
+    When I filter users page by 'Second'
+    Then I should see '1' users listed
+    And I should users with displaynames:
+      | displayname           |
+      | Second Student        |

--- a/compair/static/test/fixtures/admin/default_fixture.js
+++ b/compair/static/test/fixtures/admin/default_fixture.js
@@ -109,7 +109,7 @@ storage.criteria[criterion3.id] = criterion3;
 
 // user_courses
 storage.user_courses[admin.id] = [
-    { courseId: course.id, courseRole: "Instructor", groupName: null },
+    { courseId: course.id, courseRole: "Instructor", groupName: group1 },
     { courseId: course2.id, courseRole: "Instructor", groupName: null }
 ];
 

--- a/compair/static/test/page_objects/create_course.js
+++ b/compair/static/test/page_objects/create_course.js
@@ -2,17 +2,6 @@ var CreateCoursePage = function() {
     this.getLocation = function() {
         return 'course/new';
     };
-
-    this.clickButton = function(button) {
-        switch (button) {
-            case "Add Course":
-                return element(by.css('#create-course-btn')).click();
-            case "Download Report":
-                return element(by.css('#download-report-btn')).click();
-            case "Create Account":
-                return element(by.css('#create-user-btn')).click();
-        }
-    }
 };
 
 module.exports = CreateCoursePage;

--- a/compair/static/test/page_objects/home.js
+++ b/compair/static/test/page_objects/home.js
@@ -9,6 +9,8 @@ var HomePage = function() {
                 return element(by.css('#create-course-btn')).click();
             case "Create Account":
                 return element(by.css('#create-user-btn')).click();
+            case "Manage Users":
+                return element(by.css('#view-users-btn')).click();
             case "Profile":
                 element(by.css('#menu-dropdown')).click();
                 return element(by.css('#own-profile-link')).click();

--- a/compair/static/test/page_objects/user_courses.js
+++ b/compair/static/test/page_objects/user_courses.js
@@ -1,0 +1,7 @@
+var UserCoursesPage = function() {
+    this.getLocation = function(userId) {
+        return 'users/' + userId + '/course';
+    };
+};
+
+module.exports = UserCoursesPage;

--- a/compair/static/test/page_objects/users.js
+++ b/compair/static/test/page_objects/users.js
@@ -1,0 +1,7 @@
+var UsersPage = function() {
+    this.getLocation = function() {
+        return 'users';
+    };
+};
+
+module.exports = UsersPage;


### PR DESCRIPTION
Admins can now view a list of all users in the system as well as manage the user's course settings in another screen.

Includes:
- Adjustments caching for group list
- A new sort order option to the user list endpoint
- A new user course endpoint only accessible to system admins

Completes: #191 