### PR TITLE
Fix mobile issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 dist
 build
 compair/templates/static/*.css
+compair/templates/static/*.html
 eggs
 parts
 bin

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "tests"
   ],
   "dependencies": {
-    "bootstrap": "3.3.5",
+    "bootstrap": "3.3.7",
     "angular": "1.5.11",
     "angular-animate": "1.5.11",
     "angular-resource": "1.5.11",
@@ -34,7 +34,7 @@
     "angular-moment": "~0.10.3",
     "angular-file-upload": "~2.5.0",
     "angular-mocks": "1.5.11",
-    "angular-bootstrap": "~0.14.3",
+    "angular-bootstrap": "~2.5.0",
     "angular-timer": "1.3.4",
     "lodash": "~4.17.4",
     "angular-file-saver": "0.1.4",
@@ -44,7 +44,7 @@
     "angular-local-storage": "~0.5.2",
     "angular-promise-extras": "~0.1.8",
     "ng-kaltura-player": "~1.2.0",
-    "angular-pdfjs-viewer": "~0.7.4"
+    "pdf.js-viewer": "~1.6.211"
   },
   "resolutions": {
     "angular": "1.5.11"

--- a/compair/__init__.py
+++ b/compair/__init__.py
@@ -37,6 +37,17 @@ def get_asset_names(app):
 
     return {'ASSETS': assets}
 
+def get_asset_prefix(app):
+    prefix = ''
+    if app.config['ASSET_LOCATION'] == 'cloud':
+        prefix = app.config['ASSET_CLOUD_URI_PREFIX']
+    elif app.config['ASSET_LOCATION'] == 'local':
+        prefix = app.static_url_path + '/dist/'
+    else:
+        app.logger.error('Invalid ASSET_LOCATION value ' + app.config['ASSET_LOCATION'] + '.')
+
+    return {'ASSET_PREFIX': prefix}
+
 
 def create_persistent_dirs(conf, logger):
     """
@@ -116,6 +127,8 @@ def create_app(conf=config, settings_override=None, skip_endpoints=False, skip_a
     if not skip_assets and not app.debug and not app.config.get('TESTING', False):
         assets = get_asset_names(app)
         app.config.update(assets)
+        prefix = get_asset_prefix(app)
+        app.config.update(prefix)
 
     if not skip_endpoints:
         # Flask-Login initialization

--- a/compair/api/__init__.py
+++ b/compair/api/__init__.py
@@ -4,7 +4,7 @@ import os
 from flask import redirect, render_template, jsonify
 from flask_login import login_required, current_user, current_app
 from flask import make_response
-from flask import send_file
+from flask import send_file, url_for
 from flask_restful.reqparse import RequestParser
 
 from compair.core import event
@@ -132,13 +132,7 @@ def register_api_blueprints(app):
 
         # running in prod mode, figure out asset location
         assets = app.config['ASSETS']
-        prefix = ''
-        if app.config['ASSET_LOCATION'] == 'cloud':
-            prefix = app.config['ASSET_CLOUD_URI_PREFIX']
-        elif app.config['ASSET_LOCATION'] == 'local':
-            prefix = app.static_url_path + '/dist/'
-        else:
-            app.logger.error('Invalid ASSET_LOCATION value ' + app.config['ASSET_LOCATION'] + '.')
+        prefix = app.config['ASSET_PREFIX']
 
         return render_template(
             'index.html',
@@ -163,6 +157,23 @@ def register_api_blueprints(app):
     @app.route('/')
     def route_root():
         return redirect("/app/")
+
+    @app.route('/app/pdf')
+    def route_pdf_viewer():
+        if app.debug or app.config.get('TESTING', False):
+            return render_template(
+                'pdf-viewer.html',
+                pdf_lib_folder=url_for('static', filename='lib/pdf.js-viewer')
+            )
+
+        # running in prod mode, figure out asset location
+        assets = app.config['ASSETS']
+        prefix = app.config['ASSET_PREFIX']
+
+        return render_template(
+            'pdf-viewer.html',
+            pdf_lib_folder=prefix + 'pdf.js-viewer'
+        )
 
     @app.route('/app/<regex("attachment|report"):file_type>/<file_name>')
     @login_required

--- a/compair/static/less/mobile.less
+++ b/compair/static/less/mobile.less
@@ -124,6 +124,17 @@
 
     }//closes manage-screen
 
+
+    .modal-dialog {
+        width: 100%;
+        margin: 0;
+        padding: 0;
+    }
+
+    .modal-content {
+        border-radius: 0;
+    }
+
 }//closes 768px
 
 
@@ -169,3 +180,14 @@
 @media (max-width: 1200px) {
 
 }//closes 1200px
+
+// force selectable/editable content font size on mobile devises
+// iPhone & Safari has autozoom features that do not zoom back out
+// autozooming only happens when the font-size in less than 16px
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+    select,
+    textarea,
+    input {
+        font-size: 16px !important;
+    }
+}//closes screen and -webkit-min-device-pixel-ratio:0

--- a/compair/static/modules/rich-content/rich-content-attachment-template.html
+++ b/compair/static/modules/rich-content/rich-content-attachment-template.html
@@ -9,7 +9,7 @@
     <kaltura-player id="{{content.id}}_{{modalInstance ? 'modal' : 'inline'}}" base-url="{{content.service_url}}" width="100%" height="90px" video="content.kalturaAttributes" class="content-item"></kaltura-player>
 </div>
 <div ng-if="content.type == 'pdf'" class="embed-responsive embed-responsive-16by9">
-    <pdfjs-viewer src="{{ content.url }}" class="content-item embed-responsive-item"></pdfjs-viewer>
+    <iframe src="{{content.url}}" class="content-item embed-responsive-item"></iframe>
 </div>
 <div ng-if="content.type == 'image'">
     <img ng-src="{{content.url}}" ng-alt="{{content.title}}" class="content-item" />

--- a/compair/static/modules/rich-content/rich-content-directive.js
+++ b/compair/static/modules/rich-content/rich-content-directive.js
@@ -3,7 +3,6 @@
 var module = angular.module('ubc.ctlt.compair.rich.content',
     [
         'Kaltura.directives',
-        'pdfjsViewer',
         'ui.bootstrap',
         'ubc.ctlt.compair.common.xapi',
         'ubc.ctlt.compair.rich.content.mathjax',
@@ -100,28 +99,24 @@ module.factory("embeddableRichContent",
                     return {
                         type: 'video',
                         url: url,
-                        icon: 'fa-file-video-o',
                         displayInline: false
                     };
                 } else if (url.match(embedRegexpPatterns.basicAudio)) {
                     return {
                         type: 'audio',
                         url: url,
-                        icon: 'fa-file-audio-o',
                         displayInline: false
                     };
                 } else if (url.match(embedRegexpPatterns.basicImage)) {
                     return {
                         type: 'image',
                         url: url,
-                        icon: 'fa-file-image-o',
                         displayInline: false
                     };
                 } else if (url.match(embedRegexpPatterns.pdf)) {
                     return {
                         type: 'pdf',
                         url: url,
-                        icon: 'fa-file-pdf-o',
                         embed: pdfEmbed(url),
                         displayInline: false
                     };
@@ -129,7 +124,6 @@ module.factory("embeddableRichContent",
                     return {
                         type: 'soundCloud',
                         url: url,
-                        icon: 'fa-soundcloud',
                         embed: soundCloudEmbed(url),
                         displayInline: false
                     };
@@ -137,7 +131,6 @@ module.factory("embeddableRichContent",
                     return {
                         type: 'spotify',
                         url: url,
-                        icon: 'fa-spotify',
                         embed: spotifyEmbed(url),
                         displayInline: false
                     };
@@ -145,7 +138,6 @@ module.factory("embeddableRichContent",
                     return {
                         type: 'vimeo',
                         url: url,
-                        icon: 'fa-vimeo',
                         embed: vimeoEmbed(url),
                         displayInline: false
                     };
@@ -153,7 +145,6 @@ module.factory("embeddableRichContent",
                     return {
                         type: 'youtube',
                         url: url,
-                        icon: 'fa-youtube',
                         embed: youtubeEmbed(url),
                         displayInline: false
                     };
@@ -162,7 +153,6 @@ module.factory("embeddableRichContent",
                     var embeddableLink = {
                         type: 'twitter',
                         url: url,
-                        icon: 'fa-twitter',
                         promise: promise,
                         embed: "",
                         displayInline: false
@@ -176,7 +166,6 @@ module.factory("embeddableRichContent",
             generateAttachmentContent: function(file, downloadName) {
                 var content = {
                     type: 'attachment', // default type, should be overwritten below
-                    icon: 'file-o',
                     title: file.name,
                     displayInline: false
                 }
@@ -193,10 +182,8 @@ module.factory("embeddableRichContent",
 
                     if (file.kaltura_media.media_type == 1) {
                         content.type = 'kaltura_video';
-                        content.icon = 'fa-file-video-o';
                     } else {
                         content.type = 'kaltura_audio';
-                        content.icon = 'fa-file-audio-o';
                     }
                 } else {
                     var filePath = '/app/attachment/' + file.name;
@@ -208,17 +195,13 @@ module.factory("embeddableRichContent",
 
                     if (file.extension == 'pdf') {
                         content.type = 'pdf';
-                        content.icon = 'fa-file-pdf-o';
-                        content.url = $sce.trustAsResourceUrl(content.url);
+                        content.url = $sce.trustAsResourceUrl('/app/pdf?file='+encodeURIComponent(content.url)+'#page=1');
                     } else if (file.mimetype.match(/image/ig)) {
                         content.type = 'image';
-                        content.icon = 'fa-file-image-o';
                     } else if (file.mimetype.match(/video/ig)) {
                         content.type = 'video';
-                        content.icon = 'fa-file-video-o';
                     } else if (file.mimetype.match(/audio/ig)) {
                         content.type = 'audio';
-                        content.icon = 'fa-file-audio-o';
                     }
                 }
                 return content;

--- a/compair/static/test/features/support/hooks.js
+++ b/compair/static/test/features/support/hooks.js
@@ -35,8 +35,6 @@ var hooks = function () {
                         log.message.indexOf("Uncaught TypeError: Cannot read property 'on' of undefined") == -1 &&
                         log.message.indexOf("Uncaught TypeError: Cannot read property 'unselectable' of null") == -1 &&
                         log.message.indexOf("Uncaught TypeError: Cannot read property 'getSelection' of undefined") == -1 &&
-                        log.message.indexOf("Uncaught TypeError: Cannot read property 'page' of null") == -1 &&
-                        log.message.indexOf("Uncaught TypeError: Cannot read property 'currentScaleValue' of null") == -1 &&
                         log.message.indexOf("TypeError: a is undefined") == -1 &&
                         log.message.indexOf("window.parent is null") == -1) {
                     browserErrorLogs.push(log)

--- a/compair/templates/index-dev.html
+++ b/compair/templates/index-dev.html
@@ -18,7 +18,6 @@
         <link rel="stylesheet" href="{{ url_for('static', filename='lib/AngularJS-Toaster/toaster.css') }}" />
         <link rel="stylesheet" href="{{ url_for('static', filename='lib/chosen/chosen.css') }}" />
         <link rel="stylesheet" href="{{ url_for('static', filename='lib/chosen-bootstrap-theme/dist/chosen-bootstrap-theme.min.css') }}" />
-        <link rel="stylesheet" href="{{ url_for('static', filename='lib/pdf.js-viewer/viewer.css') }}" />
         <!-- endbower -->
 
         <!-- Javascript Libraries -->
@@ -56,8 +55,6 @@
         <script src="{{ url_for('static', filename='lib/angular-local-storage/dist/angular-local-storage.js') }}"></script>
         <script src="{{ url_for('static', filename='lib/angular-promise-extras/angular-promise-extras.js') }}"></script>
         <script src="{{ url_for('static', filename='lib/ng-kaltura-player/index.js') }}"></script>
-        <script src="{{ url_for('static', filename='lib/pdf.js-viewer/pdf.js') }}"></script>
-        <script src="{{ url_for('static', filename='lib/angular-pdfjs-viewer/dist/angular-pdfjs-viewer.js') }}"></script>
         <!-- endbower -->
         <!-- endbuild -->
 
@@ -203,7 +200,7 @@
     <!-- Main Viewport, where all the module partials are shown -->
     <div class="container">
         <!-- ngView, should have it's own row and column css organization -->
-        <div ng-view=""></div>
+        <div ng-view="" autoscroll></div>
     </div>
     </body>
 </html>

--- a/compair/templates/index.html
+++ b/compair/templates/index.html
@@ -123,7 +123,7 @@
     <!-- Main Viewport, where all the module partials are shown -->
     <div class="container">
         <!-- ngView, should have it's own row and column css organization -->
-        <div ng-view=""></div>
+        <div ng-view="" autoscroll></div>
     </div>
     </body>
 </html>

--- a/compair/templates/pdf-viewer.html
+++ b/compair/templates/pdf-viewer.html
@@ -1,0 +1,31 @@
+
+<!DOCTYPE html>
+<html ng-app="app" ng-controller="AppCtrl">
+    <head>
+        <title>PDF.js</title>
+        <script src="{{ pdf_lib_folder }}/pdf.js"></script>
+        <link rel="stylesheet" href="{{ pdf_lib_folder }}/viewer.css" />
+
+        <style>
+            html, body {
+                height: 100%;
+                width: 100%;
+                margin: 0;
+                padding: 0;
+            }
+            .pdfjs {
+                height: 100%;
+                width: 100%;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="pdfjs">
+            {{ include_raw("static/viewer.html") }}
+        </div>
+
+        <script>
+            window.PDFJS.webViewerLoad();
+        </script>
+    </body>
+</html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,6 +55,11 @@ gulp.task('bowerWiredep', ['bowerInstall'], function () {
         .pipe(gulp.dest('./compair/static/'));
 });
 
+gulp.task('copy_pdf_viewer_html_template', ['bowerInstall'], function() {
+    return gulp.src(['./compair/static/lib/pdf.js-viewer/viewer.html'])
+        .pipe(gulp.dest('./compair/templates/static'));
+});
+
 // compile css
 gulp.task('less', function () {
     return gulp.src('./compair/static/less/compair.less')
@@ -127,26 +132,28 @@ gulp.task('prod_minify_js', ['prod_templatecache'], function() {
         .pipe(uglify())
         .pipe(gulp.dest('./compair/static/build'));
 });
-gulp.task('revision', ['prod_minify_js_libs', 'prod_compile_minify_css', 'prod_minify_js', 'prod_copy_fonts', 'prod_copy_images'], function() {
-    return gulp.src(['./compair/static/build/*.css', './compair/static/build/*.js', '!compair/static/build/templates.js',
-            './compair/static/build/*.png', './compair/static/build/*.ico'])
+gulp.task('prod_pdf_viewer_files', function() {
+    return gulp.src([
+            './compair/static/lib/pdf.js-viewer/pdf.js',
+            './compair/static/lib/pdf.js-viewer/pdf.worker.js',
+            './compair/static/lib/pdf.js-viewer/viewer.css',
+            './compair/static/lib/pdf.js-viewer/images/*',
+            './compair/static/lib/pdf.js-viewer/cmaps/*',
+            './compair/static/lib/pdf.js-viewer/locale/*',
+        ], {base: './compair/static/lib/pdf.js-viewer/'})
+        .pipe(gulp.dest('./compair/static/dist/pdf.js-viewer'));
+});
+gulp.task('prod', ['prod_minify_js_libs', 'prod_compile_minify_css', 'prod_minify_js',
+        'prod_copy_fonts', 'prod_copy_images', 'prod_pdf_viewer_files'], function() {
+    return gulp.src([
+            './compair/static/build/*.css',
+            './compair/static/build/*.js',
+            '!compair/static/build/templates.js',
+        ], {base: './compair/static/build'})
         .pipe(rev())
         .pipe(gulp.dest('./compair/static/dist'))
         .pipe(rev.manifest())
         .pipe(gulp.dest('./compair/static/build'));
-});
-gulp.task('prod', ['revision'], function(){
-    var manifest = require("./compair/static/build/rev-manifest.json");
-    // modify includes to use the minified files
-    return gulp.src('./compair/static/index.html')
-        .pipe(htmlReplace(
-            {
-                prod_minify_js_libs: 'dist/' + manifest[jsLibsFilename],
-                prod_minify_js: 'dist/' + manifest[jsFilename],
-                prod_compile_minify_css: 'dist/' + manifest[targetCssFilename]
-            },
-            {keepBlockTags: true}))
-        .pipe(gulp.dest('./compair/static/'));
 });
 
 /**
@@ -343,4 +350,4 @@ gulp.task('webdriver_update', webdriver_update);
 gulp.task('webdriver_standalone', webdriver_standalone);
 
 
-gulp.task("default", ['bowerInstall', 'bowerWiredep'], function(){});
+gulp.task("default", ['bowerInstall', 'bowerWiredep', 'copy_pdf_viewer_html_template'], function(){});


### PR DESCRIPTION
- Automatically scroll to top of screen when changing pages
- Updated bootstrap and angular-bootstrap libraries
- replaced angular-pdfjs-viewer with pdf.js-viewer in an iframe to easier support production mode
- modals now are full width on screens <= 768px and appear at the top of the screen (note it is still possible to see the background page at the bottom of the screen on really short modal that are less then the view port height)
- iOS should no longer zoom in when selecting input elements (mobile inputs, textfields, and selects are not forced to have a font-size of 16px)

Closes #483