### PR TITLE
Update LTI Membership

### DIFF
--- a/alembic/versions/d402c96606ce_revised_lti_consumer_by_adding_user_id_.py
+++ b/alembic/versions/d402c96606ce_revised_lti_consumer_by_adding_user_id_.py
@@ -1,0 +1,28 @@
+"""Revised LTI consumer by adding user_id_override and removing canvas_consumer and canvas_api_token
+
+Revision ID: d402c96606ce
+Revises: 2a19cb1ab324
+Create Date: 2017-07-14 00:02:05.424665
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd402c96606ce'
+down_revision = '2a19cb1ab324'
+
+from alembic import op
+import sqlalchemy as sa
+
+from compair.models import convention
+
+def upgrade():
+    with op.batch_alter_table('lti_consumer', naming_convention=convention) as batch_op:
+        batch_op.drop_column('canvas_api_token')
+        batch_op.drop_column('canvas_consumer')
+        batch_op.add_column(sa.Column('user_id_override', sa.String(length=255), nullable=True))
+
+def downgrade():
+    with op.batch_alter_table('lti_consumer', naming_convention=convention) as batch_op:
+        batch_op.add_column(sa.Column('canvas_consumer', sa.Boolean(name='canvas_consumer'), nullable=False, default='0', server_default='0'))
+        batch_op.add_column(sa.Column('canvas_api_token', sa.String(255), nullable=True))
+        batch_op.drop_column('user_id_override')

--- a/compair/api/dataformat/__init__.py
+++ b/compair/api/dataformat/__init__.py
@@ -324,7 +324,7 @@ def get_lti_consumer(include_sensitive=False):
     ret = {
         'id': fields.String(attribute="uuid"),
         'oauth_consumer_key': fields.String,
-        'canvas_consumer': fields.Boolean,
+        'user_id_override': fields.String,
         'active': fields.Boolean,
         'modified': fields.DateTime(dt_format='iso8601', attribute=lambda x: replace_tzinfo(x.modified)),
         'created': fields.DateTime(dt_format='iso8601', attribute=lambda x: replace_tzinfo(x.created))
@@ -332,6 +332,5 @@ def get_lti_consumer(include_sensitive=False):
 
     if include_sensitive:
         ret['oauth_consumer_secret'] = fields.String
-        ret['canvas_api_token'] = fields.String
 
     return ret

--- a/compair/api/lti_consumers.py
+++ b/compair/api/lti_consumers.py
@@ -3,6 +3,7 @@ from bouncer.constants import READ, EDIT, CREATE, DELETE, MANAGE
 from flask_login import login_required, current_user
 from flask_restful import Resource, marshal, reqparse, marshal_with
 from sqlalchemy import exc, or_, and_, desc, asc
+from six import text_type
 
 from . import dataformat
 from compair.core import event, db, abort
@@ -13,11 +14,16 @@ from .util import new_restful_api, get_model_changes, pagination_parser
 lti_consumer_api = Blueprint('lti_consumer_api', __name__)
 api = new_restful_api(lti_consumer_api)
 
+def non_blank_text(value):
+    if value is None:
+        return None
+    else:
+        return None if text_type(value).strip() == "" else text_type(value)
+
 new_consumer_parser = reqparse.RequestParser()
 new_consumer_parser.add_argument('oauth_consumer_key', type=str, required=True)
 new_consumer_parser.add_argument('oauth_consumer_secret', type=str)
-new_consumer_parser.add_argument('canvas_consumer', type=bool, default=False)
-new_consumer_parser.add_argument('canvas_api_token', type=str)
+new_consumer_parser.add_argument('user_id_override', type=non_blank_text)
 
 existing_consumer_parser = new_consumer_parser.copy()
 existing_consumer_parser.add_argument('id', type=str, required=True)
@@ -73,8 +79,7 @@ class ConsumerAPI(Resource):
 
         consumer.oauth_consumer_key = params.get("oauth_consumer_key")
         consumer.oauth_consumer_secret = params.get("oauth_consumer_secret")
-        consumer.canvas_consumer = params.get("canvas_consumer")
-        consumer.canvas_api_token = params.get("canvas_api_token")
+        consumer.user_id_override = params.get("user_id_override")
 
         try:
             db.session.add(consumer)
@@ -128,8 +133,7 @@ class ConsumerIdAPI(Resource):
 
         consumer.oauth_consumer_key = params.get("oauth_consumer_key")
         consumer.oauth_consumer_secret = params.get("oauth_consumer_secret")
-        consumer.canvas_consumer = params.get("canvas_consumer")
-        consumer.canvas_api_token = params.get("canvas_api_token")
+        consumer.user_id_override = params.get("user_id_override")
         consumer.active = params.get("active")
 
         try:

--- a/compair/api/users.py
+++ b/compair/api/users.py
@@ -47,7 +47,6 @@ existing_user_parser.add_argument('email')
 existing_user_parser.add_argument('email_notification_method')
 
 update_notification_settings_parser = RequestParser()
-update_notification_settings_parser.add_argument('email_notification_method', required=False)
 update_notification_settings_parser.add_argument('email_notification_method', required=True)
 
 update_password_parser = RequestParser()

--- a/compair/models/assignment.py
+++ b/compair/models/assignment.py
@@ -89,7 +89,7 @@ class Assignment(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
 
     @hybrid_property
     def compared(self):
-        return self.compare_count > 0
+        return self.all_compare_count > 0
 
     def completed_comparison_count_for_user(self, user_id):
         return self.comparisons \
@@ -152,8 +152,7 @@ class Assignment(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
 
     @hybrid_property
     def evaluation_count(self):
-        evaluation_count = self.compare_count
-        return evaluation_count + self.self_evaluation_count
+        return self.compare_count + self.self_evaluation_count
 
     @hybrid_property
     def total_comparisons_required(self):
@@ -298,9 +297,21 @@ class Assignment(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
             group="counts"
         )
 
+        cls.all_compare_count = column_property(
+            select([func.count(Comparison.id)]).
+            where(and_(
+                Comparison.assignment_id == cls.id
+            )),
+            deferred=True,
+            group="counts"
+        )
+
         cls.compare_count = column_property(
             select([func.count(Comparison.id)]).
-            where(Comparison.assignment_id == cls.id),
+            where(and_(
+                Comparison.assignment_id == cls.id,
+                Comparison.completed == True
+            )),
             deferred=True,
             group="counts"
         )

--- a/compair/models/lti_models/helpers/__init__.py
+++ b/compair/models/lti_models/helpers/__init__.py
@@ -1,0 +1,1 @@
+from .lti_membership_service_oauth_client import LTIMemerbshipServiceOauthClient

--- a/compair/models/lti_models/helpers/lti_membership_service_oauth_client.py
+++ b/compair/models/lti_models/helpers/lti_membership_service_oauth_client.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+from oauthlib.oauth1 import Client
+import base64
+import hashlib
+
+class LTIMemerbshipServiceOauthClient(Client):
+    def get_oauth_params(self, request):
+        """Get the basic OAuth parameters to be used in generating a signature.
+        """
+        params = super(LTIMemerbshipServiceOauthClient, self).get_oauth_params(request)
+
+        # unlike parent class we need to include oauth_body_hash even if the body content is empty
+        content_type = request.headers.get('Content-Type', None)
+        content_type_eligible = content_type is None or content_type.find('application/x-www-form-urlencoded') < 0
+        if content_type_eligible and request.body is None:
+            params.append(('oauth_body_hash', base64.b64encode(hashlib.sha1("".encode('utf-8')).digest()).decode('utf-8')))
+
+        return params

--- a/compair/models/lti_models/lti_consumer.py
+++ b/compair/models/lti_models/lti_consumer.py
@@ -17,9 +17,7 @@ class LTIConsumer(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin)
     tool_consumer_instance_name = db.Column(db.String(255), nullable=True)
     tool_consumer_instance_url = db.Column(db.Text, nullable=True)
     lis_outcome_service_url = db.Column(db.Text, nullable=True)
-    canvas_consumer = db.Column(db.Boolean(name='canvas_consumer'),
-        default=False, nullable=False)
-    canvas_api_token = db.Column(db.String(255), nullable=True)
+    user_id_override = db.Column(db.String(255), nullable=True)
 
     # relationships
     lti_nonces = db.relationship("LTINonce", backref="lti_consumer", lazy="dynamic")

--- a/compair/models/lti_models/lti_context.py
+++ b/compair/models/lti_models/lti_context.py
@@ -33,15 +33,15 @@ class LTIContext(DefaultTableMixin, WriteTrackingMixin):
 
     @hybrid_property
     def membership_enabled(self):
-        return self.membership_ext_enabled or self.membership_canvas_enabled
+        return self.membership_ext_enabled or self.membership_service_enabled
 
     @hybrid_property
     def membership_ext_enabled(self):
         return self.ext_ims_lis_memberships_url and self.ext_ims_lis_memberships_id
 
     @hybrid_property
-    def membership_canvas_enabled(self):
-        return self.custom_context_memberships_url and self.lti_consumer.canvas_api_token
+    def membership_service_enabled(self):
+        return self.custom_context_memberships_url
 
     def is_linked_to_course(self):
         return self.compair_course_id != None

--- a/compair/static/modules/login/login-directive.js
+++ b/compair/static/modules/login/login-directive.js
@@ -6,9 +6,9 @@
 
         .directive('loginCreateUserForm',
             ['$route', '$log', 'UserResource', 'SystemRole', 'Toaster',
-             'AuthenticationService', 'LTI', 'UserSettings',
+             'AuthenticationService', 'LTI', 'UserSettings', 'EmailNotificationMethod',
             function ($route, $log, UserResource, SystemRole, Toaster,
-                      AuthenticationService, LTI, UserSettings) {
+                      AuthenticationService, LTI, UserSettings, EmailNotificationMethod) {
             return {
                 restrict: 'E',
                 scope: {
@@ -21,14 +21,16 @@
                     scope.submitted = false;
 
                     scope.password = {};
-                    $scope.UserSettings = UserSettings;
+                    scope.UserSettings = UserSettings;
+                    scope.EmailNotificationMethod = EmailNotificationMethod;
                     scope.SystemRole = SystemRole;
                     scope.system_roles = [SystemRole.student, SystemRole.instructor, SystemRole.sys_admin];
 
                     scope.user = {
                         // required parameter that will be ignored by backend
                         system_role: SystemRole.student,
-                        uses_compair_login: scope.uses_compair_login
+                        uses_compair_login: scope.uses_compair_login,
+                        email_notification_method: EmailNotificationMethod.enable
                     }
 
                     LTI.getStatus().then(function(status) {
@@ -37,6 +39,7 @@
                             // overwrite user with LTI user info
                             scope.user = LTI.getLTIUser();
                             scope.user.uses_compair_login = scope.uses_compair_login;
+                            scope.user.email_notification_method = EmailNotificationMethod.enable;
                         }
                     });
 

--- a/compair/static/modules/lti_consumer/lti-consumer-form-partial.html
+++ b/compair/static/modules/lti_consumer/lti-consumer-form-partial.html
@@ -18,14 +18,10 @@
                 ng-minlength="10" ng-maxlength="255"
                 required />
         </compair-field-with-feedback>
-        <compair-field-with-feedback form-control="consumerForm.canvas_consumer">
-            <input id="canvas_consumer" type="checkbox" ng-model="consumer.canvas_consumer">
-            <label class="not-bold" for="canvas_consumer">Canvas Consumer</label>
-        </compair-field-with-feedback>
-        <compair-field-with-feedback form-control="consumerForm.canvas_api_token" ng-if="consumer.canvas_consumer">
-            <label for="canvas_api_token">Consumer Secret</label>
-            <input class="form-control" id="canvas_api_token" type="text"
-                name="canvas_api_token" ng-model="consumer.canvas_api_token"
+        <compair-field-with-feedback form-control="consumerForm.user_id_override">
+            <label for="user_id_override">LTI User ID Override</label>
+            <input class="form-control" id="user_id_override" type="text"
+                name="user_id_override" ng-model="consumer.user_id_override"
                 ng-maxlength="255" />
         </compair-field-with-feedback>
         <compair-field-with-feedback form-control="consumerForm.active" ng-if="method == 'edit'">

--- a/compair/static/modules/lti_consumer/lti-consumer-view-partial.html
+++ b/compair/static/modules/lti_consumer/lti-consumer-view-partial.html
@@ -22,16 +22,9 @@
             </div>
         </div>
         <div class="row">
-            <strong class="col-md-2">Canvas Consumer:</strong>
-            <div id="consumer_canvas_consumer" class="col-md-10">
-                <span ng-if="consumer.canvas_consumer">Yes</span>
-                <span ng-if="!consumer.canvas_consumer">No</span>
-            </div>
-        </div>
-        <div class="row" ng-if="consumer.canvas_consumer">
-            <strong class="col-md-2">Canvas API Token:</strong>
-            <div id="consumer_canvas_api_token" class="col-md-10">
-                <span class="spoiler">{{consumer.canvas_api_token}}</span>
+            <strong class="col-md-2">LTI User ID Override:</strong>
+            <div id="consumer_user_id_override" class="col-md-10">
+                {{consumer.user_id_override}}
             </div>
         </div>
         <div class="row">

--- a/compair/static/modules/lti_consumer/lti-consumers-list-partial.html
+++ b/compair/static/modules/lti_consumer/lti-consumers-list-partial.html
@@ -20,7 +20,7 @@
                         <a href="" ng-click="updateTableOrderBy('oauth_consumer_key')">Consumer Key</a>
                     </th>
                     <th>
-                        <a href="" ng-click="updateTableOrderBy('oauth_consumer_secret')">Canvas Consumer</a>
+                        <a href="" ng-click="updateTableOrderBy('oauth_consumer_secret')">LTI User ID Override</a>
                     </th>
                     <th>
                         <a href="" ng-click="updateTableOrderBy('active')">Status</a>
@@ -36,8 +36,7 @@
                         <a href="#/lti/consumer/{{consumer.id}}">{{consumer.oauth_consumer_key}}</a>
                     </td>
                     <td>
-                        <span ng-if="consumer.canvas_consumer">Yes</span>
-                        <span ng-if="!consumer.canvas_consumer">No</span>
+                        <a href="#/lti/consumer/{{consumer.id}}">{{consumer.user_id_override}}</a>
                     </td>
                     <td>
                         <select ng-model="consumer.active" ng-options="key for (key , value) in {'Active': true, 'Inactive': false}"

--- a/compair/static/test/factories/lti_consumer_factory.js
+++ b/compair/static/test/factories/lti_consumer_factory.js
@@ -5,8 +5,7 @@ var ltiConsumerTemplate = {
     "oauth_consumer_key": null,
     "oauth_consumer_secret": null,
     "active": true,
-    "canvas_consumer": false,
-    "canvas_api_token": null,
+    "user_id_override": null,
     "created": "Mon, 18 Apr 2016 17:38:23 -0000",
     "modified": "Mon, 18 Apr 2016 17:38:23 -0000"
 }

--- a/compair/static/test/features/edit_lti_consumer.feature
+++ b/compair/static/test/features/edit_lti_consumer.feature
@@ -12,8 +12,7 @@ Feature: Edit LTI Consumers
     And I'm on 'edit lti consumer' page for consumer with id '1abcABC123-abcABC123_Z'
     When I fill form item 'consumer.oauth_consumer_key' in with 'new_consumer_key_1'
     And I fill form item 'consumer.oauth_consumer_secret' in with 'new_consumer_secret_1'
-    And I toggle the 'Canvas Consumer' checkbox
-    And I fill form item 'consumer.canvas_api_token' in with 'new_canvas_api_token'
+    And I fill form item 'consumer.user_id_override' in with 'new_user_id_override'
     And I toggle the 'Active' checkbox
     And I submit form with 'Save' button
     Then I should be on the 'manage lti' page

--- a/compair/static/test/features/step_definitions/view_lti_consumer.js
+++ b/compair/static/test/features/step_definitions/view_lti_consumer.js
@@ -20,35 +20,19 @@ var viewLTIConsumersStepDefinitionsWrapper = function () {
 
         expect(element(by.css("#consumer_oauth_consumer_key")).getText()).to.eventually.equal("consumer_key_1");
         expect(element(by.css("#consumer_oauth_consumer_secret")).getText()).to.eventually.equal("consumer_secret_1");
-        expect(element(by.css("#consumer_canvas_consumer")).getText()).to.eventually.equal("No");
-        expect(element(by.css("#consumer_canvas_api_token")).isPresent()).to.eventually.equal(false);
+        expect(element(by.css("#consumer_user_id_override")).getText()).to.eventually.equal("consumer_user_id_override");
         expect(element(by.model("consumer.active")).isSelected()).to.eventually.equal(true);
 
         expect(element(by.css("#consumer_created")).isPresent()).to.eventually.equal(true);
         expect(element(by.css("#consumer_modified")).isPresent()).to.eventually.equal(true);
     });
-
-    this.Then("I should see consumer_key_2's information", function () {
-        expect(element(by.css("#consumer_launch_url")).isPresent()).to.eventually.equal(true);
-
-        expect(element(by.css("#consumer_oauth_consumer_key")).getText()).to.eventually.equal("consumer_key_2");
-        expect(element(by.css("#consumer_oauth_consumer_secret")).getText()).to.eventually.equal("consumer_secret_2");
-        expect(element(by.css("#consumer_canvas_consumer")).getText()).to.eventually.equal("Yes");
-        expect(element(by.css("#consumer_canvas_api_token")).getText()).to.eventually.equal("canvas_api_token2");
-        expect(element(by.model("consumer.active")).isSelected()).to.eventually.equal(true);
-
-        expect(element(by.css("#consumer_created")).isPresent()).to.eventually.equal(true);
-        expect(element(by.css("#consumer_modified")).isPresent()).to.eventually.equal(true);
-    });
-
 
     this.Then("I should see consumer_key_3's information", function () {
         expect(element(by.css("#consumer_launch_url")).isPresent()).to.eventually.equal(true);
 
         expect(element(by.css("#consumer_oauth_consumer_key")).getText()).to.eventually.equal("consumer_key_3");
         expect(element(by.css("#consumer_oauth_consumer_secret")).getText()).to.eventually.equal("consumer_secret_3");
-        expect(element(by.css("#consumer_canvas_consumer")).getText()).to.eventually.equal("No");
-        expect(element(by.css("#consumer_canvas_api_token")).isPresent()).to.eventually.equal(false);
+        expect(element(by.css("#consumer_user_id_override")).getText()).to.eventually.equal("");
         expect(element(by.model("consumer.active")).isSelected()).to.eventually.equal(false);
 
         expect(element(by.css("#consumer_created")).isPresent()).to.eventually.equal(true);

--- a/compair/static/test/features/support/hooks.js
+++ b/compair/static/test/features/support/hooks.js
@@ -36,6 +36,7 @@ var hooks = function () {
                         log.message.indexOf("Uncaught TypeError: Cannot read property 'unselectable' of null") == -1 &&
                         log.message.indexOf("Uncaught TypeError: Cannot read property 'getSelection' of undefined") == -1 &&
                         log.message.indexOf("Uncaught TypeError: Cannot read property 'page' of null") == -1 &&
+                        log.message.indexOf("Uncaught TypeError: Cannot read property 'currentScaleValue' of null") == -1 &&
                         log.message.indexOf("TypeError: a is undefined") == -1 &&
                         log.message.indexOf("window.parent is null") == -1) {
                     browserErrorLogs.push(log)

--- a/compair/static/test/features/view_lti_consumer.feature
+++ b/compair/static/test/features/view_lti_consumer.feature
@@ -6,12 +6,11 @@ Feature: Manage LTI Consumers
     And I'm on 'manage lti' page
     When I click the first consumer's key
     Then I should be on the 'lti consumer' page
-    And I should see consumer_key_1's information
 
-  Scenario: View LTI canvas consumer as admin
+  Scenario: View LTI consumer as admin
     Given I'm a System Administrator
-    And I'm on 'lti consumer' page for consumer with id '2abcABC123-abcABC123_Z'
-    Then I should see consumer_key_2's information
+    And I'm on 'lti consumer' page for consumer with id '1abcABC123-abcABC123_Z'
+    Then I should see consumer_key_1's information
 
   Scenario: View LTI inactive consumer as admin
     Given I'm a System Administrator

--- a/compair/static/test/fixtures/admin/default_fixture.js
+++ b/compair/static/test/fixtures/admin/default_fixture.js
@@ -174,11 +174,10 @@ var assignment_upcoming = assignmentFactory.generateAssignment("4abcABC123-abcAB
 storage.assignments[assignment_upcoming.id] = assignment_upcoming;
 storage.course_assignments[course.id].push(assignment_upcoming.id);
 
-var consumer1 = ltiConsumerFactory.generateConsumer("1abcABC123-abcABC123_Z", "consumer_key_1", "consumer_secret_1");
-var consumer2 = ltiConsumerFactory.generateConsumer("2abcABC123-abcABC123_Z", "consumer_key_2", "consumer_secret_2", {
-    "canvas_consumer": true,
-    "canvas_api_token": "canvas_api_token2"
+var consumer1 = ltiConsumerFactory.generateConsumer("1abcABC123-abcABC123_Z", "consumer_key_1", "consumer_secret_1", {
+    "user_id_override": "consumer_user_id_override"
 });
+var consumer2 = ltiConsumerFactory.generateConsumer("2abcABC123-abcABC123_Z", "consumer_key_2", "consumer_secret_2");
 var consumer3 = ltiConsumerFactory.generateConsumer("3abcABC123-abcABC123_Z", "consumer_key_3", "consumer_secret_3", {
     "active": false
 });

--- a/compair/tests/api/test_lti_consumers.py
+++ b/compair/tests/api/test_lti_consumers.py
@@ -19,8 +19,7 @@ class LTIConsumersAPITests(ComPAIRAPITestCase):
         consumer_expected = {
             'oauth_consumer_key': 'new_consumer_key',
             'oauth_consumer_secret': 'new_consumer_secret',
-            'canvas_consumer': False,
-            'canvas_api_token': None
+            'user_id_override': 'new_consumer_user_id_override',
         }
 
         # Test login required
@@ -44,8 +43,7 @@ class LTIConsumersAPITests(ComPAIRAPITestCase):
             self.assert200(rv)
             self.assertEqual(consumer_expected['oauth_consumer_key'], rv.json['oauth_consumer_key'])
             self.assertEqual(consumer_expected['oauth_consumer_secret'], rv.json['oauth_consumer_secret'])
-            self.assertEqual(consumer_expected['canvas_consumer'], rv.json['canvas_consumer'])
-            self.assertEqual(consumer_expected['canvas_api_token'], rv.json['canvas_api_token'])
+            self.assertEqual(consumer_expected['user_id_override'], rv.json['user_id_override'])
             self.assertTrue(rv.json['active'])
 
             # test unique oauth_consumer_key by submitting again
@@ -53,21 +51,6 @@ class LTIConsumersAPITests(ComPAIRAPITestCase):
             self.assertStatus(rv, 409)
             self.assertEqual(rv.json['title'], "Consumer Not Saved")
             self.assertEqual(rv.json['message'], "A LTI consumer with the same consumer key already exists.")
-
-            # test canvas Consumer
-            consumer_expected = {
-                'oauth_consumer_key': 'new_canvas_consumer_key',
-                'oauth_consumer_secret': 'new_canvas_consumer_secret',
-                'canvas_consumer': True,
-                'canvas_api_token': "new_canvas_api_token"
-            }
-            rv = self.client.post(url, data=json.dumps(consumer_expected), content_type='application/json')
-            self.assert200(rv)
-            self.assertEqual(consumer_expected['oauth_consumer_key'], rv.json['oauth_consumer_key'])
-            self.assertEqual(consumer_expected['oauth_consumer_secret'], rv.json['oauth_consumer_secret'])
-            self.assertEqual(consumer_expected['canvas_consumer'], rv.json['canvas_consumer'])
-            self.assertEqual(consumer_expected['canvas_api_token'], rv.json['canvas_api_token'])
-            self.assertTrue(rv.json['active'])
 
     def test_list_lti_consumers(self):
         url = self._build_consumer_url()
@@ -98,18 +81,16 @@ class LTIConsumersAPITests(ComPAIRAPITestCase):
 
             for index, lti_consumer in enumerate(lti_consumers):
                 self.assertEqual(lti_consumer.oauth_consumer_key, rv.json['objects'][index]['oauth_consumer_key'])
-                self.assertEqual(lti_consumer.canvas_consumer, rv.json['objects'][index]['canvas_consumer'])
+                self.assertEqual(lti_consumer.user_id_override, rv.json['objects'][index]['user_id_override'])
                 self.assertEqual(lti_consumer.active, rv.json['objects'][index]['active'])
                 self.assertNotIn('oauth_consumer_secret',  rv.json['objects'][index])
-                self.assertNotIn('canvas_api_token',  rv.json['objects'][index])
 
             # test paging
             for i in range(1, 30): # add 29 more consumers
                 if i % 2 == 0:
                     self.lti_data.create_consumer(oauth_consumer_key='lti_consumer_key_'+str(i))
                 else:
-                    self.lti_data.create_consumer(oauth_consumer_key='lti_consumer_key_'+str(i),
-                        canvas_consumer=True, canvas_api_token='canvas_api_token_'+str(i))
+                    self.lti_data.create_consumer(oauth_consumer_key='lti_consumer_key_'+str(i), user_id_override='user_id_override_'+str(i))
             lti_consumers = self.lti_data.lti_consumers
 
             rv = self.client.get(url)
@@ -119,10 +100,9 @@ class LTIConsumersAPITests(ComPAIRAPITestCase):
 
             for index, lti_consumer in enumerate(lti_consumers[:20]):
                 self.assertEqual(lti_consumer.oauth_consumer_key, rv.json['objects'][index]['oauth_consumer_key'])
-                self.assertEqual(lti_consumer.canvas_consumer, rv.json['objects'][index]['canvas_consumer'])
+                self.assertEqual(lti_consumer.user_id_override, rv.json['objects'][index]['user_id_override'])
                 self.assertEqual(lti_consumer.active, rv.json['objects'][index]['active'])
                 self.assertNotIn('oauth_consumer_secret',  rv.json['objects'][index])
-                self.assertNotIn('canvas_api_token',  rv.json['objects'][index])
 
             rv = self.client.get(url+"?page=2")
             self.assert200(rv)
@@ -131,49 +111,44 @@ class LTIConsumersAPITests(ComPAIRAPITestCase):
 
             for index, lti_consumer in enumerate(lti_consumers[20:]):
                 self.assertEqual(lti_consumer.oauth_consumer_key, rv.json['objects'][index]['oauth_consumer_key'])
-                self.assertEqual(lti_consumer.canvas_consumer, rv.json['objects'][index]['canvas_consumer'])
+                self.assertEqual(lti_consumer.user_id_override, rv.json['objects'][index]['user_id_override'])
                 self.assertEqual(lti_consumer.active, rv.json['objects'][index]['active'])
                 self.assertNotIn('oauth_consumer_secret',  rv.json['objects'][index])
-                self.assertNotIn('canvas_api_token',  rv.json['objects'][index])
 
             # test order by
-            rv = self.client.get(url+"?orderBy=canvas_consumer")
+            rv = self.client.get(url+"?orderBy=oauth_consumer_key")
             self.assert200(rv)
             self.assertEqual(len(rv.json['objects']), 20)
             self.assertEqual(rv.json['total'], 30)
 
             sorted_lti_consumers = sorted(
                 [consumer for consumer in lti_consumers],
-                key=lambda consumer: consumer.canvas_consumer)[:20]
+                key=lambda consumer: consumer.oauth_consumer_key)[:20]
 
             for index, lti_consumer in enumerate(sorted_lti_consumers):
                 self.assertEqual(lti_consumer.oauth_consumer_key, rv.json['objects'][index]['oauth_consumer_key'])
-                self.assertEqual(lti_consumer.canvas_consumer, rv.json['objects'][index]['canvas_consumer'])
+                self.assertEqual(lti_consumer.user_id_override, rv.json['objects'][index]['user_id_override'])
                 self.assertEqual(lti_consumer.active, rv.json['objects'][index]['active'])
                 self.assertNotIn('oauth_consumer_secret',  rv.json['objects'][index])
-                self.assertNotIn('canvas_api_token',  rv.json['objects'][index])
 
-            rv = self.client.get(url+"?orderBy=canvas_consumer&reverse=true")
+            rv = self.client.get(url+"?orderBy=oauth_consumer_key&reverse=true")
             self.assert200(rv)
             self.assertEqual(len(rv.json['objects']), 20)
             self.assertEqual(rv.json['total'], 30)
 
             sorted_lti_consumers = sorted(
                 [consumer for consumer in lti_consumers],
-                key=lambda consumer: consumer.canvas_consumer,
+                key=lambda consumer: consumer.oauth_consumer_key,
                 reverse=True)[:20]
 
             for index, lti_consumer in enumerate(sorted_lti_consumers):
                 self.assertEqual(lti_consumer.oauth_consumer_key, rv.json['objects'][index]['oauth_consumer_key'])
-                self.assertEqual(lti_consumer.canvas_consumer, rv.json['objects'][index]['canvas_consumer'])
+                self.assertEqual(lti_consumer.user_id_override, rv.json['objects'][index]['user_id_override'])
                 self.assertEqual(lti_consumer.active, rv.json['objects'][index]['active'])
                 self.assertNotIn('oauth_consumer_secret',  rv.json['objects'][index])
-                self.assertNotIn('canvas_api_token',  rv.json['objects'][index])
 
     def test_get_lti_consumer(self):
         lti_consumer = self.lti_data.lti_consumer
-        canvas_consumer = self.lti_data.create_consumer(oauth_consumer_key='canvas_consumer',
-            canvas_consumer=True, canvas_api_token='canvas_api_token')
         url = self._build_consumer_url(lti_consumer.uuid)
 
         # Test login required
@@ -202,19 +177,8 @@ class LTIConsumersAPITests(ComPAIRAPITestCase):
             self.assert200(rv)
             self.assertEqual(lti_consumer.oauth_consumer_key, rv.json['oauth_consumer_key'])
             self.assertEqual(lti_consumer.oauth_consumer_secret, rv.json['oauth_consumer_secret'])
-            self.assertEqual(lti_consumer.canvas_consumer, rv.json['canvas_consumer'])
-            self.assertEqual(lti_consumer.canvas_api_token, rv.json['canvas_api_token'])
+            self.assertEqual(lti_consumer.user_id_override, rv.json['user_id_override'])
             self.assertTrue(lti_consumer.active, rv.json['active'])
-
-            # test canvas_consumer
-            url = self._build_consumer_url(canvas_consumer.uuid)
-            rv = self.client.get(url)
-            self.assert200(rv)
-            self.assertEqual(canvas_consumer.oauth_consumer_key, rv.json['oauth_consumer_key'])
-            self.assertEqual(canvas_consumer.oauth_consumer_secret, rv.json['oauth_consumer_secret'])
-            self.assertEqual(canvas_consumer.canvas_consumer, rv.json['canvas_consumer'])
-            self.assertEqual(canvas_consumer.canvas_api_token, rv.json['canvas_api_token'])
-            self.assertTrue(canvas_consumer.active, rv.json['active'])
 
     def test_edit_lti_consumer(self):
         lti_consumer = self.lti_data.lti_consumer
@@ -224,8 +188,7 @@ class LTIConsumersAPITests(ComPAIRAPITestCase):
             'id': lti_consumer.uuid,
             'oauth_consumer_key': 'edit_consumer_key',
             'oauth_consumer_secret': 'edit_consumer_secret',
-            'canvas_consumer': False,
-            'canvas_api_token': None,
+            'user_id_override': 'edit_consumer_user_id_override',
             'active': False
         }
 
@@ -261,19 +224,17 @@ class LTIConsumersAPITests(ComPAIRAPITestCase):
             self.assert200(rv)
             self.assertEqual(consumer_expected['oauth_consumer_key'], rv.json['oauth_consumer_key'])
             self.assertEqual(consumer_expected['oauth_consumer_secret'], rv.json['oauth_consumer_secret'])
-            self.assertEqual(consumer_expected['canvas_consumer'], rv.json['canvas_consumer'])
-            self.assertEqual(consumer_expected['canvas_api_token'], rv.json['canvas_api_token'])
+            self.assertEqual(consumer_expected['user_id_override'], rv.json['user_id_override'])
             self.assertEqual(consumer_expected['active'], rv.json['active'])
 
-            # test edit to canvas consumer
-            consumer_expected['canvas_consumer'] = True
-            consumer_expected['canvas_api_token'] = "canvas_api_token"
-            rv = self.client.post(url, data=json.dumps(consumer_expected), content_type='application/json')
+            # valid url (empty user_id_override)
+            consumer_expected_no_override = consumer_expected.copy()
+            consumer_expected_no_override['user_id_override'] = ""
+            rv = self.client.post(url, data=json.dumps(consumer_expected_no_override), content_type='application/json')
             self.assert200(rv)
             self.assertEqual(consumer_expected['oauth_consumer_key'], rv.json['oauth_consumer_key'])
             self.assertEqual(consumer_expected['oauth_consumer_secret'], rv.json['oauth_consumer_secret'])
-            self.assertEqual(consumer_expected['canvas_consumer'], rv.json['canvas_consumer'])
-            self.assertEqual(consumer_expected['canvas_api_token'], rv.json['canvas_api_token'])
+            self.assertIsNone(rv.json['user_id_override'])
             self.assertEqual(consumer_expected['active'], rv.json['active'])
 
             # test edit duplicate consumer key

--- a/compair/tests/test_compair.py
+++ b/compair/tests/test_compair.py
@@ -182,7 +182,7 @@ class ComPAIRAPITestCase(ComPAIRTestCase):
 
     @contextmanager
     def lti_launch(self, lti_consumer, lti_resource_link_id,
-                         assignment_uuid=None, query_assignment_uuid=None,
+                         assignment_uuid=None, query_assignment_uuid=None, custom_puid=None,
                          nonce=None, timestamp=None, follow_redirects=True,
                          **kwargs):
         launch_url = "http://localhost/api/lti/auth"
@@ -190,6 +190,8 @@ class ComPAIRAPITestCase(ComPAIRTestCase):
         launch_params['resource_link_id'] = lti_resource_link_id
         if assignment_uuid:
             launch_params['custom_assignment'] = assignment_uuid
+        if custom_puid:
+            launch_params['custom_puid'] = custom_puid
         if query_assignment_uuid:
             launch_url = launch_url+"?assignment="+query_assignment_uuid
 


### PR DESCRIPTION
- Removed Canvas specific parameters (api token) and made it a generic LTI membership services request following the LTI Memberships Services spec (for LTI 2.0).
- Added user_id_override that allow overriding the user id from LTI launch and memberships requests with another parameter (basic, custom, ext).
- Fixed an issue with comparison count display
- Fixed an issue with LTI account creation in javascript

Closes #543 