### PR TITLE
Add Canvas LTI support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ node_modules
 bower_components
 
 .data
+docker-compose.overrides.yml

--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,8 @@ compair/static/tracking.js
 # docker generated data
 .data
 
+# docker-compose overrides
+docker-compose.overrides.yml
+
 celerybeat-schedule
 celerybeat.pid

--- a/alembic/versions/2a19cb1ab324_added_custom_context_memberships_url_.py
+++ b/alembic/versions/2a19cb1ab324_added_custom_context_memberships_url_.py
@@ -1,0 +1,32 @@
+"""Added custom_context_memberships_url column to lti_context table
+
+Revision ID: 2a19cb1ab324
+Revises: 852abaee3a25
+Create Date: 2017-06-23 19:10:05.295553
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2a19cb1ab324'
+down_revision = '852abaee3a25'
+
+from alembic import op
+import sqlalchemy as sa
+
+from compair.models import convention
+
+def upgrade():
+    with op.batch_alter_table('lti_consumer', naming_convention=convention) as batch_op:
+        batch_op.add_column(sa.Column('canvas_consumer', sa.Boolean(name='canvas_consumer'), nullable=False, default='0', server_default='0'))
+        batch_op.add_column(sa.Column('canvas_api_token', sa.String(255), nullable=True))
+
+    with op.batch_alter_table('lti_context', naming_convention=convention) as batch_op:
+        batch_op.add_column(sa.Column('custom_context_memberships_url', sa.Text(), nullable=True))
+
+def downgrade():
+    with op.batch_alter_table('lti_context', naming_convention=convention) as batch_op:
+        batch_op.drop_column('custom_context_memberships_url')
+
+    with op.batch_alter_table('lti_consumer', naming_convention=convention) as batch_op:
+        batch_op.drop_column('canvas_api_token')
+        batch_op.drop_column('canvas_consumer')

--- a/compair/api/dataformat/__init__.py
+++ b/compair/api/dataformat/__init__.py
@@ -320,12 +320,18 @@ def get_gradebook(include_scores=False, include_self_evaluation=False):
 
     return ret
 
-def get_lti_consumer():
-    return {
+def get_lti_consumer(include_sensitive=False):
+    ret = {
         'id': fields.String(attribute="uuid"),
         'oauth_consumer_key': fields.String,
-        'oauth_consumer_secret': fields.String,
+        'canvas_consumer': fields.Boolean,
         'active': fields.Boolean,
         'modified': fields.DateTime(dt_format='iso8601', attribute=lambda x: replace_tzinfo(x.modified)),
         'created': fields.DateTime(dt_format='iso8601', attribute=lambda x: replace_tzinfo(x.created))
     }
+
+    if include_sensitive:
+        ret['oauth_consumer_secret'] = fields.String
+        ret['canvas_api_token'] = fields.String
+
+    return ret

--- a/compair/api/lti_consumers.py
+++ b/compair/api/lti_consumers.py
@@ -16,6 +16,8 @@ api = new_restful_api(lti_consumer_api)
 new_consumer_parser = reqparse.RequestParser()
 new_consumer_parser.add_argument('oauth_consumer_key', type=str, required=True)
 new_consumer_parser.add_argument('oauth_consumer_secret', type=str)
+new_consumer_parser.add_argument('canvas_consumer', type=bool, default=False)
+new_consumer_parser.add_argument('canvas_api_token', type=str)
 
 existing_consumer_parser = new_consumer_parser.copy()
 existing_consumer_parser.add_argument('id', type=str, required=True)
@@ -71,6 +73,8 @@ class ConsumerAPI(Resource):
 
         consumer.oauth_consumer_key = params.get("oauth_consumer_key")
         consumer.oauth_consumer_secret = params.get("oauth_consumer_secret")
+        consumer.canvas_consumer = params.get("canvas_consumer")
+        consumer.canvas_api_token = params.get("canvas_api_token")
 
         try:
             db.session.add(consumer)
@@ -86,7 +90,7 @@ class ConsumerAPI(Resource):
             db.session.rollback()
             abort(409, title="Consumer Not Saved", message="A LTI consumer with the same consumer key already exists.")
 
-        return marshal(consumer, dataformat.get_lti_consumer())
+        return marshal(consumer, dataformat.get_lti_consumer(include_sensitive=True))
 
 
 api.add_resource(ConsumerAPI, '')
@@ -107,7 +111,7 @@ class ConsumerIdAPI(Resource):
             user=current_user
         )
 
-        return marshal(consumer, dataformat.get_lti_consumer())
+        return marshal(consumer, dataformat.get_lti_consumer(include_sensitive=True))
 
     @login_required
     def post(self, consumer_uuid):
@@ -124,6 +128,8 @@ class ConsumerIdAPI(Resource):
 
         consumer.oauth_consumer_key = params.get("oauth_consumer_key")
         consumer.oauth_consumer_secret = params.get("oauth_consumer_secret")
+        consumer.canvas_consumer = params.get("canvas_consumer")
+        consumer.canvas_api_token = params.get("canvas_api_token")
         consumer.active = params.get("active")
 
         try:
@@ -138,7 +144,7 @@ class ConsumerIdAPI(Resource):
             db.session.rollback()
             abort(409, title="Consumer Not Updated", message="A LTI consumer with the same consumer key already exists.")
 
-        return marshal(consumer, dataformat.get_lti_consumer())
+        return marshal(consumer, dataformat.get_lti_consumer(include_sensitive=True))
 
 
 api.add_resource(ConsumerIdAPI, '/<consumer_uuid>')

--- a/compair/models/lti_models/lti_consumer.py
+++ b/compair/models/lti_models/lti_consumer.py
@@ -17,6 +17,9 @@ class LTIConsumer(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin)
     tool_consumer_instance_name = db.Column(db.String(255), nullable=True)
     tool_consumer_instance_url = db.Column(db.Text, nullable=True)
     lis_outcome_service_url = db.Column(db.Text, nullable=True)
+    canvas_consumer = db.Column(db.Boolean(name='canvas_consumer'),
+        default=False, nullable=False)
+    canvas_api_token = db.Column(db.String(255), nullable=True)
 
     # relationships
     lti_nonces = db.relationship("LTINonce", backref="lti_consumer", lazy="dynamic")
@@ -46,7 +49,12 @@ class LTIConsumer(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin)
         lti_consumer.tool_consumer_instance_guid = tool_provider.tool_consumer_instance_guid
         lti_consumer.tool_consumer_instance_name = tool_provider.tool_consumer_instance_name
         lti_consumer.tool_consumer_instance_url = tool_provider.tool_consumer_instance_url
-        lti_consumer.lis_outcome_service_url = tool_provider.lis_outcome_service_url
+
+        # do no overwrite lis_outcome_service_url if value is None
+        # some LTI consumers do not always send the lis_outcome_service_url
+        # ex: Canvas when linking from module instead of an assignment
+        if tool_provider.lis_outcome_service_url:
+            lti_consumer.lis_outcome_service_url = tool_provider.lis_outcome_service_url
 
         db.session.commit()
 

--- a/compair/models/lti_models/lti_context.py
+++ b/compair/models/lti_models/lti_context.py
@@ -18,6 +18,7 @@ class LTIContext(DefaultTableMixin, WriteTrackingMixin):
     context_title = db.Column(db.String(255), nullable=True)
     ext_ims_lis_memberships_id = db.Column(db.String(255), nullable=True)
     ext_ims_lis_memberships_url = db.Column(db.Text, nullable=True)
+    custom_context_memberships_url = db.Column(db.Text, nullable=True)
     compair_course_id = db.Column(db.Integer, db.ForeignKey("course.id", ondelete="CASCADE"),
         nullable=True)
 
@@ -29,6 +30,18 @@ class LTIContext(DefaultTableMixin, WriteTrackingMixin):
 
     # hyprid and other functions
     compair_course_uuid = association_proxy('compair_course', 'uuid')
+
+    @hybrid_property
+    def membership_enabled(self):
+        return self.membership_ext_enabled or self.membership_canvas_enabled
+
+    @hybrid_property
+    def membership_ext_enabled(self):
+        return self.ext_ims_lis_memberships_url and self.ext_ims_lis_memberships_id
+
+    @hybrid_property
+    def membership_canvas_enabled(self):
+        return self.custom_context_memberships_url and self.lti_consumer.canvas_api_token
 
     def is_linked_to_course(self):
         return self.compair_course_id != None
@@ -84,6 +97,9 @@ class LTIContext(DefaultTableMixin, WriteTrackingMixin):
         lti_context.context_title = tool_provider.context_title
         lti_context.ext_ims_lis_memberships_id = tool_provider.ext_ims_lis_memberships_id
         lti_context.ext_ims_lis_memberships_url = tool_provider.ext_ims_lis_memberships_url
+
+        if tool_provider.custom_context_memberships_url:
+            lti_context.custom_context_memberships_url = tool_provider.custom_context_memberships_url
 
         db.session.commit()
 

--- a/compair/static/compair-config.js
+++ b/compair/static/compair-config.js
@@ -654,9 +654,9 @@ myApp.config(
             })
         .when('/lti/consumer',
             {
-                templateUrl: 'modules/lti_consumer/lti-consumers-partial.html',
+                templateUrl: 'modules/lti_consumer/lti-consumers-list-partial.html',
                 label: "Manage LTI",
-                controller: 'LTIConsumerController',
+                controller: 'LTIConsumerListController',
                 resolve: {
                     resolvedData: function() {
                         return ResolveDeferredRouteData({
@@ -683,6 +683,20 @@ myApp.config(
                 templateUrl: 'modules/lti_consumer/lti-consumer-form-partial.html',
                 label: "Edit LTI Consumer",
                 controller: 'LTIConsumerWriteController',
+                resolve: {
+                    resolvedData: function() {
+                        return ResolveDeferredRouteData({
+                            consumer: RouteResolves.consumer(),
+                            canManageUsers: RouteResolves.canManageUsers()
+                        }, ['consumer']);
+                    }
+                },
+            })
+        .when('/lti/consumer/:consumerId',
+            {
+                templateUrl: 'modules/lti_consumer/lti-consumer-view-partial.html',
+                label: "View LTI Consumer",
+                controller: 'LTIConsumerViewController',
                 resolve: {
                     resolvedData: function() {
                         return ResolveDeferredRouteData({

--- a/compair/static/less/overall.less
+++ b/compair/static/less/overall.less
@@ -261,6 +261,17 @@ dt {
 
 }//closes am-fade
 
+/* for hiding sensitive info */
+.spoiler {
+    background-color: black;
+    color: black;
+}
+
+.spoiler:hover {
+    background-color: transparent;
+    color: inherit;
+}
+
 /* for ie9 */
 .ie9 .search-courses:before {
   content: 'Filter courses by keyword:';

--- a/compair/static/modules/lti_consumer/lti-consumer-form-partial.html
+++ b/compair/static/modules/lti_consumer/lti-consumer-form-partial.html
@@ -18,6 +18,20 @@
                 ng-minlength="10" ng-maxlength="255"
                 required />
         </compair-field-with-feedback>
+        <compair-field-with-feedback form-control="consumerForm.canvas_consumer">
+            <input id="canvas_consumer" type="checkbox" ng-model="consumer.canvas_consumer">
+            <label class="not-bold" for="canvas_consumer">Canvas Consumer</label>
+        </compair-field-with-feedback>
+        <compair-field-with-feedback form-control="consumerForm.canvas_api_token" ng-if="consumer.canvas_consumer">
+            <label for="canvas_api_token">Consumer Secret</label>
+            <input class="form-control" id="canvas_api_token" type="text"
+                name="canvas_api_token" ng-model="consumer.canvas_api_token"
+                ng-maxlength="255" />
+        </compair-field-with-feedback>
+        <compair-field-with-feedback form-control="consumerForm.active" ng-if="method == 'edit'">
+            <input id="active" type="checkbox" ng-model="consumer.active">
+            <label class="not-bold" for="active">Active</label>
+        </compair-field-with-feedback>
     </fieldset>
 
     <input type="submit" class="btn btn-success center-block btn-lg" value="Save"

--- a/compair/static/modules/lti_consumer/lti-consumer-module.js
+++ b/compair/static/modules/lti_consumer/lti-consumer-module.js
@@ -30,14 +30,13 @@ module.factory('LTIConsumerResource',
     return ret;
 }]);
 
-module.controller('LTIConsumerController',
+module.controller('LTIConsumerListController',
     ['$scope', '$location', '$route', '$routeParams', 'UserResource', 'LTIConsumerResource',
      'Toaster', 'breadcrumbs', 'xAPIStatementHelper', 'resolvedData',
     function($scope, $location, $route, $routeParams, UserResource, LTIConsumerResource,
              Toaster, breadcrumbs, xAPIStatementHelper, resolvedData)
     {
         $scope.canManageUsers = resolvedData.canManageUsers;
-        $scope.launchUrl = $location.absUrl().replace("app/#"+$location.url(), "") + 'api/lti/auth';
 
         $scope.totalNumConsumers = 0;
         $scope.consumerFilters = {
@@ -93,6 +92,36 @@ module.controller('LTIConsumerController',
     }]
 );
 
+module.controller("LTIConsumerViewController",
+    ['$scope', '$location', '$route', '$routeParams', 'UserResource', 'LTIConsumerResource',
+     'Toaster', 'breadcrumbs', 'xAPIStatementHelper', 'resolvedData',
+    function($scope, $location, $route, $routeParams, UserResource, LTIConsumerResource,
+             Toaster, breadcrumbs, xAPIStatementHelper, resolvedData)
+    {
+        $scope.consumerId = $routeParams.consumerId;
+        $scope.launchUrl = $location.absUrl().replace("app/#"+$location.url(), "") + 'api/lti/auth';
+
+        $scope.consumer = resolvedData.consumer || {};
+        $scope.canManageUsers = resolvedData.canManageUsers;
+
+        if (!$scope.canManageUsers) {
+            $location.path('/');
+        }
+
+        $scope.updateConsumerActive = function() {
+            LTIConsumerResource.save($scope.consumer).$promise.then(
+                function (ret) {
+                    $scope.consumer = ret;
+                    if (ret.active) {
+                         Toaster.success("LTI Consumer Activated!");
+                    } else {
+                         Toaster.success("LTI Consumer Deactivated!");
+                    }
+                }
+            );
+        };
+    }
+]);
 
 module.controller("LTIConsumerWriteController",
     ['$scope', '$location', '$route', '$routeParams', 'UserResource', 'LTIConsumerResource',

--- a/compair/static/modules/lti_consumer/lti-consumer-view-partial.html
+++ b/compair/static/modules/lti_consumer/lti-consumer-view-partial.html
@@ -1,0 +1,53 @@
+<div>
+    <div class="pull-right">
+        <a id="edit-profile-btn" ng-href="#/lti/consumer/{{consumer.id}}/edit" class="btn btn-primary">
+            <i class="fa fa-edit"></i> Edit
+        </a>
+    </div>
+    <h1><i class="fa fa-cog"></i> View LTI Consumer</h1>
+
+    <div class="user-details">
+        <div class="row">
+            <strong class="col-md-2">Launch Url:</strong>
+            <div id="consumer_launch_url" class="col-md-10">{{ launchUrl }}</div>
+        </div>
+        <div class="row">
+            <strong class="col-md-2">Consumer Key:</strong>
+            <div id="consumer_oauth_consumer_key" class="col-md-10">{{ consumer.oauth_consumer_key }}</div>
+        </div>
+        <div class="row">
+            <strong class="col-md-2">Consumer Secret:</strong>
+            <div id="consumer_oauth_consumer_secret" class="col-md-10">
+                <span class="spoiler">{{ consumer.oauth_consumer_secret }}</span>
+            </div>
+        </div>
+        <div class="row">
+            <strong class="col-md-2">Canvas Consumer:</strong>
+            <div id="consumer_canvas_consumer" class="col-md-10">
+                <span ng-if="consumer.canvas_consumer">Yes</span>
+                <span ng-if="!consumer.canvas_consumer">No</span>
+            </div>
+        </div>
+        <div class="row" ng-if="consumer.canvas_consumer">
+            <strong class="col-md-2">Canvas API Token:</strong>
+            <div id="consumer_canvas_api_token" class="col-md-10">
+                <span class="spoiler">{{consumer.canvas_api_token}}</span>
+            </div>
+        </div>
+        <div class="row">
+            <strong class="col-md-2">Active:</strong>
+            <div class="col-md-10">
+                <input id="consumer_active" type="checkbox" ng-model="consumer.active"
+                    ng-change="updateConsumerActive()">
+            </div>
+        </div>
+        <div class="row">
+            <strong class="col-md-2">Created:</strong>
+            <div id="consumer_created" class="col-md-10">{{ consumer.created | amDateFormat: 'MMM Do, YYYY @ h:mm a' }}</div>
+        </div>
+        <div class="row">
+            <strong class="col-md-2">Last Modified:</strong>
+            <div id="consumer_modified" class="col-md-10">{{ consumer.modified | amDateFormat: 'MMM Do, YYYY @ h:mm a' }}</div>
+        </div>
+    </div>
+</div>

--- a/compair/static/modules/lti_consumer/lti-consumers-list-partial.html
+++ b/compair/static/modules/lti_consumer/lti-consumers-list-partial.html
@@ -2,16 +2,6 @@
     <div class="row">
         <header class="col-md-6">
             <h1><i class="fa fa-cogs"></i> Manage LTI Consumers</h1>
-            <div class="lti-param-copy">
-                Launch Url: "<em>{{launchUrl}}</em>"
-                &nbsp;&nbsp;
-                <!-- TODO: when ui bootstrap is updated change trigger to 'outsideClick' -->
-                <a href="" uib-tooltip="Copied" tooltip-placement="bottom" tooltip-trigger="click"
-                    ngclipboard data-clipboard-text="{{launchUrl}}"
-                    title="Copy the launch url to create an LTI service">
-                    Copy?
-                </a>
-            </div>
         </header>
         <div class="col-md-6 sub-nav">
             <a href="#/lti/consumer/create" class="btn btn-primary" id="create-lti-consumer-btn">
@@ -30,7 +20,7 @@
                         <a href="" ng-click="updateTableOrderBy('oauth_consumer_key')">Consumer Key</a>
                     </th>
                     <th>
-                        <a href="" ng-click="updateTableOrderBy('oauth_consumer_secret')">Consumer Secret</a>
+                        <a href="" ng-click="updateTableOrderBy('oauth_consumer_secret')">Canvas Consumer</a>
                     </th>
                     <th>
                         <a href="" ng-click="updateTableOrderBy('active')">Status</a>
@@ -42,8 +32,13 @@
                     <td class="nowrap">
                         <a href="#/lti/consumer/{{consumer.id}}/edit">Edit</a>
                     </td>
-                    <td>{{consumer.oauth_consumer_key}}</td>
-                    <td>{{consumer.oauth_consumer_secret}}</td>
+                    <td>
+                        <a href="#/lti/consumer/{{consumer.id}}">{{consumer.oauth_consumer_key}}</a>
+                    </td>
+                    <td>
+                        <span ng-if="consumer.canvas_consumer">Yes</span>
+                        <span ng-if="!consumer.canvas_consumer">No</span>
+                    </td>
                     <td>
                         <select ng-model="consumer.active" ng-options="key for (key , value) in {'Active': true, 'Inactive': false}"
                                 ng-change="updateConsumer(consumer)">

--- a/compair/static/modules/route/route-provider_spec.js
+++ b/compair/static/modules/route/route-provider_spec.js
@@ -1019,7 +1019,7 @@ describe('user-module', function () {
             var path = '/lti/consumer';
 
             it('should load correctly', function() {
-                $httpBackend.expectGET('modules/lti_consumer/lti-consumers-partial.html').respond('');
+                $httpBackend.expectGET('modules/lti_consumer/lti-consumers-list-partial.html').respond('');
 
                 expect($route.current).toBeUndefined();
                 $location.path(path);
@@ -1031,8 +1031,8 @@ describe('user-module', function () {
 
                 expect(toaster.error).not.toHaveBeenCalled();
                 expect($rootScope.routeResolveLoadError).toBeUndefined();
-                expect($route.current.templateUrl).toBe('modules/lti_consumer/lti-consumers-partial.html');
-                expect($route.current.controller).toBe('LTIConsumerController');
+                expect($route.current.templateUrl).toBe('modules/lti_consumer/lti-consumers-list-partial.html');
+                expect($route.current.controller).toBe('LTIConsumerListController');
             });
         });
 
@@ -1054,6 +1054,47 @@ describe('user-module', function () {
                 expect($rootScope.routeResolveLoadError).toBeUndefined();
                 expect($route.current.templateUrl).toBe('modules/lti_consumer/lti-consumer-form-partial.html');
                 expect($route.current.controller).toBe('LTIConsumerWriteController');
+            });
+        });
+
+        describe('"/lti/consumer/:consumerId"', function() {
+            var path = '/lti/consumer/'+mockConsumerId;
+
+            it('should handle pre-loading errors', function() {
+                $httpBackend.expectGET('/api/lti/consumers/'+mockConsumerId).respond(404, '');
+                $httpBackend.expectGET('modules/lti_consumer/lti-consumer-view-partial.html').respond('');
+
+                expect($route.current).toBeUndefined();
+                $location.path(path);
+
+                expect($route.current).toBeUndefined();
+                $httpBackend.flush();
+
+                expect(Session.getUser).not.toHaveBeenCalled();
+                expect(Authorize.can).toHaveBeenCalledWith(Authorize.MANAGE, "User");
+
+                expect(toaster.error).toHaveBeenCalled();
+                expect($rootScope.routeResolveLoadError).not.toBeUndefined();
+                expect($route.current.templateUrl).toBe('modules/lti_consumer/lti-consumer-view-partial.html');
+                expect($route.current.controller).toBe('LTIConsumerViewController');
+            });
+
+            it('should load correctly', function() {
+                $httpBackend.expectGET('/api/lti/consumers/'+mockConsumerId).respond({});
+                $httpBackend.expectGET('modules/lti_consumer/lti-consumer-view-partial.html').respond('');
+
+                expect($route.current).toBeUndefined();
+                $location.path(path);
+                expect($route.current).toBeUndefined();
+                $httpBackend.flush();
+
+                expect(Session.getUser).not.toHaveBeenCalled();
+                expect(Authorize.can).toHaveBeenCalledWith(Authorize.MANAGE, "User");
+
+                expect(toaster.error).not.toHaveBeenCalled();
+                expect($rootScope.routeResolveLoadError).toBeUndefined();
+                expect($route.current.templateUrl).toBe('modules/lti_consumer/lti-consumer-view-partial.html');
+                expect($route.current.controller).toBe('LTIConsumerViewController');
             });
         });
 

--- a/compair/static/test/factories/lti_consumer_factory.js
+++ b/compair/static/test/factories/lti_consumer_factory.js
@@ -5,6 +5,8 @@ var ltiConsumerTemplate = {
     "oauth_consumer_key": null,
     "oauth_consumer_secret": null,
     "active": true,
+    "canvas_consumer": false,
+    "canvas_api_token": null,
     "created": "Mon, 18 Apr 2016 17:38:23 -0000",
     "modified": "Mon, 18 Apr 2016 17:38:23 -0000"
 }

--- a/compair/static/test/features/edit_lti_consumer.feature
+++ b/compair/static/test/features/edit_lti_consumer.feature
@@ -4,7 +4,7 @@ Feature: Edit LTI Consumers
   Scenario: Loading edit LTI consumer page as admin
     Given I'm a System Administrator
     And I'm on 'manage lti' page
-    When I set the first consumer's Edit button
+    When I click the first consumer's Edit button
     Then I should be on the 'edit lti consumer' page
 
   Scenario: Editing a lti consumer as admin
@@ -12,6 +12,9 @@ Feature: Edit LTI Consumers
     And I'm on 'edit lti consumer' page for consumer with id '1abcABC123-abcABC123_Z'
     When I fill form item 'consumer.oauth_consumer_key' in with 'new_consumer_key_1'
     And I fill form item 'consumer.oauth_consumer_secret' in with 'new_consumer_secret_1'
+    And I toggle the 'Canvas Consumer' checkbox
+    And I fill form item 'consumer.canvas_api_token' in with 'new_canvas_api_token'
+    And I toggle the 'Active' checkbox
     And I submit form with 'Save' button
     Then I should be on the 'manage lti' page
     And I should see '3' consumers listed

--- a/compair/static/test/features/step_definitions/common.js
+++ b/compair/static/test/features/step_definitions/common.js
@@ -42,6 +42,10 @@ var commonStepDefinitionsWrapper = function() {
         return element(by.cssContainingText('label', label)).click();
     });
 
+    this.When("I toggle the '$model' form checkbox", function (model) {
+        return element(by.model(model)).click();
+    });
+
     // generate page factory
     this.Given("I'm on '$pageName' page", function (pageName) {
         page = pageFactory.createPage(pageName);
@@ -99,7 +103,8 @@ var commonStepDefinitionsWrapper = function() {
             'user courses': /.*\/users\/[A-Za-z0-9_-]{22}\/course(\?.+)?$/,
             'manage lti': /.*\/lti\/consumer(\?.+)?$/,
             'create lti consumer': /.*\/lti\/consumer\/create$/,
-            'edit lti consumer': /.*\/lti\/consumer\/[A-Za-z0-9_-]{22}\/edit?$/,
+            'edit lti consumer': /.*\/lti\/consumer\/[A-Za-z0-9_-]{22}\/edit$/,
+            'lti consumer': /.*\/lti\/consumer\/[A-Za-z0-9_-]{22}$/
         };
         return expect(browser.getCurrentUrl()).to.eventually.match(page_regex[page]);
     });

--- a/compair/static/test/features/step_definitions/view_lti_consumer.js
+++ b/compair/static/test/features/step_definitions/view_lti_consumer.js
@@ -1,0 +1,60 @@
+// Use the external Chai As Promised to deal with resolving promises in
+// expectations
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+
+var expect = chai.expect;
+
+var viewLTIConsumersStepDefinitionsWrapper = function () {
+
+    this.When("I click the first consumer's key", function () {
+        return element.all(by.repeater("consumer in consumers"))
+            .get(0)
+            .element(by.cssContainingText('a', 'consumer_key_1'))
+            .click();
+    });
+
+    this.Then("I should see consumer_key_1's information", function () {
+        expect(element(by.css("#consumer_launch_url")).isPresent()).to.eventually.equal(true);
+
+        expect(element(by.css("#consumer_oauth_consumer_key")).getText()).to.eventually.equal("consumer_key_1");
+        expect(element(by.css("#consumer_oauth_consumer_secret")).getText()).to.eventually.equal("consumer_secret_1");
+        expect(element(by.css("#consumer_canvas_consumer")).getText()).to.eventually.equal("No");
+        expect(element(by.css("#consumer_canvas_api_token")).isPresent()).to.eventually.equal(false);
+        expect(element(by.model("consumer.active")).isSelected()).to.eventually.equal(true);
+
+        expect(element(by.css("#consumer_created")).isPresent()).to.eventually.equal(true);
+        expect(element(by.css("#consumer_modified")).isPresent()).to.eventually.equal(true);
+    });
+
+    this.Then("I should see consumer_key_2's information", function () {
+        expect(element(by.css("#consumer_launch_url")).isPresent()).to.eventually.equal(true);
+
+        expect(element(by.css("#consumer_oauth_consumer_key")).getText()).to.eventually.equal("consumer_key_2");
+        expect(element(by.css("#consumer_oauth_consumer_secret")).getText()).to.eventually.equal("consumer_secret_2");
+        expect(element(by.css("#consumer_canvas_consumer")).getText()).to.eventually.equal("Yes");
+        expect(element(by.css("#consumer_canvas_api_token")).getText()).to.eventually.equal("canvas_api_token2");
+        expect(element(by.model("consumer.active")).isSelected()).to.eventually.equal(true);
+
+        expect(element(by.css("#consumer_created")).isPresent()).to.eventually.equal(true);
+        expect(element(by.css("#consumer_modified")).isPresent()).to.eventually.equal(true);
+    });
+
+
+    this.Then("I should see consumer_key_3's information", function () {
+        expect(element(by.css("#consumer_launch_url")).isPresent()).to.eventually.equal(true);
+
+        expect(element(by.css("#consumer_oauth_consumer_key")).getText()).to.eventually.equal("consumer_key_3");
+        expect(element(by.css("#consumer_oauth_consumer_secret")).getText()).to.eventually.equal("consumer_secret_3");
+        expect(element(by.css("#consumer_canvas_consumer")).getText()).to.eventually.equal("No");
+        expect(element(by.css("#consumer_canvas_api_token")).isPresent()).to.eventually.equal(false);
+        expect(element(by.model("consumer.active")).isSelected()).to.eventually.equal(false);
+
+        expect(element(by.css("#consumer_created")).isPresent()).to.eventually.equal(true);
+        expect(element(by.css("#consumer_modified")).isPresent()).to.eventually.equal(true);
+    });
+
+};
+
+module.exports = viewLTIConsumersStepDefinitionsWrapper;

--- a/compair/static/test/features/step_definitions/view_lti_consumers.js
+++ b/compair/static/test/features/step_definitions/view_lti_consumers.js
@@ -50,7 +50,7 @@ var viewLTIConsumersStepDefinitionsWrapper = function () {
         return element(by.css("body")).click();
     });
 
-    this.When("I set the first consumer's Edit button", function () {
+    this.When("I click the first consumer's Edit button", function () {
         return element.all(by.exactRepeater("consumer in consumers"))
             .get(0)
             .element(by.cssContainingText('a', 'Edit'))

--- a/compair/static/test/features/view_lti_consumer.feature
+++ b/compair/static/test/features/view_lti_consumer.feature
@@ -1,0 +1,31 @@
+Feature: Manage LTI Consumers
+  As user, I want to manage LTI consumers
+
+  Scenario: Loading view LTI consumer as admin
+    Given I'm a System Administrator
+    And I'm on 'manage lti' page
+    When I click the first consumer's key
+    Then I should be on the 'lti consumer' page
+    And I should see consumer_key_1's information
+
+  Scenario: View LTI canvas consumer as admin
+    Given I'm a System Administrator
+    And I'm on 'lti consumer' page for consumer with id '2abcABC123-abcABC123_Z'
+    Then I should see consumer_key_2's information
+
+  Scenario: View LTI inactive consumer as admin
+    Given I'm a System Administrator
+    And I'm on 'lti consumer' page for consumer with id '3abcABC123-abcABC123_Z'
+    Then I should see consumer_key_3's information
+
+  Scenario: Disable LTI consumer as admin
+    Given I'm a System Administrator
+    And I'm on 'lti consumer' page for consumer with id '1abcABC123-abcABC123_Z'
+    When I toggle the 'consumer.active' form checkbox
+    Then I should see a success message
+
+  Scenario: Enable LTI consumer as admin
+    Given I'm a System Administrator
+    And I'm on 'lti consumer' page for consumer with id '3abcABC123-abcABC123_Z'
+    When I toggle the 'consumer.active' form checkbox
+    Then I should see a success message

--- a/compair/static/test/fixtures/admin/default_fixture.js
+++ b/compair/static/test/fixtures/admin/default_fixture.js
@@ -175,7 +175,10 @@ storage.assignments[assignment_upcoming.id] = assignment_upcoming;
 storage.course_assignments[course.id].push(assignment_upcoming.id);
 
 var consumer1 = ltiConsumerFactory.generateConsumer("1abcABC123-abcABC123_Z", "consumer_key_1", "consumer_secret_1");
-var consumer2 = ltiConsumerFactory.generateConsumer("2abcABC123-abcABC123_Z", "consumer_key_2", "consumer_secret_2");
+var consumer2 = ltiConsumerFactory.generateConsumer("2abcABC123-abcABC123_Z", "consumer_key_2", "consumer_secret_2", {
+    "canvas_consumer": true,
+    "canvas_api_token": "canvas_api_token2"
+});
 var consumer3 = ltiConsumerFactory.generateConsumer("3abcABC123-abcABC123_Z", "consumer_key_3", "consumer_secret_3", {
     "active": false
 });

--- a/compair/static/test/page_objects/lti_consumer.js
+++ b/compair/static/test/page_objects/lti_consumer.js
@@ -1,0 +1,7 @@
+var ViewLTIConsumerPage = function() {
+    this.getLocation = function(id) {
+        return 'lti/consumer/'+id;
+    };
+};
+
+module.exports = ViewLTIConsumerPage;

--- a/compair/tests/test_compair.py
+++ b/compair/tests/test_compair.py
@@ -182,19 +182,22 @@ class ComPAIRAPITestCase(ComPAIRTestCase):
 
     @contextmanager
     def lti_launch(self, lti_consumer, lti_resource_link_id,
-                         assignment_uuid=None, nonce=None, timestamp=None, follow_redirects=True,
+                         assignment_uuid=None, query_assignment_uuid=None,
+                         nonce=None, timestamp=None, follow_redirects=True,
                          **kwargs):
+        launch_url = "http://localhost/api/lti/auth"
         launch_params = kwargs.copy()
         launch_params['resource_link_id'] = lti_resource_link_id
         if assignment_uuid:
             launch_params['custom_assignment'] = assignment_uuid
+        if query_assignment_uuid:
+            launch_url = launch_url+"?assignment="+query_assignment_uuid
 
         tool_consumer = ToolConsumer(
             lti_consumer.oauth_consumer_key,
             lti_consumer.oauth_consumer_secret,
             params=launch_params,
-            #launch_url not actually used. Just needed for validation
-            launch_url='http://localhost/api/lti/auth'
+            launch_url=launch_url
         )
 
         launch_request = tool_consumer.generate_launch_request(nonce=nonce, timestamp=timestamp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ SQLAlchemy-Enum34==1.0.1
 mock==2.0.0
 elo==0.1.1
 trueskill==0.4.4
-lti==0.8.4
+lti==0.9.2
 Celery==4.0.2
 redis==2.10.5
 git+git://github.com/andrew-gardener/TinCanPython.git@python35


### PR DESCRIPTION
Consumers now be marked as canvas consumers with api tokens. api tokens are used for Canvas' LTI membership implementation

Launch requests can optionally include the assignment uuid in the query string (allows canvas LTI links to have link level custom parameters)

Restructured the LTI Manage section to be a bit more carful with sensitive data:
- consumer secrets and canvas api tokens are no longer included in consumer list endpoint
- added consumer view screen with secret and canvas api token hidden by eyesight unless hovered