### PR TITLE
Add ckeditor iframe feature

### DIFF
--- a/compair/static/modules/answer/answer-form-partial.html
+++ b/compair/static/modules/answer/answer-form-partial.html
@@ -3,7 +3,7 @@
 <form class="form" name="answerForm" ng-submit="answerSubmit()" novalidate confirm-form-exit form-type="answer">
     <fieldset>
         <h2 ng-hide="comparison_example"><i class="fa fa-comments"></i> {{assignment.name}}</h2>
-        <div class="assignment-desc" mathjax hljs ng-bind-html="assignment.description" ng-hide="comparison_example"></div>
+        <ckeditor-html-content class="assignment-desc" html-content="assignment.description" ng-hide="comparison_example"></ckeditor-html-content>
 
         <!-- Attachment -->
         <compair-attachment-inline label="See assignment details:" attachment="assignment.file" ng-hide="comparison_example"></compair-attachment-inline>

--- a/compair/static/modules/assignment/assignment-form-partial.html
+++ b/compair/static/modules/assignment/assignment-form-partial.html
@@ -240,7 +240,7 @@
                         <p class="text-muted"><em>Click 'Edit' above to add your example answer here.</em></p>
                     </div>
                     <div>
-                        <div mathjax hljs ng-bind-html="comparison_example.answer1.content"></div>
+                        <ckeditor-html-content class="assignment-desc" html-content="comparison_example.answer1.content"></ckeditor-html-content>
                         <compair-attachment-inline label="See answer details:"
                             attachment="comparison_example.answer1.file">
                         </compair-attachment-inline>

--- a/compair/static/modules/assignment/assignment-view-partial.html
+++ b/compair/static/modules/assignment/assignment-view-partial.html
@@ -6,7 +6,7 @@
         <h2><i class="fa fa-comments"></i> {{assignment.name}}</h2>
 
         <!-- Assignment Details -->
-        <div class="assignmentmathjax assignment-desc" mathjax hljs ng-bind-html="assignment.description"></div>
+        <ckeditor-html-content class="assignment-desc" html-content="assignment.description"></ckeditor-html-content>
 
         <!-- Assignment Attachment -->
         <compair-attachment-inline label="See assignment details:" attachment="assignment.file"></compair-attachment-inline>
@@ -238,7 +238,7 @@
 
                     <!-- Instructor Answer -->
                     <div class="content instructor-answer">
-                        <div mathjax hljs ng-bind-html="answer.content"></div>
+                        <ckeditor-html-content html-content="comparison_example.answer1.content"></ckeditor-html-content>
                         <!-- Instructor Attachment -->
                         <compair-attachment-inline label="See answer details:" attachment="answer.file"></compair-attachment-inline>
                     </div>
@@ -284,7 +284,7 @@
 
                     <!-- Student Answer -->
                     <div class="content {{answer.id}}" get-height>
-                        <div mathjax hljs ng-bind-html="answer.content"></div>
+                        <ckeditor-html-content html-content="answer.content"></ckeditor-html-content>
                         <!-- Student Attachment -->
                         <compair-attachment-inline label="See answer details:" attachment="answer.file" ng-click="revealAnswer(answer)"></compair-attachment-inline>
                     </div>
@@ -360,7 +360,7 @@
                             </div>
 
                             <!-- Student Reply -->
-                            <div class="content" mathjax hljs ng-bind-html="comment.content"></div>
+                            <ckeditor-html-content class="content" html-content="comment.content"></ckeditor-html-content>
 
                         </div><!-- closes each-reply (student) -->
 
@@ -426,8 +426,7 @@
 
                 <!-- Student Answer -->
                 <div class="content {{answer.id}}">
-                    <div mathjax hljs ng-bind-html="answer.content">
-                    </div>
+                    <ckeditor-html-content html-content="answer.content"></ckeditor-html-content>
 
                     <!-- Student Attachment -->
                     <compair-attachment-inline label="See answer details:"
@@ -473,7 +472,7 @@
                         </div>
 
                         <!-- Student Reply -->
-                        <div class="content" mathjax hljs ng-bind-html="comment.content"></div>
+                        <ckeditor-html-content class="content" html-content="comment.content"></ckeditor-html-content>
 
                     </div><!-- closes each-reply (student) -->
 
@@ -507,7 +506,7 @@
                         <h5 class="content">Feedback for Odd-Numbered Answer</h5>
                         <!-- feedback for odd-numbered answer -->
                         <div ng-repeat="feedback in comparison_set.answer1_feedback">
-                            <div class="content" mathjax hljs ng-bind-html="feedback.content"></div>
+                            <ckeditor-html-content class="content" html-content="feedback.content"></ckeditor-html-content>
                         </div>
                     </div>
 
@@ -515,7 +514,7 @@
                         <h5 class="content">Feedback for Even-Numbered Answer</h5>
                         <!-- feedback for even-numbered answer -->
                         <div ng-repeat="feedback in comparison_set.answer2_feedback">
-                            <div class="content" mathjax hljs ng-bind-html="feedback.content"></div>
+                            <ckeditor-html-content class="content" html-content="feedback.content"></ckeditor-html-content>
                         </div>
                     </div>
                 </div>
@@ -553,7 +552,7 @@
                             </a>
                         </div>
                     </div>
-                    <div class="content" mathjax hljs ng-bind-html="comment.content"></div>
+                    <ckeditor-html-content class="content" html-content="comment.content"></ckeditor-html-content>
                 </div>
             </div>
 
@@ -610,7 +609,7 @@
                 </div>
 
                 <!-- Comment -->
-                <div class="content" mathjax hljs ng-bind-html="comment.content"></div>
+                <ckeditor-html-content class="content" html-content="comment.content"></ckeditor-html-content>
 
             </div><!-- closes each-comment -->
 

--- a/compair/static/modules/comment/answer-content.html
+++ b/compair/static/modules/comment/answer-content.html
@@ -9,7 +9,7 @@
                 </span>
             </span>
         </h4>
-        <div mathjax hljs ng-if="answer" ng-bind-html="answer.content"></div>
+        <ckeditor-html-content html-content="answer.content" ng-if="answer"></ckeditor-html-content>
         <div ng-if="!answer"><i>(This answer has been deleted.)</i></div>
         <!-- Attachments -->
         <compair-attachment-inline label="See details:" attachment="answer.file"></compair-attachment-inline>

--- a/compair/static/modules/comment/answer.html
+++ b/compair/static/modules/comment/answer.html
@@ -1,7 +1,7 @@
 <div ng-if="answer">
     <compair-avatar user-id="answer.user_id" avatar="answer.user.avatar" display-name="answer.user.displayname"></compair-avatar>
     <strong>answered</strong> on {{ answer.created | amDateFormat: 'MMM D @ h:mm a'}}:
-    <div class="content" mathjax hljs ng-bind-html="answer.content"></div>
+    <ckeditor-html-content class="content" html-content="answer.content"></ckeditor-html-content>
     <compair-attachment-inline ng-if="answer" label="See details:" attachment="answer.file"></compair-attachment-inline>
 </div>
 <div ng-if="!answer"><p><i>(No answer has been submitted by this student.)</i></p></div>

--- a/compair/static/modules/comment/comment-comparison-partial.html
+++ b/compair/static/modules/comment/comment-comparison-partial.html
@@ -81,14 +81,14 @@
                         <h5 class="content">Feedback for Odd-Numbered Answer</h5>
                         <!-- feedback for odd-numbered answer -->
                         <div ng-repeat="feedback in comparison_set.answer1_feedback">
-                            <div class="content" mathjax hljs ng-bind-html="feedback.content"></div>
+                            <ckeditor-html-content class="content" html-content="feedback.content"></ckeditor-html-content>
                         </div>
                     </div>
                     <div class="col-md-6">
                         <h5 class="content">Feedback for Even-Numbered Answer</h5>
                         <!-- feedback for even-numbered answer -->
                         <div ng-repeat="feedback in comparison_set.answer2_feedback">
-                            <div class="content" mathjax hljs ng-bind-html="feedback.content"></div>
+                            <ckeditor-html-content class="content" html-content="feedback.content"></ckeditor-html-content>
                         </div>
                     </div>
                 </div>
@@ -112,7 +112,7 @@
                         <strong>self-evaluated</strong> on {{ self_evaluation.created | amDateFormat: 'MMM D @ h:mm a'}}:
                     </div>
 
-                    <div class="content" mathjax hljs ng-bind-html="self_evaluation.content"></div>
+                    <ckeditor-html-content class="content" html-content="self_evaluation.content"></ckeditor-html-content>
                 </div>
             </div>
         </div>

--- a/compair/static/modules/comment/comment-form-partial.html
+++ b/compair/static/modules/comment/comment-form-partial.html
@@ -3,7 +3,7 @@
         <h2 ng-if="parent.name"><i class="fa fa-comments"></i> {{parent.name}}</h2>
         <i class="fa fa-quote-left pull-left" ng-if="!parent.name && parent.content"></i>
         <i class="fa fa-quote-right pull-right" ng-if="!parent.name && parent.content"></i>
-        <div class="assignment-desc" mathjax hljs ng-bind-html="parent.content"></div>
+        <ckeditor-html-content class="assignment-desc" html-content="parent.content"></ckeditor-html-content>
         <!-- Attachment -->
         <compair-attachment-inline label="See assignment details:" attachment="parent.file"></compair-attachment-inline>
 

--- a/compair/static/modules/common/common-module.js
+++ b/compair/static/modules/common/common-module.js
@@ -16,4 +16,46 @@ module.filter("emptyToEnd", function () {
     };
 });
 
+module.directive('ckeditorHtmlContent',
+    ['$sce',
+    function ($sce)
+    {
+        return {
+            restrict: 'E',
+            scope: {
+                htmlContent: '='
+            },
+            link: function(scope, element, attrs) {
+                scope.trustedContent = [];
+
+                scope.$watch('htmlContent', function(walks) {
+                    scope.bindHtml();
+                })
+
+                scope.bindHtml = function() {
+                    if (scope.htmlContent) {
+                        // add trusted content (iframe) as safe html
+                        var chunks = scope.htmlContent.split(/\<iframe|\<\/iframe\>/gi);
+
+                        // add back iframe tags and mark safe
+                        chunks.forEach(function(chunk, index) {
+                            if (index % 2 == 1) {
+                                chunks[index] = $sce.trustAsHtml("<iframe"+chunk+"</iframe>");
+                            }
+                        });
+
+                        scope.trustedContent = chunks;
+                    } else {
+                        scope.trustedContent = [];
+                    }
+                }
+                scope.bindHtml();
+            },
+            template: '<div mathjax hljs ng-repeat="htmlContent in trustedContent"> ' +
+                          '<div ng-bind-html="htmlContent"></div>' +
+                      '</div>'
+        };
+    }]
+);
+
 })();

--- a/compair/static/modules/common/form-directive.js
+++ b/compair/static/modules/common/form-directive.js
@@ -131,7 +131,7 @@ module.service('EditorOptions', function() {
         height: "150px",
 
         // enable custom plugin that combines ASCIIMath and LaTeX math input and code highlighting
-        extraPlugins: 'codesnippet,combinedmath'
+        extraPlugins: 'iframe,codesnippet,combinedmath'
     };
 });
 

--- a/compair/static/modules/comparison/comparison-core.html
+++ b/compair/static/modules/comparison/comparison-core.html
@@ -16,7 +16,7 @@
 
     <div ng-show="showAssignment " class="standalone-assignment">
         <h2><i class="fa fa-comments"></i> {{assignment.name}}</h2>
-        <div mathjax hljs ng-bind-html="assignment.description"></div>
+        <ckeditor-html-content html-content="assignment.description"></ckeditor-html-content>
         <!-- Attachment -->
         <compair-attachment-inline label="See assignment details:" attachment="assignment.file"></compair-attachment-inline>
     </div>
@@ -46,7 +46,7 @@
         <div class="col-md-6" ng-hide="comparisonsError">
             <div class="answer-choice clearfix">
                 <h3 class="text-center">Answer {{firstAnsNum}}</h3>
-                <div mathjax hljs ng-bind-html="answer1.content"></div>
+                <ckeditor-html-content html-content="answer1.content"></ckeditor-html-content>
                 <!-- Attachment -->
                 <compair-attachment-inline label="See detail:"
                     attachment="answer1.file" download-name="'Answer #'+firstAnsNum">
@@ -67,7 +67,7 @@
         <div class="col-md-6" ng-hide="comparisonsError">
             <div class="answer-choice clearfix">
                 <h3 class="text-center">Answer {{secondAnsNum}}</h3>
-                <div mathjax hljs ng-bind-html="answer2.content"></div>
+                <ckeditor-html-content html-content="answer2.content"></ckeditor-html-content>
                 <!-- Attachment -->
                 <compair-attachment-inline label="See detail:"
                     attachment="answer2.file" download-name="'Answer #'+secondAnsNum">
@@ -107,9 +107,7 @@
                             <div class="col-sm-8">
                                 <h4><i class="fa fa-gavel"></i> {{comparison.criterion.name}}</h4>
                                 <hr />
-                                <div class="criteria" mathjax hljs
-                                     ng-bind-html="comparison.criterion.description">
-                                </div>
+                                <ckeditor-html-content class="criteria" html-content="comparison.criterion.description"></ckeditor-html-content>
                             </div>
                             <div class="col-sm-4 text-center">
                                 <p><strong>Select one:</strong></p>

--- a/compair/static/modules/course/course-assignments-partial.html
+++ b/compair/static/modules/course/course-assignments-partial.html
@@ -3,8 +3,7 @@
     <div class="row">
         <header class="col-sm-6">
             <h1><i class="fa fa-book"></i> {{course.name}} <br />({{course.year}} {{course.term}})</h1>
-            <div class="intro-text" mathjax hljs ng-bind-html="course.description">
-            </div>
+            <ckeditor-html-content class="intro-text" html-content="course.description"></ckeditor-html-content>
         </header>
         <div class="col-sm-6 sub-nav">
             <span ng-if="canCreateAssignments">
@@ -69,7 +68,7 @@
 
                 <!-- Details -->
                 <div class="assignment-desc">
-                    <div mathjax hljs ng-bind-html="assignment.description"></div>
+                    <ckeditor-html-content html-content="assignment.description"></ckeditor-html-content>
                     <!-- Attachment -->
                     <compair-attachment-inline label="See assignment details:" attachment="assignment.file"></compair-attachment-inline>
                 </div>

--- a/compair/static/modules/criterion/criterion-assignment-partial.html
+++ b/compair/static/modules/criterion/criterion-assignment-partial.html
@@ -27,7 +27,7 @@
         </div>
         <div class="col-sm-8">
             <strong>{{ key + 1 }}. {{ criterion.name }}</strong>
-            <div mathjax hljs ng-bind-html="criterion.description"></div>
+            <ckeditor-html-content html-content="criterion.description"></ckeditor-html-content>
         </div>
     </div>
 


### PR DESCRIPTION
Due to angularjs filtering out iframes as unsafe, ckeditor html now needs to be parsed to allow iframe content to be marked as safe before reaching the ng-bind-html directive.

Fixes: #491 