### PR TITLE
Modify editor link targets

### DIFF
--- a/compair/static/compair-config.js
+++ b/compair/static/compair-config.js
@@ -273,12 +273,43 @@ myApp.config(['$routeProvider', '$logProvider', '$httpProvider', '$locationProvi
     $logProvider.debugEnabled(debugMode);
 }]);
 
-myApp.config(['localStorageServiceProvider', function (localStorageServiceProvider) {
-    localStorageServiceProvider
-        .setPrefix('ComPAIR')
-        .setStorageType('sessionStorage') // options [localStorage, sessionStorage]
-        .setStorageCookie(0); // fallback default settings
-}]);
+myApp.config(
+    ['localStorageServiceProvider',
+    function (localStorageServiceProvider)
+    {
+        // config local storage
+        localStorageServiceProvider
+            .setPrefix('ComPAIR')
+            .setStorageType('sessionStorage') // options [localStorage, sessionStorage]
+            .setStorageCookie(0); // fallback default settings
+
+        // config MathJax
+        window.MathJax.Hub.Config({
+            skipStartupTypeset: true
+        });
+        window.MathJax.Hub.Configured();
+
+        // config CKEDITOR
+        window.CKEDITOR.plugins.addExternal( 'combinedmath', '/app/lib_extension/ckeditor/plugins/combinedmath/' );
+        window.CKEDITOR.on('dialogDefinition', function(ev) {
+            var dialogName = ev.data.name;
+            var dialog = ev.data.definition.dialog;
+            var dialogDefinition = ev.data.definition;
+
+            if (dialogName === 'link') {
+                var target = dialogDefinition.getContents('target');
+                var options = target.get('linkTargetType').items;
+
+                for (var i = options.length-1; i >= 0; i--) {
+                    var value = options[i][1];
+                    if (!value.match(/\_self|\_blank|notSet/i)) {
+                        options.splice(i, 1);
+                    }
+                }
+            }
+        });
+    }
+]);
 
 // placeholder for templates module to store templates into cache
 // gulp prod will generate the actual templates module and put contents into cache

--- a/compair/templates/index-dev.html
+++ b/compair/templates/index-dev.html
@@ -73,13 +73,6 @@
 
         <!-- MathJax, should figure out how to bower manage this -->
         <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_HTMLorMML&delayStartupUntil=configured"></script>
-        <script type="text/javascript">
-        MathJax.Hub.Config({
-          skipStartupTypeset: true
-        });
-        MathJax.Hub.Configured();
-        CKEDITOR.plugins.addExternal( 'combinedmath', '/app/lib_extension/ckeditor/plugins/combinedmath/' );
-        </script>
 
         <!-- build:prod_minify_js -->
         <!-- AngularJS Modules/Controllers/Services/etc -->

--- a/compair/templates/index.html
+++ b/compair/templates/index.html
@@ -27,13 +27,6 @@
 
         <!-- MathJax, should figure out how to bower manage this -->
         <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_HTMLorMML&delayStartupUntil=configured"></script>
-        <script type="text/javascript">
-        MathJax.Hub.Config({
-          skipStartupTypeset: true
-        });
-        MathJax.Hub.Configured();
-        CKEDITOR.plugins.addExternal( 'combinedmath', '/app/lib_extension/ckeditor/plugins/combinedmath/' );
-        </script>
 
         <!-- build:prod_minify_js -->
         <script src="{{ compair_js }}"></script>


### PR DESCRIPTION
Several of the link target options allowed by ckeditor are not supported by angularjs’s sanitizer (due to using unsafe javascript).
Instead only the basic options should be allowed (not set, _blank, _self).

Also moved the MathJax and ckeditor setup scripts into the angular app config