### PR TITLE
Fix course sort order

### DIFF
--- a/compair/models/course.py
+++ b/compair/models/course.py
@@ -51,13 +51,19 @@ class Course(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
 
     @hybrid_property
     def start_date_order(self):
-        return self.start_date if self.start_date else self.min_assignment_answer_start
+        if self.start_date:
+            return self.start_date
+        elif self.min_assignment_answer_start:
+            return self.min_assignment_answer_start
+        else:
+            return self.created
 
     @start_date_order.expression
     def start_date_order(cls):
         return case([
-            (cls.start_date != None, cls.start_date)
-        ], else_ = cls.min_assignment_answer_start)
+            (cls.start_date != None, cls.start_date),
+            (cls.min_assignment_answer_start != None, cls.min_assignment_answer_start)
+        ], else_ = cls.created)
 
     def calculate_grade(self, user):
         from . import CourseGrade

--- a/compair/tests/api/test_users.py
+++ b/compair/tests/api/test_users.py
@@ -639,6 +639,7 @@ class UsersAPITests(ComPAIRAPITestCase):
             url = '/api/users/courses'
 
             self.data.get_course().start_date = None
+            self.data.get_course().created = datetime.datetime.now() - datetime.timedelta(days=10)
 
             course_2 = self.data.create_course()
             course_2.start_date = datetime.datetime.now()
@@ -735,6 +736,7 @@ class UsersAPITests(ComPAIRAPITestCase):
             url = '/api/users/'+ self.data.get_authorized_instructor().uuid +'/courses'
 
             self.data.get_course().start_date = None
+            self.data.get_course().created = datetime.datetime.now() - datetime.timedelta(days=10)
 
             course_2 = self.data.create_course()
             course_2.start_date = datetime.datetime.now()


### PR DESCRIPTION
courses will now be sorted by:
- start date if it has a start date.
- min assignment answer start date if it has assignments.
- or created date as the final fallback

Closes #537