### PR TITLE
Add start/end date constraints to date-pickers

### DIFF
--- a/compair/api/assignment.py
+++ b/compair/api/assignment.py
@@ -129,6 +129,13 @@ class AssignmentIdAPI(Resource):
             assignment.compare_end = datetime.datetime.strptime(
                 params.get('compare_end', assignment.compare_end),
                 '%Y-%m-%dT%H:%M:%S.%fZ')
+
+        # validate answer + comparison period start & end times
+        valid, error_message = Assignment.validate_periods(course.start_date, course.end_date,
+             assignment.answer_start, assignment.answer_end, assignment.compare_start, assignment.compare_end)
+        if not valid:
+            return {"error": error_message}, 400
+
         assignment.students_can_reply = params.get('students_can_reply', False)
         assignment.number_of_comparisons = params.get(
             'number_of_comparisons', assignment.number_of_comparisons)
@@ -336,6 +343,13 @@ class AssignmentRootAPI(Resource):
         new_assignment.compare_end = params.get('compare_end', None)
         if new_assignment.compare_end is not None:
             new_assignment.compare_end = dateutil.parser.parse(params.get('compare_end', None))
+
+        # validate answer + comparison period start & end times
+        valid, error_message = Assignment.validate_periods(course.start_date, course.end_date,
+             new_assignment.answer_start, new_assignment.answer_end,
+             new_assignment.compare_start, new_assignment.compare_end)
+        if not valid:
+            return {"error": error_message}, 400
 
         new_assignment.students_can_reply = params.get('students_can_reply', False)
         new_assignment.number_of_comparisons = params.get('number_of_comparisons')

--- a/compair/static/modules/assignment/assignment-form-partial.html
+++ b/compair/static/modules/assignment/assignment-form-partial.html
@@ -78,9 +78,12 @@
                 <label class="required-star">Answering Begins</label><br />
                 <div class="assignment-date">
                     <span class="input-group">
-                        <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.astart.date" is-open="date.astart.opened" required />
+                        <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.astart.date"
+                            min-date="datePickerMinDate(course.start_date)"
+                            max-date="datePickerMaxDate(date.aend.date, course.end_date)"
+                            is-open="date.astart.opened" required />
                         <span class="input-group-btn">
-                            <button type="button" class="btn btn-default" ng-click="date.astart.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                            <button type="button" class="btn btn-default" ng-click="datePickerOpen($event, date.astart)"><i class="glyphicon glyphicon-calendar"></i></button>
                         </span>
                     </span>
                 </div>
@@ -92,9 +95,12 @@
                 <label class="required-star">Answering Ends</label><br />
                 <div class="assignment-date">
                     <span class="input-group">
-                        <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.aend.date" is-open="date.aend.opened" required />
+                        <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.aend.date"
+                            min-date="datePickerMinDate(date.astart.date, course.start_date)"
+                            max-date="datePickerMaxDate(course.end_date)"
+                            is-open="date.aend.opened" required />
                         <span class="input-group-btn">
-                            <button type="button" class="btn btn-default" ng-click="date.aend.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                            <button type="button" class="btn btn-default" ng-click="datePickerOpen($event, date.aend)"><i class="glyphicon glyphicon-calendar"></i></button>
                         </span>
                     </span>
                 </div>
@@ -117,9 +123,12 @@
                     <label class="required-star">Comparing Begins</label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.cstart.date" is-open="date.cstart.opened" ng-required="assignment.availableCheck" />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.cstart.date"
+                                min-date="datePickerMinDate(date.astart.date, course.start_date)"
+                                max-date="datePickerMaxDate(date.cend.date, course.end_date)"
+                                is-open="date.cstart.opened" ng-required="assignment.availableCheck" />
                             <span class="input-group-btn">
-                                <button type="button" class="btn btn-default" ng-click="date.cstart.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                                <button type="button" class="btn btn-default" ng-click="datePickerOpen($event, date.cstart)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>
@@ -131,9 +140,12 @@
                     <label class="required-star">Comparing Ends</label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.cend.date" is-open="date.cend.opened" ng-required="assignment.availableCheck" />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.cend.date"
+                                min-date="datePickerMinDate(date.cstart.date, course.start_date)"
+                                max-date="datePickerMaxDate(course.end_date)"
+                                is-open="date.cend.opened" ng-required="assignment.availableCheck" />
                             <span class="input-group-btn">
-                                <button type="button" class="btn btn-default" ng-click="date.cend.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                                <button type="button" class="btn btn-default" ng-click="datePickerOpen($event, date.cend)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>

--- a/compair/static/modules/assignment/assignment-module.js
+++ b/compair/static/modules/assignment/assignment-module.js
@@ -775,14 +775,15 @@ module.controller("AssignmentWriteController",
     [ "$scope", "$q", "$location", "$routeParams", "$route", "AssignmentResource", "$uibModal", "Authorize",
              "CriterionResource", "required_rounds", "Toaster", "attachService",
              "Session", "EditorOptions", "PairingAlgorithm", "ComparisonExampleResource",
-             "AnswerResource", "xAPIStatementHelper",
+             "AnswerResource", "xAPIStatementHelper", "CourseResource", "moment",
     function($scope, $q, $location, $routeParams, $route, AssignmentResource, $uibModal, Authorize,
              CriterionResource, required_rounds, Toaster, attachService,
              Session, EditorOptions, PairingAlgorithm, ComparisonExampleResource,
-             AnswerResource, xAPIStatementHelper)
+             AnswerResource, xAPIStatementHelper, CourseResource, moment)
     {
         var courseId = $routeParams['courseId'];
         //initialize assignment so this scope can access data from included form
+        $scope.course = CourseResource.get({'id': courseId});
         $scope.assignment = {criteria: []};
         $scope.availableCriteria = [];
         $scope.editorOptions = EditorOptions.basic;
@@ -967,29 +968,46 @@ module.controller("AssignmentWriteController",
             );
         }
 
-        $scope.date.astart.open = function($event) {
+        $scope.datePickerOpen = function($event, object) {
             $event.preventDefault();
             $event.stopPropagation();
 
-            $scope.date.astart.opened = true;
+            object.opened = true;
         };
-        $scope.date.aend.open = function($event) {
-            $event.preventDefault();
-            $event.stopPropagation();
 
-            $scope.date.aend.opened = true;
+        $scope.datePickerMinDate = function() {
+            var dates = Array.prototype.slice.call(arguments).filter(function(val) {
+                return val !== null;
+            });
+            if (dates.length == 0) {
+                return null;
+            }
+            return dates.reduce(function (left, right) {
+                return moment(left) > moment(right) ? left : right;
+            }, dates[0]);
         };
-        $scope.date.cstart.open = function($event) {
-            $event.preventDefault();
-            $event.stopPropagation();
 
-            $scope.date.cstart.opened = true;
+        $scope.datePickerMaxDate = function() {
+            var dates = Array.prototype.slice.call(arguments).filter(function(val) {
+                return val !== null;
+            });
+            if (dates.length == 0) {
+                return null;
+            }
+            return dates.reduce(function (left, right) {
+                return moment(left) < moment(right) ? left : right;
+            }, dates[0]);
         };
-        $scope.date.cend.open = function($event) {
-            $event.preventDefault();
-            $event.stopPropagation();
 
-            $scope.date.cend.opened = true;
+        $scope.getMinDate = function(startDate) {
+            minDate = null;
+            if ($scope.course.start_date) {
+                minDate = $scope.course.start_date;
+            }
+            if (startDate) {
+                minDate = startDate;
+            }
+            return minDate;
         };
 
         $scope.criteriaCanDraw = function() {

--- a/compair/static/modules/assignment/assignment-module_spec.js
+++ b/compair/static/modules/assignment/assignment-module_spec.js
@@ -1096,6 +1096,7 @@ describe('assignment-module', function () {
         describe('new:', function() {
             beforeEach(function () {
                 controller = createController({current: {method: 'new'}}, {courseId: "1abcABC123-abcABC123_Z"});
+                $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z').respond(mockCourse);
                 $httpBackend.expectGET('/api/criteria').respond(mockCritiera);
                 $httpBackend.flush();
 
@@ -1397,6 +1398,7 @@ describe('assignment-module', function () {
         describe('edit:', function() {
             beforeEach(function () {
                 controller = createController({current: {method: 'edit'}}, {courseId: "1abcABC123-abcABC123_Z", assignmentId: "1abcABC123-abcABC123_Z"});
+                $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z').respond(mockCourse);
                 $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z/assignments/1abcABC123-abcABC123_Z').respond(mockAssignment);
                 $httpBackend.expectGET('/api/criteria').respond(mockCritiera);
                 $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z/assignments/1abcABC123-abcABC123_Z/comparisons/examples').respond(mockComparisonExamples);
@@ -1655,6 +1657,7 @@ describe('assignment-module', function () {
         describe('copy:', function() {
             beforeEach(function () {
                 controller = createController({current: {method: 'copy'}}, {courseId: "1abcABC123-abcABC123_Z", assignmentId: "1abcABC123-abcABC123_Z"});
+                $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z').respond(mockCourse);
                 $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z/assignments/1abcABC123-abcABC123_Z').respond(mockAssignment);
                 $httpBackend.expectGET('/api/criteria').respond(mockCritiera);
                 $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z/assignments/1abcABC123-abcABC123_Z/comparisons/examples').respond(mockComparisonExamples);

--- a/compair/static/modules/course/course-duplicate-partial.html
+++ b/compair/static/modules/course/course-duplicate-partial.html
@@ -38,9 +38,11 @@
                 <label>Course Begins</label><br />
                 <div class="assignment-date">
                     <span class="input-group">
-                        <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="duplicateCourse.date.course_start.date" is-open="duplicateCourse.date.course_start.opened" />
+                        <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="duplicateCourse.date.course_start.date"
+                            max-date="duplicateCourse.date.course_end.date"
+                            is-open="duplicateCourse.date.course_start.opened" />
                         <span class="input-group-btn">
-                            <button type="button" class="btn btn-default" ng-click="duplicateCourse.date.course_start.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                            <button type="button" class="btn btn-default" ng-click="datePickerOpen($event, duplicateCourse.date.course_start)"><i class="glyphicon glyphicon-calendar"></i></button>
                         </span>
                     </span>
                 </div>
@@ -52,9 +54,11 @@
                 <label>Course Ends</label><br />
                 <div class="assignment-date">
                     <span class="input-group">
-                        <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="duplicateCourse.date.course_end.date" is-open="duplicateCourse.date.course_end.opened" />
+                        <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="duplicateCourse.date.course_end.date"
+                            min-date="duplicateCourse.date.course_start.date"
+                            is-open="duplicateCourse.date.course_end.opened" />
                         <span class="input-group-btn">
-                            <button type="button" class="btn btn-default" ng-click="duplicateCourse.date.course_end.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                            <button type="button" class="btn btn-default" ng-click="datePickerOpen($event, duplicateCourse.date.course_end)"><i class="glyphicon glyphicon-calendar"></i></button>
                         </span>
                     </span>
                 </div>
@@ -106,9 +110,12 @@
                     </label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="assignment.date.astart.date" is-open="assignment.date.astart.opened" required />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="assignment.date.astart.date"
+                                min-date="datePickerMinDate(duplicateCourse.date.course_start.date)"
+                                max-date="datePickerMaxDate(assignment.date.aend.date, duplicateCourse.date.course_end.date)"
+                                is-open="assignment.date.astart.opened" required />
                             <span class="input-group-btn">
-                                <button type="button" class="btn btn-default" ng-click="assignment.date.astart.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                                <button type="button" class="btn btn-default" ng-click="datePickerOpen($event, assignment.date.astart)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>
@@ -125,9 +132,12 @@
                     </label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="assignment.date.aend.date" is-open="assignment.date.aend.opened" required />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="assignment.date.aend.date"
+                                min-date="datePickerMinDate(assignment.date.astart.date, duplicateCourse.date.course_start.date)"
+                                max-date="datePickerMaxDate(duplicateCourse.date.course_end.date)"
+                                is-open="assignment.date.aend.opened" required />
                             <span class="input-group-btn">
-                                <button type="button" class="btn btn-default" ng-click="assignment.date.aend.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                                <button type="button" class="btn btn-default" ng-click="datePickerOpen($event, assignment.date.aend)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>
@@ -147,9 +157,12 @@
                     </label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="assignment.date.cstart.date" is-open="assignment.date.cstart.opened" ng-required="assignment.availableCheck" />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="assignment.date.cstart.date"
+                                min-date="datePickerMinDate(assignment.date.astart.date, duplicateCourse.date.course_start.date)"
+                                max-date="datePickerMaxDate(assignment.date.cend.date, duplicateCourse.date.course_end.date)"
+                                is-open="assignment.date.cstart.opened" ng-required="assignment.availableCheck" />
                             <span class="input-group-btn">
-                                <button type="button" class="btn btn-default" ng-click="assignment.date.cstart.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                                <button type="button" class="btn btn-default" ng-click="datePickerOpen($event, assignment.date.cstart)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>
@@ -166,9 +179,12 @@
                     </label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="assignment.date.cend.date" is-open="assignment.date.cend.opened" ng-required="assignment.availableCheck" />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="assignment.date.cend.date"
+                                min-date="datePickerMinDate(assignment.date.cstart.date, duplicateCourse.date.course_start.date)"
+                                max-date="datePickerMaxDate(duplicateCourse.date.course_end.date)"
+                                is-open="assignment.date.cend.opened" ng-required="assignment.availableCheck" />
                             <span class="input-group-btn">
-                                <button type="button" class="btn btn-default" ng-click="assignment.date.cend.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                                <button type="button" class="btn btn-default" ng-click="datePickerOpen($event, assignment.date.cend)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>

--- a/compair/static/modules/course/course-module.js
+++ b/compair/static/modules/course/course-module.js
@@ -231,15 +231,11 @@ module.controller(
             $scope.originalCourse = angular.copy(course);
         };
 
-        $scope.date.course_start.open = function($event) {
+        $scope.datePickerOpen = function($event, object) {
             $event.preventDefault();
             $event.stopPropagation();
-            $scope.date.course_start.opened = true;
-        };
-        $scope.date.course_end.open = function($event) {
-            $event.preventDefault();
-            $event.stopPropagation();
-            $scope.date.course_end.opened = true;
+
+            object.opened = true;
         };
 
         $scope.save = function() {
@@ -336,17 +332,6 @@ module.controller(
                 }
             }
 
-            $scope.duplicateCourse.date.course_start.open = function($event) {
-                $event.preventDefault();
-                $event.stopPropagation();
-                $scope.duplicateCourse.date.course_start.opened = true;
-            };
-            $scope.duplicateCourse.date.course_end.open = function($event) {
-                $event.preventDefault();
-                $event.stopPropagation();
-                $scope.duplicateCourse.date.course_end.opened = true;
-            };
-
             $scope.originalAssignments = [];
             $scope.duplicateAssignments = [];
             AssignmentResource.get({'courseId': $scope.originalCourse.id}).$promise.then(
@@ -411,29 +396,15 @@ module.controller(
                     duplicate_assignment.availableCheck = true;
                 }
 
-                duplicate_assignment.date.astart.open = function($event) {
-                    $event.preventDefault();
-                    $event.stopPropagation();
-                    duplicate_assignment.date.astart.opened = true;
-                };
-                duplicate_assignment.date.aend.open = function($event) {
-                    $event.preventDefault();
-                    $event.stopPropagation();
-                    duplicate_assignment.date.aend.opened = true;
-                };
-                duplicate_assignment.date.cstart.open = function($event) {
-                    $event.preventDefault();
-                    $event.stopPropagation();
-                    duplicate_assignment.date.cstart.opened = true;
-                };
-                duplicate_assignment.date.cend.open = function($event) {
-                    $event.preventDefault();
-                    $event.stopPropagation();
-                    duplicate_assignment.date.cend.opened = true;
-                };
-
                 $scope.duplicateAssignments.push(duplicate_assignment);
             });
+        };
+
+        $scope.datePickerOpen = function($event, object) {
+            $event.preventDefault();
+            $event.stopPropagation();
+
+            object.opened = true;
         };
 
         $scope.cancelDuplicateCourse = function() {
@@ -442,6 +413,30 @@ module.controller(
             } else {
                 $scope.$dismiss();
             }
+        };
+
+        $scope.datePickerMinDate = function() {
+            var dates = Array.prototype.slice.call(arguments).filter(function(val) {
+                return val !== null;
+            });
+            if (dates.length == 0) {
+                return null;
+            }
+            return dates.reduce(function (left, right) {
+                return moment(left) > moment(right) ? left : right;
+            }, dates[0]);
+        };
+
+        $scope.datePickerMaxDate = function() {
+            var dates = Array.prototype.slice.call(arguments).filter(function(val) {
+                return val !== null;
+            });
+            if (dates.length == 0) {
+                return null;
+            }
+            return dates.reduce(function (left, right) {
+                return moment(left) < moment(right) ? left : right;
+            }, dates[0]);
         };
 
         $scope.duplicate = function() {
@@ -469,6 +464,7 @@ module.controller(
 
                 var assignment_submit = {
                     id: assignment.id,
+                    name: assignment.name,
                     answer_start: combineDateTime(assignment.date.astart),
                     answer_end: combineDateTime(assignment.date.aend),
                     compare_start: combineDateTime(assignment.date.cstart),
@@ -567,17 +563,11 @@ module.controller(
             $scope.loggedInUserId = user.id;
         });
 
-        $scope.date.course_start.open = function($event) {
+        $scope.datePickerOpen = function($event, object) {
             $event.preventDefault();
             $event.stopPropagation();
 
-            $scope.date.course_start.opened = true;
-        };
-        $scope.date.course_end.open = function($event) {
-            $event.preventDefault();
-            $event.stopPropagation();
-
-            $scope.date.course_end.opened = true;
+            object.opened = true;
         };
 
         $scope.save = function() {

--- a/compair/static/modules/course/course-partial.html
+++ b/compair/static/modules/course/course-partial.html
@@ -41,9 +41,11 @@
                     <label>Course Begins</label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.course_start.date" is-open="date.course_start.opened" />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.course_start.date"
+                                max-date="date.course_end.date"
+                                is-open="date.course_start.opened" />
                             <span class="input-group-btn">
-                                <button type="button" class="btn btn-default" ng-click="date.course_start.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                                <button type="button" class="btn btn-default" ng-click="datePickerOpen($event, date.course_start)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>
@@ -55,9 +57,11 @@
                     <label>Course Ends</label><br />
                     <div class="assignment-date">
                         <span class="input-group">
-                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.course_end.date" is-open="date.course_end.opened" />
+                            <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.course_end.date"
+                                min-date="date.course_start.date"
+                                is-open="date.course_end.opened" />
                             <span class="input-group-btn">
-                                <button type="button" class="btn btn-default" ng-click="date.course_end.open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+                                <button type="button" class="btn btn-default" ng-click="datePickerOpen($event, date.course_end)"><i class="glyphicon glyphicon-calendar"></i></button>
                             </span>
                         </span>
                     </div>


### PR DESCRIPTION
Only affects the date-picker popup. User can still manually type incorrect dates (which will be caught by validation in both front-end and back-end)

Completes: #447