### PR TITLE
Use browser local storage instead of cookies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,6 @@
     "bootstrap": "3.3.5",
     "angular": "1.4.7",
     "angular-animate": "1.4.7",
-    "angular-cookies": "~1.4.7",
     "angular-resource": "~1.4.7",
     "angular-route": "~1.4.7",
     "angular-sanitize": "~1.4.7",
@@ -41,7 +40,8 @@
     "angular-file-saver": "0.1.4",
     "ngclipboard": "~1.1.1",
     "tincan": "~0.50.0",
-    "angular-uuids": "~0.0.4"
+    "angular-uuids": "~0.0.4",
+    "angular-local-storage": "~0.5.2"
   },
   "resolutions": {
     "angular": "1.4.7"

--- a/compair/api/lti_launch.py
+++ b/compair/api/lti_launch.py
@@ -98,13 +98,7 @@ class LTIAuthAPI(Resource):
                 # set angular route to home page by default
                 angular_route = "/"
 
-            # clear cookies in case they exist from previous user
-            response = current_app.make_response(redirect("/app/#"+angular_route))
-            response.set_cookie('current.permissions', value='', path='/static')
-            response.set_cookie('current.lti.status', value='', path='/static')
-            response.set_cookie('current.user', value='', path='/static')
-
-            return response
+            return current_app.make_response(redirect("/app/#"+angular_route))
         else:
             display_message = "Invalid Request"
 

--- a/compair/authorization.py
+++ b/compair/authorization.py
@@ -127,62 +127,65 @@ def get_logged_in_user_permissions():
         .filter(UserCourse.course_role != CourseRole.dropped) \
         .all()
 
-    admin = user.system_role == SystemRole.sys_admin
+    is_admin = user.system_role == SystemRole.sys_admin
     permissions = {}
     models = {
         User.__name__: user,
     }
-    operations = {
-        MANAGE,
-        READ,
-        EDIT,
-        CREATE,
-        DELETE
-    }
+    operations = [MANAGE, READ, EDIT,  CREATE, DELETE]
+
     # global models
     for model_name, model in models.items():
         # create entry if not already exists
         permissions.setdefault(model_name, {})
         # if not model_name in permissions:
         # permissions[model_name] = {}
-        # obtain permission values for each operation
+        # obtain permission values for each operations
+
+        global_permissions = set()
         for operation in operations:
-            permissions[model_name][operation] = {'global': True}
-            try:
-                ensure(operation, model)
-            except Unauthorized:
-                permissions[model_name][operation]['global'] = False
+            if allow(operation, model):
+                global_permissions.add(operation)
+        permissions[model_name]['global'] = list(global_permissions)
+
     # course model
-    # model_name / operation / courseId OR global
-    permissions['Course'] = {CREATE: {'global': allow(CREATE, Course)}}
-    mod_operations = {MANAGE, READ, EDIT, DELETE}
-    for operation in mod_operations:
-        permissions['Course'].setdefault(operation, {})
-        permissions['Course'][operation]['global'] = admin
-        for course in courses:
-            course_uuid = course.course_uuid
-            try:
-                ensure(operation, Course(id=course.course_id))
-                permissions['Course'][operation][course_uuid] = True
-                permissions['Course'][operation]['global'] = True
-            except Unauthorized:
-                permissions['Course'][operation][course_uuid] = False
+    # model_name / courseId OR global / operation
+    permissions['Course'] = {}
+    mod_operations = [MANAGE, READ, EDIT, DELETE]
+    course_global_permissions = set()
+
+    for course in courses:
+        course_permissions = set()
+        for operation in mod_operations:
+            if allow(operation, Course(id=course.course_id)):
+                course_permissions.add(operation)
+                course_global_permissions.add(operation)
+        permissions['Course'][course.course_uuid] = list(course_permissions)
+
+    if allow(CREATE, Course):
+        course_global_permissions.add(CREATE)
+    if is_admin:
+        for operation in mod_operations:
+            course_global_permissions.add(operation)
+    permissions['Course']['global'] = list(course_global_permissions)
 
     # assignment model
-    # model_name / operation / courseId OR global
+    # model_name / courseId OR global / operation
     permissions['Assignment'] = {}
-    mod_operations = {MANAGE, READ, EDIT, CREATE, DELETE}
-    for operation in mod_operations:
-        permissions['Assignment'].setdefault(operation, {})
-        permissions['Assignment'][operation]['global'] = admin
-        for course in courses:
-            course_uuid = course.course_uuid
-            try:
-                ensure(operation, Assignment(course_id=course.course_id))
-                permissions['Assignment'][operation][course_uuid] = True
-                permissions['Assignment'][operation]['global'] = True
-            except Unauthorized:
-                permissions['Assignment'][operation][course_uuid] = False
+    assignment_global_permissions = set()
+
+    for course in courses:
+        assignment_permissions = set()
+        for operation in operations:
+            if allow(operation, Assignment(course_id=course.course_id)):
+                assignment_permissions.add(operation)
+                assignment_global_permissions.add(operation)
+        permissions['Assignment'][course.course_uuid] = list(assignment_permissions)
+
+    if is_admin:
+        for operation in operations:
+            assignment_global_permissions.add(operation)
+    permissions['Assignment']['global'] = list(assignment_global_permissions)
 
     return permissions
 

--- a/compair/static/compair-config.js
+++ b/compair/static/compair-config.js
@@ -8,7 +8,7 @@ String.prototype.format = function() {
 var myApp = angular.module('myApp', [
     'ngRoute',
     'http-auth-interceptor',
-    'ngCookies',
+    'LocalStorageModule',
     'ng-breadcrumbs',
     'angular-loading-bar',
     'ubc.ctlt.compair.common',
@@ -244,7 +244,15 @@ myApp.config(['$routeProvider', '$logProvider', '$httpProvider', '$locationProvi
     $logProvider.debugEnabled(debugMode);
 }]);
 
+myApp.config(['localStorageServiceProvider', function (localStorageServiceProvider) {
+    localStorageServiceProvider
+        .setPrefix('ComPAIR')
+        .setStorageType('sessionStorage') // options [localStorage, sessionStorage]
+        .setStorageCookie(0); // fallback default settings
+}]);
+
 // placeholder for templates module to store templates into cache
 // gulp prod will generate the actual templates module and put contents into cache
-angular.module('templates', []).run(['$templateCache', function ($templateCache){
+angular.module('templates', []).run(['$templateCache', function ($templateCache) {
+
 }]);

--- a/compair/static/modules/assignment/assignment-form-partial.html
+++ b/compair/static/modules/assignment/assignment-form-partial.html
@@ -6,7 +6,7 @@
             LTI Parameter: "<em>assignment={{assignment.id}}</em>"
             &nbsp;&nbsp;
             <!-- TODO: when ui bootstrap is updated change trigger to 'outsideClick' -->
-            <a href="" tooltip="Copied" tooltip-placement="bottom" tooltip-trigger="click"
+            <a href="" uib-tooltip="Copied" tooltip-placement="bottom" tooltip-trigger="click"
                   ngclipboard data-clipboard-text="assignment={{assignment.id}}"
                   title="Copy the parameter to create a link from an LTI tool">
                 Copy?
@@ -78,28 +78,28 @@
                 <label class="required-star">Answering Begins</label><br />
                 <div class="assignment-date">
                     <span class="input-group">
-                        <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="date.astart.date" is-open="date.astart.opened" required />
+                        <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.astart.date" is-open="date.astart.opened" required />
                         <span class="input-group-btn">
                             <button type="button" class="btn btn-default" ng-click="date.astart.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
                         </span>
                     </span>
                 </div>
                 <div class="assignment-date">
-                    <timepicker ng-model="date.astart.time" minute-step="1" mousewheel="false"></timepicker>
+                    <uib-timepicker ng-model="date.astart.time" minute-step="1" mousewheel="false"></uib-timepicker>
                 </div>
             </div>
             <div class="col-md-6 form-group">
                 <label class="required-star">Answering Ends</label><br />
                 <div class="assignment-date">
                     <span class="input-group">
-                        <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="date.aend.date" is-open="date.aend.opened" required />
+                        <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.aend.date" is-open="date.aend.opened" required />
                         <span class="input-group-btn">
                             <button type="button" class="btn btn-default" ng-click="date.aend.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
                         </span>
                     </span>
                 </div>
                 <div class="assignment-date">
-                    <timepicker ng-model="date.aend.time" minute-step="1" mousewheel="false"></timepicker>
+                    <uib-timepicker ng-model="date.aend.time" minute-step="1" mousewheel="false"></uib-timepicker>
                 </div>
             </div>
         </div>
@@ -117,28 +117,28 @@
                     <label class="required-star">Comparing Begins</label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="date.cstart.date" is-open="date.cstart.opened" ng-required="assignment.availableCheck" />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.cstart.date" is-open="date.cstart.opened" ng-required="assignment.availableCheck" />
                             <span class="input-group-btn">
                                 <button type="button" class="btn btn-default" ng-click="date.cstart.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>
                     <div class="assignment-date">
-                        <timepicker ng-model="date.cstart.time" minute-step="1" mousewheel="false"></timepicker>
+                        <uib-timepicker ng-model="date.cstart.time" minute-step="1" mousewheel="false"></uib-timepicker>
                     </div>
                 </div>
                 <div class="col-md-6 form-group">
                     <label class="required-star">Comparing Ends</label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="date.cend.date" is-open="date.cend.opened" ng-required="assignment.availableCheck" />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.cend.date" is-open="date.cend.opened" ng-required="assignment.availableCheck" />
                             <span class="input-group-btn">
                                 <button type="button" class="btn btn-default" ng-click="date.cend.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>
                     <div class="assignment-date">
-                        <timepicker ng-model="date.cend.time" minute-step="1" mousewheel="false"></timepicker>
+                        <uib-timepicker ng-model="date.cend.time" minute-step="1" mousewheel="false"></uib-timepicker>
                     </div>
                 </div>
             </div>

--- a/compair/static/modules/assignment/assignment-module.js
+++ b/compair/static/modules/assignment/assignment-module.js
@@ -84,31 +84,13 @@ module.directive(
     }
 ]);
 
-module.directive(
-    'toolTip',
-    function() {
-        return {
-            restrict: 'A',
-            link: function(scope, element) {
-                $(element).hover(function(){
-                    // on mouseenter
-                    $(element).tooltip('show');
-                }, function(){
-                    // on mouseleave
-                    $(element).tooltip('hide');
-                });
-            }
-        };
-    }
-);
-
 module.directive('comparisonPreview', function() {
     return {
         /* this template is our simple text with button to launch the preview */
         templateUrl: 'modules/assignment/preview-inline-template.html',
         controller:
-                ["$scope", "$modal", "xAPIStatementHelper",
-                function ($scope, $modal, xAPIStatementHelper) {
+                ["$scope", "$uibModal", "xAPIStatementHelper",
+                function ($scope, $uibModal, xAPIStatementHelper) {
             /* need to pass to comparison template all expected properties to complete the preview */
             $scope.previewPopup = function() {
                 /* set current round #, answer #s, and total round # for preview */
@@ -144,7 +126,7 @@ module.directive('comparisonPreview', function() {
                     });
                 });
                 /* student view preview is comparison template */
-                $scope.thePreview = $modal.open({
+                $scope.thePreview = $uibModal.open({
                     templateUrl: 'modules/comparison/comparison-core.html',
                     scope: $scope
                 });
@@ -245,10 +227,10 @@ module.filter("notScoredEnd", function () {
 module.controller("AssignmentViewController",
     ["$scope", "$routeParams", "$location", "AnswerResource", "Authorize", "AssignmentResource", "AssignmentCommentResource",
              "ComparisonResource", "CourseResource", "required_rounds", "Session", "Toaster", "AnswerCommentResource",
-             "GroupResource", "AnswerCommentType", "PairingAlgorithm", "$modal", "xAPIStatementHelper",
+             "GroupResource", "AnswerCommentType", "PairingAlgorithm", "$uibModal", "xAPIStatementHelper",
     function($scope, $routeParams, $location, AnswerResource, Authorize, AssignmentResource, AssignmentCommentResource,
              ComparisonResource, CourseResource, required_rounds, Session, Toaster, AnswerCommentResource,
-             GroupResource, AnswerCommentType, PairingAlgorithm, $modal, xAPIStatementHelper)
+             GroupResource, AnswerCommentType, PairingAlgorithm, $uibModal, xAPIStatementHelper)
     {
         $scope.courseId = $routeParams['courseId'];
         $scope.AnswerCommentType = AnswerCommentType;
@@ -483,7 +465,7 @@ module.controller("AssignmentViewController",
             modalScope.assignment = angular.copy($scope.assignment);
             modalScope.answer = angular.copy(answer);
 
-            $scope.modalInstance = $modal.open({
+            $scope.modalInstance = $uibModal.open({
                 animation: true,
                 backdrop: 'static',
                 controller: "AnswerEditModalController",
@@ -514,7 +496,7 @@ module.controller("AssignmentViewController",
             modalScope.assignmentId = $scope.assignment.id;
             modalScope.answerId = answer.id;
 
-            $scope.modalInstance = $modal.open({
+            $scope.modalInstance = $uibModal.open({
                 animation: true,
                 backdrop: 'static',
                 controller: "AnswerCommentModalController",
@@ -546,7 +528,7 @@ module.controller("AssignmentViewController",
             modalScope.answerId = answer.id;
             modalScope.comment = angular.copy(comment);
 
-            $scope.modalInstance = $modal.open({
+            $scope.modalInstance = $uibModal.open({
                 animation: true,
                 backdrop: 'static',
                 controller: "AnswerCommentModalController",
@@ -586,7 +568,7 @@ module.controller("AssignmentViewController",
             modalScope.courseId = $scope.courseId;
             modalScope.assignmentId = $scope.assignment.id;
 
-            $scope.modalInstance = $modal.open({
+            $scope.modalInstance = $uibModal.open({
                 animation: true,
                 backdrop: 'static',
                 controller: "AssignmentCommentModalController",
@@ -610,7 +592,7 @@ module.controller("AssignmentViewController",
             modalScope.assignmentId = $scope.assignment.id;
             modalScope.comment = angular.copy(comment);
 
-            $scope.modalInstance = $modal.open({
+            $scope.modalInstance = $uibModal.open({
                 animation: true,
                 backdrop: 'static',
                 controller: "AssignmentCommentModalController",
@@ -755,11 +737,11 @@ module.controller("AssignmentViewController",
     }
 ]);
 module.controller("AssignmentWriteController",
-    [ "$scope", "$q", "$location", "$routeParams", "$route", "AssignmentResource", "$modal", "Authorize",
+    [ "$scope", "$q", "$location", "$routeParams", "$route", "AssignmentResource", "$uibModal", "Authorize",
              "AssignmentCriterionResource", "CriterionResource", "required_rounds", "Toaster", "attachService",
              "AttachmentResource", "Session", "EditorOptions", "PairingAlgorithm", "ComparisonExampleResource",
              "AnswerResource", "xAPIStatementHelper",
-    function($scope, $q, $location, $routeParams, $route, AssignmentResource, $modal, Authorize,
+    function($scope, $q, $location, $routeParams, $route, AssignmentResource, $uibModal, Authorize,
              AssignmentCriterionResource, CriterionResource, required_rounds, Toaster, attachService,
              AttachmentResource, Session, EditorOptions, PairingAlgorithm, ComparisonExampleResource,
              AnswerResource, xAPIStatementHelper)
@@ -969,7 +951,7 @@ module.controller("AssignmentWriteController",
             var criterionCancelListener = $scope.$on('CRITERION_CANCEL', function() {
                 modalInstance.dismiss('cancel');
             });
-            modalInstance = $modal.open({
+            modalInstance = $uibModal.open({
                 animation: true,
                 backdrop: 'static',
                 template: '<criterion-form criterion=criterion editor-options=editorOptions></criterion-form>',
@@ -996,7 +978,7 @@ module.controller("AssignmentWriteController",
             var modalName = modalScope.answer.id ?
                 'Edit Comparison Example' : 'Create Comparison Example';
 
-            $scope.modalInstance = $modal.open({
+            $scope.modalInstance = $uibModal.open({
                 animation: true,
                 backdrop: 'static',
                 controller: "ComparisonExampleModalController",

--- a/compair/static/modules/assignment/assignment-module_spec.js
+++ b/compair/static/modules/assignment/assignment-module_spec.js
@@ -5,25 +5,31 @@ describe('assignment-module', function () {
         "id": id,
         "permissions": {
             "Course": {
-                "create": true,
-                "delete": true,
-                "edit": true,
-                "manage": true,
-                "read": true
+                "global": [
+                    "create",
+                    "delete",
+                    "edit",
+                    "manage",
+                    "read"
+                ]
             },
             "Assignment": {
-                "create": true,
-                "delete": true,
-                "edit": true,
-                "manage": true,
-                "read": true
+                "global": [
+                    "create",
+                    "delete",
+                    "edit",
+                    "manage",
+                    "read"
+                ]
             },
             "User": {
-                "create": true,
-                "delete": true,
-                "edit": true,
-                "manage": true,
-                "read": true
+                "global": [
+                    "create",
+                    "delete",
+                    "edit",
+                    "manage",
+                    "read"
+                ]
             }
         }
     };
@@ -807,15 +813,15 @@ describe('assignment-module', function () {
     });
 
     describe('AssignmentViewController', function () {
-        var $rootScope, createController, $location, $modal, $q;
+        var $rootScope, createController, $location, $uibModal, $q;
         var controller;
         var toaster;
         var xAPISettings;
 
-        beforeEach(inject(function ($controller, _$rootScope_, _$location_, _$modal_, _$q_, _Toaster_, _xAPISettings_) {
+        beforeEach(inject(function ($controller, _$rootScope_, _$location_, _$uibModal_, _$q_, _Toaster_, _xAPISettings_) {
             $rootScope = _$rootScope_;
             $location = _$location_;
-            $modal = _$modal_;
+            $uibModal = _$uibModal_;
             $q = _$q_;
             toaster = _Toaster_;
             createController = function (route, params) {
@@ -1063,15 +1069,15 @@ describe('assignment-module', function () {
     });
 
     describe('AssignmentWriteController', function () {
-        var $rootScope, createController, $location, $modal, $q;
+        var $rootScope, createController, $location, $uibModal, $q;
         var controller;
         var defaultCriteria;
         var otherCriteria;
 
-        beforeEach(inject(function ($controller, _$rootScope_, _$location_, _$modal_, _$q_) {
+        beforeEach(inject(function ($controller, _$rootScope_, _$location_, _$uibModal_, _$q_) {
             $rootScope = _$rootScope_;
             $location = _$location_;
-            $modal = _$modal_;
+            $uibModal = _$uibModal_;
             $q = _$q_;
             createController = function (route, params) {
                 return $controller('AssignmentWriteController', {
@@ -1146,7 +1152,7 @@ describe('assignment-module', function () {
                     criterion = {id: "1abcABC123-abcABC123_Z", name: 'test'};
                     deferred = $q.defer();
                     closeFunc = jasmine.createSpy('close');
-                    spyOn($modal, 'open').and.returnValue({
+                    spyOn($uibModal, 'open').and.returnValue({
                         result: deferred.promise,
                         close: closeFunc,
                         opened: deferred.promise
@@ -1155,7 +1161,7 @@ describe('assignment-module', function () {
                 });
 
                 it('should open a modal dialog', function() {
-                    expect($modal.open).toHaveBeenCalledWith({
+                    expect($uibModal.open).toHaveBeenCalledWith({
                         animation: true,
                         backdrop: 'static',
                         template: '<criterion-form criterion=criterion editor-options=editorOptions></criterion-form>',
@@ -1207,12 +1213,12 @@ describe('assignment-module', function () {
                 };
                 beforeEach(function() {
                     $rootScope.comparison_example.answer1 = {};
-                    spyOn($modal, 'open').and.returnValue(fakeModal);
+                    spyOn($uibModal, 'open').and.returnValue(fakeModal);
                     $rootScope.changeAnswer($rootScope.comparison_example.answer1, true);
                 });
 
                 it('should open a modal dialog', function() {
-                    expect($modal.open).toHaveBeenCalledWith({
+                    expect($uibModal.open).toHaveBeenCalledWith({
                         animation: true,
                         backdrop: 'static',
                         controller: "ComparisonExampleModalController",
@@ -1438,7 +1444,7 @@ describe('assignment-module', function () {
                     criterion = {id: "1abcABC123-abcABC123_Z", name: 'test'};
                     deferred = $q.defer();
                     closeFunc = jasmine.createSpy('close');
-                    spyOn($modal, 'open').and.returnValue({
+                    spyOn($uibModal, 'open').and.returnValue({
                         result: deferred.promise,
                         close: closeFunc,
                         opened: deferred.promise
@@ -1447,7 +1453,7 @@ describe('assignment-module', function () {
                 });
 
                 it('should open a modal dialog', function() {
-                    expect($modal.open).toHaveBeenCalledWith({
+                    expect($uibModal.open).toHaveBeenCalledWith({
                         animation: true,
                         backdrop: 'static',
                         template: '<criterion-form criterion=criterion editor-options=editorOptions></criterion-form>',
@@ -1498,12 +1504,12 @@ describe('assignment-module', function () {
                     }
                 };
                 beforeEach(function() {
-                    spyOn($modal, 'open').and.returnValue(fakeModal);
+                    spyOn($uibModal, 'open').and.returnValue(fakeModal);
                     $rootScope.changeAnswer($rootScope.comparison_example.answer1, true);
                 });
 
                 it('should open a modal dialog', function() {
-                    expect($modal.open).toHaveBeenCalledWith({
+                    expect($uibModal.open).toHaveBeenCalledWith({
                         animation: true,
                         backdrop: 'static',
                         controller: "ComparisonExampleModalController",

--- a/compair/static/modules/assignment/assignment-view-partial.html
+++ b/compair/static/modules/assignment/assignment-view-partial.html
@@ -168,7 +168,7 @@
                                     class="btn btn-sm" ng-class="{'btn-info': answerFilters.anonymous, 'btn-default': !answerFilters.anonymous}">
                                     Anonymize<span ng-show="answerFilters.anonymous">d</span> Answers<span ng-show="!answerFilters.anonymous">?</span>
                                 </button>
-                                <a href="" tooltip="Hide student names, scores, and replies when sharing this screen with students" tooltip-trigger tooltip-animation="false" tooltip-placement="bottom">
+                                <a href="" uib-tooltip="Hide student names, scores, and replies when sharing this screen with students" tooltip-trigger tooltip-animation="false" tooltip-placement="left">
                                     <i class="fa fa-question-circle"></i>
                                 </a>
                             </span>
@@ -295,7 +295,7 @@
                     <!-- Student Score (not used for instructor answers) -->
                     <p class="pull-right score-display" ng-if="canManageAssignment && !answerFilters.anonymous && score.criterion_id==answerFilters.orderBy && answer.scores.length > 0" ng-repeat="score in answer.scores">
                         <em>Score: {{score.normalized_score}}%</em>
-                        <a href="" tooltip="The top-ranked answer or&mdash;in the case of a tie&mdash;answers for the assignment receive 100%. All other answers receive a lower percentage based on how well they did compared to the top-ranked answer." tooltip-trigger tooltip-animation="false" tooltip-placement="left" class="score-tooltip">
+                        <a href="" uib-tooltip="The top-ranked answer or&mdash;in the case of a tie&mdash;answers for the assignment receive 100%. All other answers receive a lower percentage based on how well they did compared to the top-ranked answer." tooltip-trigger tooltip-animation="false" tooltip-placement="left" class="score-tooltip">
                             <i class="fa fa-question-circle"></i>
                         </a>
                     </p>
@@ -306,7 +306,7 @@
                         </em>
                         <em ng-if="score.rank > 0 && score.rank > rankLimit">
                             Students Ranked: <strong>N/A</strong>
-                            <a href="" tooltip="Answers that are ranked outside the top {{rankLimit}} do not receive a rank number for this assignment." tooltip-trigger tooltip-animation="false" tooltip-placement="left" class="score-tooltip">
+                            <a href="" uib-tooltip="Answers that are ranked outside the top {{rankLimit}} do not receive a rank number for this assignment." tooltip-trigger tooltip-animation="false" tooltip-placement="left" class="score-tooltip">
                                 <i class="fa fa-question-circle"></i>
                             </a>
                         </em>
@@ -382,7 +382,7 @@
             </div><!-- closes answered show-hide div -->
 
             <div class="text-center">
-                <pagination total-items="totalNumAnswers" ng-model="answerFilters.page" max-size="10" class="pagination-sm" boundary-links="true" direction-links="false" items-per-page="answerFilters.perPage" num-pages="numPages" ng-hide="numPages == 1"></pagination>
+                <uib-pagination total-items="totalNumAnswers" ng-model="answerFilters.page" max-size="10" class="pagination-sm" boundary-links="true" direction-links="false" items-per-page="answerFilters.perPage" num-pages="numPages" ng-hide="numPages == 1"></uib-pagination>
             </div>
 
         </div><!-- closes answers-tab -->
@@ -580,7 +580,7 @@
                 <blockquote>
                     <p>For general technical issues, please try:</p>
                     <ul>
-                        <li>Enabling Java and cookies in your browser settings</li>
+                        <li>Enabling Javascript and cookies in your browser settings</li>
                         <li>Disabling extra plugins and add-ons for your browser</li>
                         <li>Clearing your browser cache</li>
                         <li>Using a different browser (supported browsers include <a href="https://www.mozilla.org/en-US/firefox/new/">Firefox</a>, <a href="http://www.google.com/chrome/">Chrome</a>, <a href="https://www.apple.com/ca/safari/">Safari</a>, and <a href="http://windows.microsoft.com/en-ca/internet-explorer/download-ie">IE9+</a>)</li>

--- a/compair/static/modules/authorization/authorization-module.js
+++ b/compair/static/modules/authorization/authorization-module.js
@@ -16,14 +16,11 @@ module.factory('Authorize',
     ["$log", "$q", "Session",
     function($log, $q, Session)
     {
-        var _allow_operation = function(operation, resource, courseId, permissions) {
+        var _allow_operation = function(operation, resource, resource_scope, permissions) {
             if (resource in permissions)
             {
-                if (operation in permissions[resource])
-                {
-                    if (courseId in permissions[resource][operation]) {
-                        return permissions[resource][operation][courseId];
-                    }
+                if (resource_scope in permissions[resource]) {
+                    return permissions[resource][resource_scope].indexOf(operation) != -1;
                 }
             }
             return false;
@@ -47,8 +44,8 @@ module.factory('Authorize',
                     }
 
                     return Session.getPermissions().then(function(permissions) {
-                        var course_id = courseId || 'global';
-                        return $q.when(_allow_operation(operation, resource, course_id, permissions));
+                        var resource_scope = courseId || 'global';
+                        return $q.when(_allow_operation(operation, resource, resource_scope, permissions));
                     });
                 });
             }

--- a/compair/static/modules/classlist/classlist-enrol-partial.html
+++ b/compair/static/modules/classlist/classlist-enrol-partial.html
@@ -4,7 +4,7 @@
             <label>Add: </label>
             <div class="input-group">
                 <label class="sr-only" for="user">Name</label>
-                <input type="text" ng-model="user" name="user" required typeahead="u as u.fullname+' ('+u.system_role+')' for u in getUsersAhead($viewValue)"
+                <input type="text" ng-model="user" name="user" required uib-typeahead="u as u.fullname+' ('+u.system_role+')' for u in getUsersAhead($viewValue)"
                    placeholder="type user's name" class="form-control" autocomplete="off"
                    typeahead-editable="false" typeahead-min-length="2" typeahead-wait-ms="300">
             </div>

--- a/compair/static/modules/classlist/classlist-module.js
+++ b/compair/static/modules/classlist/classlist-module.js
@@ -61,10 +61,10 @@ module.controller(
     'ClassViewController',
     ["$scope", "$log", "$routeParams", "$route", "ClassListResource", "CourseResource",
              "CourseRole", "GroupResource", "Toaster", "Session", "SaveAs", "LTIResource",
-             "UserResource", "Authorize", "$modal", "xAPIStatementHelper",
+             "UserResource", "Authorize", "$uibModal", "xAPIStatementHelper",
     function($scope, $log, $routeParams, $route, ClassListResource, CourseResource,
              CourseRole, GroupResource, Toaster, Session, SaveAs, LTIResource,
-             UserResource, Authorize, $modal, xAPIStatementHelper)
+             UserResource, Authorize, $uibModal, xAPIStatementHelper)
     {
         $scope.course = {};
         $scope.classlist = [];
@@ -140,7 +140,7 @@ module.controller(
         $scope.course_roles = [CourseRole.student, CourseRole.teaching_assistant, CourseRole.instructor];
 
         $scope.addUsersToNewGroup = function() {
-            var modalInstance = $modal.open({
+            var modalInstance = $uibModal.open({
                 animation: true,
                 backdrop: 'static',
                 controller: "AddGroupModalController",

--- a/compair/static/modules/comment/comment-comparison-partial.html
+++ b/compair/static/modules/comment/comment-comparison-partial.html
@@ -120,7 +120,7 @@
     </div>
 
     <div class="text-center">
-        <pagination total-items="comparisons.total" ng-model="listFilters.page" max-size="10" class="pagination-sm" boundary-links="true" direction-links="false" items-per-page="listFilters.perPage" num-pages="numPages" ng-hide="numPages == 1"></pagination>
+        <uib-pagination total-items="comparisons.total" ng-model="listFilters.page" max-size="10" class="pagination-sm" boundary-links="true" direction-links="false" items-per-page="listFilters.perPage" num-pages="numPages" ng-hide="numPages == 1"></uib-pagination>
     </div>
 
     <div ng-show="!comparisons.objects.length">

--- a/compair/static/modules/common/attachment-directive.js
+++ b/compair/static/modules/common/attachment-directive.js
@@ -30,8 +30,8 @@ module.directive('compairAttachmentInline', function() {
             label: '@'
         },
         controller: [
-                "$scope", "$log", "$window", "$sce", "$modal", "xAPIStatementHelper",
-                function ($scope, $log, $window, $sce, $modal, xAPIStatementHelper) {
+                "$scope", "$log", "$window", "$sce", "$uibModal", "xAPIStatementHelper",
+                function ($scope, $log, $window, $sce, $uibModal, xAPIStatementHelper) {
             $scope.inline = null;
             $scope.inlineVisible = false;
             $scope.inlineUrl = null;
@@ -42,7 +42,7 @@ module.directive('compairAttachmentInline', function() {
                     var modalScope = $scope.$new();
                     modalScope.file = filepath;
                     modalScope.name = 'Attached PDF: Use + and - to zoom';
-                    var modalInstance = $modal.open({
+                    var modalInstance = $uibModal.open({
                         templateUrl: 'modules/common/attachment-overlaid-template.html',
                         scope: modalScope
                     });

--- a/compair/static/modules/comparison/comparison-module_spec.js
+++ b/compair/static/modules/comparison/comparison-module_spec.js
@@ -5,25 +5,31 @@ describe('comparison-module', function () {
         "id": id,
         "permissions": {
             "Course": {
-                "create": true,
-                "delete": true,
-                "edit": true,
-                "manage": true,
-                "read": true
+                "global": [
+                    "create",
+                    "delete",
+                    "edit",
+                    "manage",
+                    "read"
+                ]
             },
             "Assignment": {
-                "create": true,
-                "delete": true,
-                "edit": true,
-                "manage": true,
-                "read": true
+                "global": [
+                    "create",
+                    "delete",
+                    "edit",
+                    "manage",
+                    "read"
+                ]
             },
             "User": {
-                "create": true,
-                "delete": true,
-                "edit": true,
-                "manage": true,
-                "read": true
+                "global": [
+                    "create",
+                    "delete",
+                    "edit",
+                    "manage",
+                    "read"
+                ]
             }
         }
     };
@@ -74,7 +80,7 @@ describe('comparison-module', function () {
     });
 
     describe('ComparisonController', function () {
-        var $rootScope, createController, $location, $modal, $q, xAPI, xAPISettings;
+        var $rootScope, createController, $location, $uibModal, $q, xAPI, xAPISettings;
         var mockCritiera = {
             "criteria": [{
                 "created": "Sat, 06 Sep 2014 02:13:07 -0000",
@@ -364,10 +370,10 @@ describe('comparison-module', function () {
             }
         };
 
-        beforeEach(inject(function ($controller, _$rootScope_, _$location_, _$modal_, _$q_, _xAPI_, _xAPISettings_) {
+        beforeEach(inject(function ($controller, _$rootScope_, _$location_, _$uibModal_, _$q_, _xAPI_, _xAPISettings_) {
             $rootScope = _$rootScope_;
             $location = _$location_;
-            $modal = _$modal_;
+            $uibModal = _$uibModal_;
             $q = _$q_;
             xAPI = _xAPI_;
             createController = function (route, params) {

--- a/compair/static/modules/course/course-duplicate-partial.html
+++ b/compair/static/modules/course/course-duplicate-partial.html
@@ -38,28 +38,28 @@
                 <label>Course Begins</label><br />
                 <div class="assignment-date">
                     <span class="input-group">
-                        <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="duplicateCourse.date.course_start.date" is-open="duplicateCourse.date.course_start.opened" />
+                        <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="duplicateCourse.date.course_start.date" is-open="duplicateCourse.date.course_start.opened" />
                         <span class="input-group-btn">
                             <button type="button" class="btn btn-default" ng-click="duplicateCourse.date.course_start.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
                         </span>
                     </span>
                 </div>
                 <div class="assignment-date">
-                    <timepicker ng-model="duplicateCourse.date.course_start.time" minute-step="1" mousewheel="false"></timepicker>
+                    <uib-timepicker ng-model="duplicateCourse.date.course_start.time" minute-step="1" mousewheel="false"></uib-timepicker>
                 </div>
             </div>
             <div class="col-md-6 form-group">
                 <label>Course Ends</label><br />
                 <div class="assignment-date">
                     <span class="input-group">
-                        <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="duplicateCourse.date.course_end.date" is-open="duplicateCourse.date.course_end.opened" />
+                        <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="duplicateCourse.date.course_end.date" is-open="duplicateCourse.date.course_end.opened" />
                         <span class="input-group-btn">
                             <button type="button" class="btn btn-default" ng-click="duplicateCourse.date.course_end.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
                         </span>
                     </span>
                 </div>
                 <div class="assignment-date">
-                    <timepicker ng-model="duplicateCourse.date.course_end.time" minute-step="1" mousewheel="false"></timepicker>
+                    <uib-timepicker ng-model="duplicateCourse.date.course_end.time" minute-step="1" mousewheel="false"></uib-timepicker>
                 </div>
             </div>
         </div>
@@ -106,14 +106,14 @@
                     </label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="assignment.date.astart.date" is-open="assignment.date.astart.opened" required />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="assignment.date.astart.date" is-open="assignment.date.astart.opened" required />
                             <span class="input-group-btn">
                                 <button type="button" class="btn btn-default" ng-click="assignment.date.astart.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>
                     <div class="assignment-date">
-                        <timepicker ng-model="assignment.date.astart.time" minute-step="1" mousewheel="false"></timepicker>
+                        <uib-timepicker ng-model="assignment.date.astart.time" minute-step="1" mousewheel="false"></uib-timepicker>
                     </div>
                 </div>
                 <div class="col-md-6 form-group">
@@ -125,14 +125,14 @@
                     </label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="assignment.date.aend.date" is-open="assignment.date.aend.opened" required />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="assignment.date.aend.date" is-open="assignment.date.aend.opened" required />
                             <span class="input-group-btn">
                                 <button type="button" class="btn btn-default" ng-click="assignment.date.aend.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>
                     <div class="assignment-date">
-                        <timepicker ng-model="assignment.date.aend.time" minute-step="1" mousewheel="false"></timepicker>
+                        <uib-timepicker ng-model="assignment.date.aend.time" minute-step="1" mousewheel="false"></uib-timepicker>
                     </div>
                 </div>
             </div>
@@ -147,14 +147,14 @@
                     </label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="assignment.date.cstart.date" is-open="assignment.date.cstart.opened" ng-required="assignment.availableCheck" />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="assignment.date.cstart.date" is-open="assignment.date.cstart.opened" ng-required="assignment.availableCheck" />
                             <span class="input-group-btn">
                                 <button type="button" class="btn btn-default" ng-click="assignment.date.cstart.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>
                     <div class="assignment-date">
-                        <timepicker ng-model="assignment.date.cstart.time" minute-step="1" mousewheel="false"></timepicker>
+                        <uib-timepicker ng-model="assignment.date.cstart.time" minute-step="1" mousewheel="false"></uib-timepicker>
                     </div>
                 </div>
                 <div class="col-md-6 form-group">
@@ -166,14 +166,14 @@
                     </label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="assignment.date.cend.date" is-open="assignment.date.cend.opened" ng-required="assignment.availableCheck" />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="assignment.date.cend.date" is-open="assignment.date.cend.opened" ng-required="assignment.availableCheck" />
                             <span class="input-group-btn">
                                 <button type="button" class="btn btn-default" ng-click="assignment.date.cend.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>
                     <div class="assignment-date">
-                        <timepicker ng-model="assignment.date.cend.time" minute-step="1" mousewheel="false"></timepicker>
+                        <uib-timepicker ng-model="assignment.date.cend.time" minute-step="1" mousewheel="false"></uib-timepicker>
                     </div>
                 </div>
             </div>

--- a/compair/static/modules/course/course-module_spec.js
+++ b/compair/static/modules/course/course-module_spec.js
@@ -5,25 +5,31 @@ describe('course-module', function () {
         "id": id,
         "permissions": {
             "Course": {
-                "create": true,
-                "delete": true,
-                "edit": true,
-                "manage": true,
-                "read": true
+                "global": [
+                    "create",
+                    "delete",
+                    "edit",
+                    "manage",
+                    "read"
+                ]
             },
             "Assignment": {
-                "create": true,
-                "delete": true,
-                "edit": true,
-                "manage": true,
-                "read": true
+                "global": [
+                    "create",
+                    "delete",
+                    "edit",
+                    "manage",
+                    "read"
+                ]
             },
             "User": {
-                "create": true,
-                "delete": true,
-                "edit": true,
-                "manage": true,
-                "read": true
+                "global": [
+                    "create",
+                    "delete",
+                    "edit",
+                    "manage",
+                    "read"
+                ]
             }
         }
     };
@@ -72,12 +78,12 @@ describe('course-module', function () {
     });
 
     describe('CourseController', function () {
-        var $rootScope, createController, $location, $modal, $q, xAPISettings;
+        var $rootScope, createController, $location, $uibModal, $q, xAPISettings;
 
-        beforeEach(inject(function ($controller, _$rootScope_, _$location_, _$modal_, _$q_, _xAPISettings_) {
+        beforeEach(inject(function ($controller, _$rootScope_, _$location_, _$uibModal_, _$q_, _xAPISettings_) {
             $rootScope = _$rootScope_;
             $location = _$location_;
-            $modal = _$modal_;
+            $uibModal = _$uibModal_;
             $q = _$q_;
             createController = function (route, params) {
                 return $controller('CourseController', {
@@ -215,12 +221,12 @@ describe('course-module', function () {
     });
 
     describe('CourseSelectModalController', function () {
-        var $rootScope, createController, $location, $modal, $q;
+        var $rootScope, createController, $location, $uibModal, $q;
 
-        beforeEach(inject(function ($controller, _$rootScope_, _$location_, _$modal_, _$q_) {
+        beforeEach(inject(function ($controller, _$rootScope_, _$location_, _$uibModal_, _$q_) {
             $rootScope = _$rootScope_;
             $location = _$location_;
-            $modal = _$modal_;
+            $uibModal = _$uibModal_;
             $q = _$q_;
             modalInstance = {
                 close: jasmine.createSpy('modalInstance.close'),
@@ -360,12 +366,12 @@ describe('course-module', function () {
     });
 
     describe('CourseDuplicateModalController', function () {
-        var $rootScope, createController, $location, $modal, $q;
+        var $rootScope, createController, $location, $uibModal, $q;
 
-        beforeEach(inject(function ($controller, _$rootScope_, _$location_, _$modal_, _$q_) {
+        beforeEach(inject(function ($controller, _$rootScope_, _$location_, _$uibModal_, _$q_) {
             $rootScope = _$rootScope_;
             $location = _$location_;
-            $modal = _$modal_;
+            $uibModal = _$uibModal_;
             $q = _$q_;
             modalInstance = {
                 close: jasmine.createSpy('modalInstance.close'),

--- a/compair/static/modules/course/course-partial.html
+++ b/compair/static/modules/course/course-partial.html
@@ -50,28 +50,28 @@
                     <label>Course Begins</label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="date.course_start.date" is-open="date.course_start.opened" />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.course_start.date" is-open="date.course_start.opened" />
                             <span class="input-group-btn">
                                 <button type="button" class="btn btn-default" ng-click="date.course_start.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>
                     <div class="assignment-date">
-                        <timepicker ng-model="date.course_start.time" minute-step="1" mousewheel="false"></timepicker>
+                        <uib-timepicker ng-model="date.course_start.time" minute-step="1" mousewheel="false"></uib-timepicker>
                     </div>
                 </div>
                 <div class="col-md-6 form-group">
                     <label>Course Ends</label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="date.course_end.date" is-open="date.course_end.opened" />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.course_end.date" is-open="date.course_end.opened" />
                             <span class="input-group-btn">
                                 <button type="button" class="btn btn-default" ng-click="date.course_end.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>
                     <div class="assignment-date">
-                        <timepicker ng-model="date.course_end.time" minute-step="1" mousewheel="false"></timepicker>
+                        <uib-timepicker ng-model="date.course_end.time" minute-step="1" mousewheel="false"></uib-timepicker>
                     </div>
                 </div>
             </div>

--- a/compair/static/modules/course/course-select-partial.html
+++ b/compair/static/modules/course/course-select-partial.html
@@ -38,10 +38,10 @@
                     </table>
 
                     <div class="text-center" ng-if="courses.length">
-                        <pagination total-items="totalNumCourses" ng-model="courseFilters.page"
+                        <uib-pagination total-items="totalNumCourses" ng-model="courseFilters.page"
                                     max-size="10" class="pagination-sm" boundary-links="true"
                                     direction-links="false" items-per-page="courseFilters.perPage"
-                                    num-pages="numPages" ng-hide="numPages == 1"></pagination>
+                                    num-pages="numPages" ng-hide="numPages == 1"></uib-pagination>
                     </div>
 
                     <div ng-if="!courses.length">

--- a/compair/static/modules/gradebook/gradebook-partial.html
+++ b/compair/static/modules/gradebook/gradebook-partial.html
@@ -20,7 +20,7 @@
                 </span>
                 <br />
                 <span class="filter" ng-if="canManageAssignment && includeScores">
-                    <label>Display scores <a href="" tooltip="The top-ranked answer or&mdash;in the case of a tie&mdash;answers for the assignment receive 100%. All other answers receive a lower percentage based on how well they did compared to the top-ranked answer." tooltip-trigger tooltip-animation="false" tooltip-placement="left" class="score-tooltip">
+                    <label>Display scores <a href="" uib-tooltip="The top-ranked answer or&mdash;in the case of a tie&mdash;answers for the assignment receive 100%. All other answers receive a lower percentage based on how well they did compared to the top-ranked answer." tooltip-trigger tooltip-animation="false" tooltip-placement="left" class="score-tooltip">
                             <i class="fa fa-question-circle"></i></a> below for: &nbsp;</label>
                     <select ng-model="gradebookFilters.sortby" chosen disable_search_threshold="8"
                             ng-options="c.id as c.name for c in criteria">

--- a/compair/static/modules/home/home-module.js
+++ b/compair/static/modules/home/home-module.js
@@ -24,9 +24,9 @@ var module = angular.module('ubc.ctlt.compair.home',
 module.controller(
     'HomeController',
     ["$rootScope", "$scope", "$location", "Session", "AuthenticationService", "AssignmentResource",
-     "Authorize", "CourseResource", "Toaster", "UserResource", "$modal", "xAPIStatementHelper",
+     "Authorize", "CourseResource", "Toaster", "UserResource", "$uibModal", "xAPIStatementHelper",
     function ($rootScope, $scope, $location, Session, AuthenticationService, AssignmentResource,
-              Authorize, CourseResource, Toaster, UserResource, $modal, xAPIStatementHelper) {
+              Authorize, CourseResource, Toaster, UserResource, $uibModal, xAPIStatementHelper) {
 
         $scope.loggedInUserId = null;
         $scope.totalNumCourses = 0;
@@ -106,7 +106,7 @@ module.controller(
             var modalScope = $scope.$new();
             modalScope.originalCourse = course;
 
-            $scope.modalInstance = $modal.open({
+            $scope.modalInstance = $uibModal.open({
                 animation: true,
                 backdrop: 'static',
                 controller: "CourseDuplicateModalController",

--- a/compair/static/modules/home/home-partial.html
+++ b/compair/static/modules/home/home-partial.html
@@ -103,10 +103,10 @@
     </div>
 
     <div class="text-center" ng-if="courses.length">
-        <pagination total-items="totalNumCourses" ng-model="courseFilters.page"
+        <uib-pagination total-items="totalNumCourses" ng-model="courseFilters.page"
                     max-size="10" class="pagination-sm" boundary-links="true"
                     direction-links="false" items-per-page="courseFilters.perPage"
-                    num-pages="numPages" ng-hide="numPages == 1"></pagination>
+                    num-pages="numPages" ng-hide="numPages == 1"></uib-pagination>
     </div>
 
     <div ng-if="!courses.length">

--- a/compair/static/modules/login/login-module.js
+++ b/compair/static/modules/login/login-module.js
@@ -54,9 +54,9 @@ module.directive('autoFocus', ["$timeout", "$log", function($timeout, $log) {
 /***** Listeners *****/
 // display the login page if user is not logged in
 module.run(
-    ["$rootScope", "$route", "$location", "$log", "$modal", "$cacheFactory", "AuthenticationService",
+    ["$rootScope", "$route", "$location", "$log", "$uibModal", "$cacheFactory", "AuthenticationService",
      "Toaster", "$http",
-    function ($rootScope, $route, $location, $log, $modal, $cacheFactory, AuthenticationService,
+    function ($rootScope, $route, $location, $log, $uibModal, $cacheFactory, AuthenticationService,
               Toaster, $http) {
     // Create a modal dialog box for containing the login form
     var loginBox;
@@ -78,7 +78,7 @@ module.run(
 
     $rootScope.showLogin = function() {
         if (isOpen) return;
-        loginBox = $modal.open({
+        loginBox = $uibModal.open({
             templateUrl: 'modules/login/login-partial.html',
             backdrop: 'static', // can't close login on backdrop click
             keyboard: false, // can't close login on pressing Esc key

--- a/compair/static/modules/login/login-partial.html
+++ b/compair/static/modules/login/login-partial.html
@@ -55,7 +55,7 @@
                 <ul>
                     <li ng-if="authTypesEnabled.cas">Make sure your CWL is functioning normally (try logging in somewhere else).</li>
                     <li>Confirm your registration in the course that is using this application.</li>
-                    <li>Enable Java and cookies in your browser settings.</li>
+                    <li>Enable Javascript and cookies in your browser settings.</li>
                     <li>Clear your browser cache or try a different one (supported browsers include <a href="https://www.mozilla.org/en-US/firefox/new/">Firefox</a>, <a href="http://www.google.com/chrome/">Chrome</a>, <a href="https://www.apple.com/ca/safari/">Safari</a>, and <a href="http://windows.microsoft.com/en-ca/internet-explorer/download-ie">IE9+</a>).</li>
                     <li>Disable extra plugins and add-ons for your browser.</li>
                 </ul>

--- a/compair/static/modules/navbar/navbar-partial.html
+++ b/compair/static/modules/navbar/navbar-partial.html
@@ -97,8 +97,8 @@
                         </a>
                         <div notification></div> -->
                     </li>
-                    <li dropdown>
-                        <a href="" id="menu-dropdown" dropdown-toggle>
+                    <li uib-dropdown>
+                        <a href="" id="menu-dropdown" uib-dropdown-toggle>
                             {{loggedInUser.displayname}} <i class='fa fa-angle-down'></i>
                         </a>
                         <!-- User drop down menu -->

--- a/compair/static/modules/session/session-service_spec.js
+++ b/compair/static/modules/session/session-service_spec.js
@@ -1,5 +1,5 @@
 describe('Service: Session', function() {
-    var sessionService, $httpBackend, $cookies;
+    var sessionService, $httpBackend, localStorageService;
     var id = "1abcABC123-abcABC123_Z";
     var expectedSession = {
         "id": id,
@@ -46,7 +46,7 @@ describe('Service: Session', function() {
 
     beforeEach(inject(function($injector) {
         $httpBackend = $injector.get('$httpBackend');
-        $cookies = $injector.get('$cookies');
+        localStorageService = $injector.get('localStorageService');
         sessionService = $injector.get('Session');
     }));
 
@@ -81,8 +81,8 @@ describe('Service: Session', function() {
                 expect(user.id).toEqual(expectedUser.id);
             }));
 
-            it('and set cookie', inject(function($cookies) {
-                expect($cookies.getObject('current.user')).toEqual(expectedUser);
+            it('and set local storage', inject(function(localStorageService) {
+                expect(localStorageService.get('user')).toEqual(expectedUser);
             }));
 
             it('and cache user in Session', function() {
@@ -107,8 +107,8 @@ describe('Service: Session', function() {
                 });
             });
 
-            it('should get user from cookie', inject(function($cookies, UserResource) {
-                $cookies.putObject('current.user', expectedUser);
+            it('should get user from local storage', inject(function(localStorageService, UserResource) {
+                localStorageService.set('user', expectedUser);
                 var t = new UserResource;
                 angular.extend(t, expectedUser);
                 sessionService.getUser().then(function(result) {
@@ -139,8 +139,8 @@ describe('Service: Session', function() {
                 expect(permissions).toEqual(expectedSession.permissions);
             });
 
-            it('and set cookie', inject(function($cookies) {
-                expect($cookies.getObject('current.permissions')).toEqual(expectedSession.permissions);
+            it('and set local storage', inject(function(localStorageService) {
+                expect(localStorageService.get('permissions')).toEqual(expectedSession.permissions);
             }));
 
             it('and cache permission in Session', function() {
@@ -164,8 +164,8 @@ describe('Service: Session', function() {
                 })
             });
 
-            it('should get permissions from cookie', inject(function($cookies) {
-                $cookies.putObject('current.permissions', expectedSession.permissions);
+            it('should get permissions from local storage', inject(function(localStorageService) {
+                localStorageService.set('permissions', expectedSession.permissions);
                 expect(sessionService._permissions).toBe(null);
                 sessionService.getPermissions().then(function(result) {
                     expect(result).toEqual(expectedSession.permissions);

--- a/compair/static/modules/user/user-module_spec.js
+++ b/compair/static/modules/user/user-module_spec.js
@@ -5,25 +5,31 @@ describe('user-module', function () {
         "id": id,
         "permissions": {
             "Course": {
-                "create": true,
-                "delete": true,
-                "edit": true,
-                "manage": true,
-                "read": true
+                "global": [
+                    "create",
+                    "delete",
+                    "edit",
+                    "manage",
+                    "read"
+                ]
             },
             "Assignment": {
-                "create": true,
-                "delete": true,
-                "edit": true,
-                "manage": true,
-                "read": true
+                "global": [
+                    "create",
+                    "delete",
+                    "edit",
+                    "manage",
+                    "read"
+                ]
             },
             "User": {
-                "create": true,
-                "delete": true,
-                "edit": true,
-                "manage": true,
-                "read": true
+                "global": [
+                    "create",
+                    "delete",
+                    "edit",
+                    "manage",
+                    "read"
+                ]
             }
         }
     };

--- a/compair/static/test/factories/session_factory.js
+++ b/compair/static/test/factories/session_factory.js
@@ -2,74 +2,77 @@ var objectAssign = require('object-assign');
 
 var permission_admin = {
     "Course": {
-        "create": {'global': true},
-        "delete": {'global': true},
-        "edit": {'global': true},
-        "manage": {'global': true},
-        "read": {'global': true}
+        "global": [
+            "create",
+            "delete",
+            "edit",
+            "manage",
+            "read"
+        ]
     },
     "Assignment": {
-        "create": {'global': true},
-        "delete": {'global': true},
-        "edit": {'global': true},
-        "manage": {'global': true},
-        "read": {'global': true}
+        "global": [
+            "create",
+            "delete",
+            "edit",
+            "manage",
+            "read"
+        ]
     },
     "User": {
-        "create": {'global': true},
-        "delete": {'global': true},
-        "edit": {'global': true},
-        "manage": {'global': true},
-        "read": {'global': true}
+        "global": [
+            "create",
+            "delete",
+            "edit",
+            "manage",
+            "read"
+        ]
     }
 };
 
 var permission_instructor = {
     "Course": {
-        "create": {'global': true},
-        "delete": {'global': false},
-        "edit": {'global': true},
-        "manage": {'global': false},
-        "read": {'global': true}
+        "global": [
+            "create",
+            "delete",
+            "edit",
+            "read"
+        ]
     },
     "Assignment": {
-        "create": {'global': true},
-        "delete": {'global': true},
-        "edit": {'global': true},
-        "manage": {'global': true},
-        "read": {'global': true}
+        "global": [
+            "create",
+            "delete",
+            "edit",
+            "manage",
+            "read"
+        ]
     },
     "User": {
-        "create": {'global': false},
-        "delete": {'global': false},
-        "edit": {'global': true},
-        "manage": {'global': false},
-        "read": {'global': true}
+        "global": [
+            "edit",
+            "read"
+        ]
     }
 };
 
 
 var permission_student = {
     "Course": {
-        "create": {'global': false},
-        "delete": {'global': false},
-        "edit": {'global': false},
-        "manage": {'global': false},
-        "read": {'global': true}
+        "global": [
+            "read"
+        ]
     },
     "Assignment": {
-        "create": {'global': false},
-        "delete": {'global': false},
-        "edit": {'global': false},
-        "manage": {'global': false},
-        "read": {'global': true}
+        "global": [
+            "read"
+        ]
     },
     "User": {
-        "create": {'global': false},
-        "delete": {'global': false},
-        "edit": {'global': true},
-        "manage": {'global': false},
-        "read": {'global': true}
+        "global": [
+            "edit",
+            "read"
+        ]
     }
 }
 
@@ -97,10 +100,8 @@ SessionFactory.prototype.generateSession = function (userId, type, additionalPer
 
     if(additionalPermissions) {
         for(var domain in additionalPermissions) {
-            for(var action in additionalPermissions[domain]) {
-                var permissionBase = newSession.permissions[domain][action];
-                var permissionExtend = additionalPermissions[domain][action];
-                newSession.permissions[domain][action] = objectAssign({}, permissionBase, permissionExtend);
+            for(var courseId in additionalPermissions[domain]) {
+                newSession.permissions[domain][courseId] = additionalPermissions[domain][courseId];
             }
         }
     }

--- a/compair/static/test/features/support/hooks.js
+++ b/compair/static/test/features/support/hooks.js
@@ -17,8 +17,10 @@ var hooks = function () {
             }
         });
 
-        // ensure cookies are cleared
+        // ensure cookies and local storage are cleared
         browser.manage().deleteAllCookies();
+        browser.executeScript('window.sessionStorage.clear();');
+        browser.executeScript('window.localStorage.clear();');
 
         // print any js errors
         browser.manage().logs().get('browser').then( function(browserLog) {

--- a/compair/static/test/fixtures/instructor/default_fixture.js
+++ b/compair/static/test/fixtures/instructor/default_fixture.js
@@ -172,18 +172,33 @@ storage.course_assignments[course.id].push(assignment_upcoming.id);
 storage.loginDetails = { id: instructor.id, username: instructor.username, password: "password" };
 var session = sessionFactory.generateSession(instructor.id, instructor.system_role, {
     "Course": {
-        "delete": {'1abcABC123-abcABC123_Z': false, '2abcABC123-abcABC123_Z': false},
-        "edit": {'1abcABC123-abcABC123_Z': true, '2abcABC123-abcABC123_Z': true},
-        "manage": {'1abcABC123-abcABC123_Z': false, '2abcABC123-abcABC123_Z': false},
-        "read": {'1abcABC123-abcABC123_Z': true, '2abcABC123-abcABC123_Z': true},
+        "1abcABC123-abcABC123_Z": [
+            "delete",
+            "edit",
+            "read"
+        ],
+        "2abcABC123-abcABC123_Z": [
+            "delete",
+            "edit",
+            "read"
+        ]
     },
     "Assignment": {
-        "create": {'1abcABC123-abcABC123_Z': true, '2abcABC123-abcABC123_Z': true, '3abcABC123-abcABC123_Z': true, '4abcABC123-abcABC123_Z': true},
-        "delete": {'1abcABC123-abcABC123_Z': true, '2abcABC123-abcABC123_Z': true, '3abcABC123-abcABC123_Z': true, '4abcABC123-abcABC123_Z': true},
-        "edit": {'1abcABC123-abcABC123_Z': true, '2abcABC123-abcABC123_Z': true, '3abcABC123-abcABC123_Z': true, '4abcABC123-abcABC123_Z': true},
-        "manage": {'1abcABC123-abcABC123_Z': true, '2abcABC123-abcABC123_Z': true, '3abcABC123-abcABC123_Z': true, '4abcABC123-abcABC123_Z': true},
-        "read": {'1abcABC123-abcABC123_Z': true, '2abcABC123-abcABC123_Z': true, '3abcABC123-abcABC123_Z': true, '4abcABC123-abcABC123_Z': true}
-    },
+        "1abcABC123-abcABC123_Z": [
+            "create",
+            "delete",
+            "edit",
+            "manage",
+            "read"
+        ],
+        "2abcABC123-abcABC123_Z": [
+            "create",
+            "delete",
+            "edit",
+            "manage",
+            "read"
+        ]
+    }
 });
 storage.session = session;
 

--- a/compair/static/test/fixtures/student/default_fixture.js
+++ b/compair/static/test/fixtures/student/default_fixture.js
@@ -168,17 +168,20 @@ storage.course_assignments[course.id].push(assignment_being_answered.id);
 storage.loginDetails = { id: student.id, username: student.username, password: "password" };
 var session = sessionFactory.generateSession(student.id, student.system_role, {
     "Course": {
-        "delete": {'1abcABC123-abcABC123_Z': false, '2abcABC123-abcABC123_Z': false},
-        "edit": {'1abcABC123-abcABC123_Z': false, '2abcABC123-abcABC123_Z': false},
-        "manage": {'1abcABC123-abcABC123_Z': false, '2abcABC123-abcABC123_Z': false},
-        "read": {'1abcABC123-abcABC123_Z': true, '2abcABC123-abcABC123_Z': true},
+        "1abcABC123-abcABC123_Z": [
+            "read"
+        ],
+        "2abcABC123-abcABC123_Z": [
+            "read"
+        ]
     },
     "Assignment": {
-        "create": {'1abcABC123-abcABC123_Z': false, '2abcABC123-abcABC123_Z': false, '3abcABC123-abcABC123_Z': false, '4abcABC123-abcABC123_Z': false},
-        "delete": {'1abcABC123-abcABC123_Z': false, '2abcABC123-abcABC123_Z': false, '3abcABC123-abcABC123_Z': false, '4abcABC123-abcABC123_Z': false},
-        "edit": {'1abcABC123-abcABC123_Z': false, '2abcABC123-abcABC123_Z': false, '3abcABC123-abcABC123_Z': false, '4abcABC123-abcABC123_Z': false},
-        "manage": {'1abcABC123-abcABC123_Z': false, '2abcABC123-abcABC123_Z': false, '3abcABC123-abcABC123_Z': false, '4abcABC123-abcABC123_Z': false},
-        "read": {'1abcABC123-abcABC123_Z': true, '2abcABC123-abcABC123_Z': true, '3abcABC123-abcABC123_Z': true, '4abcABC123-abcABC123_Z': true}
+        "1abcABC123-abcABC123_Z": [
+            "read"
+        ],
+        "2abcABC123-abcABC123_Z": [
+            "read"
+        ]
     },
 });
 storage.session = session;

--- a/compair/templates/index-dev.html
+++ b/compair/templates/index-dev.html
@@ -28,7 +28,6 @@
         <script src="{{ url_for('static', filename='lib/jquery/dist/jquery.js') }}"></script>
         <script src="{{ url_for('static', filename='lib/angular/angular.js') }}"></script>
         <script src="{{ url_for('static', filename='lib/angular-animate/angular-animate.js') }}"></script>
-        <script src="{{ url_for('static', filename='lib/angular-cookies/angular-cookies.js') }}"></script>
         <script src="{{ url_for('static', filename='lib/angular-resource/angular-resource.js') }}"></script>
         <script src="{{ url_for('static', filename='lib/angular-route/angular-route.js') }}"></script>
         <script src="{{ url_for('static', filename='lib/angular-sanitize/angular-sanitize.js') }}"></script>
@@ -55,6 +54,7 @@
         <script src="{{ url_for('static', filename='lib/ngclipboard/dist/ngclipboard.js') }}"></script>
         <script src="{{ url_for('static', filename='lib/tincan/build/tincan.js') }}"></script>
         <script src="{{ url_for('static', filename='lib/angular-uuids/angular-uuid.js') }}"></script>
+        <script src="{{ url_for('static', filename='lib/angular-local-storage/dist/angular-local-storage.js') }}"></script>
         <!-- endbower -->
         <!-- endbuild -->
 


### PR DESCRIPTION
- Use angular-local-storage library for storing user, permissions, and lit information. Library will use browser session storage (with fallback to cookies) to act similarly to how the cookies were used. Moving away from cookies will be useful for when switching to token based auth in the future (#249)
- Reduced the complexity/size of permissions data (structure is now model_name -> course_uuid/global -> list of allowed permissions)
- Updated references to deprecated angular-bootstrap directives/providers

Fixes #468
Related #249