### PR TITLE
Add lis_result_sourcedid for LTI membership service

### DIFF
--- a/alembic/versions/346c3877ffae_add_lis_result_sourcedid_to_lti_.py
+++ b/alembic/versions/346c3877ffae_add_lis_result_sourcedid_to_lti_.py
@@ -1,0 +1,26 @@
+"""Add lis_result_sourcedid to lti_membership
+
+Revision ID: 346c3877ffae
+Revises: d402c96606ce
+Create Date: 2017-08-15 23:30:27.653010
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '346c3877ffae'
+down_revision = 'd402c96606ce'
+
+from alembic import op
+import sqlalchemy as sa
+
+from compair.models import convention
+
+
+def upgrade():
+    with op.batch_alter_table('lti_membership', naming_convention=convention) as batch_op:
+        batch_op.add_column(sa.Column('lis_result_sourcedids', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('lti_membership', naming_convention=convention) as batch_op:
+        batch_op.drop_column('lis_result_sourcedids')

--- a/compair/models/lti_models/lti_membership.py
+++ b/compair/models/lti_models/lti_membership.py
@@ -1,3 +1,4 @@
+import json
 from six import text_type
 
 # sqlalchemy
@@ -16,9 +17,15 @@ from oauthlib.oauth1 import SIGNATURE_TYPE_BODY, SIGNATURE_TYPE_AUTH_HEADER, SIG
 from .helpers import LTIMemerbshipServiceOauthClient
 
 from requests_oauthlib import OAuth1
-from lti.utils import parse_qs
+from lti.utils import parse_qs, urlparse
 import requests
 from xml.etree import ElementTree
+
+import urllib
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
 
 class LTIMembership(DefaultTableMixin, WriteTrackingMixin):
     __tablename__ = 'lti_membership'
@@ -30,6 +37,7 @@ class LTIMembership(DefaultTableMixin, WriteTrackingMixin):
         nullable=False)
     roles = db.Column(db.String(255), nullable=True)
     lis_result_sourcedid = db.Column(db.String(255), nullable=True)
+    lis_result_sourcedids = db.Column(db.Text, nullable=True)
     course_role = db.Column(EnumType(CourseRole, name="course_role"),
         nullable=False)
 
@@ -40,8 +48,10 @@ class LTIMembership(DefaultTableMixin, WriteTrackingMixin):
     # lti_conext via LTIContext Model
     # lti_user via LTIUser Model
 
-
     # hyprid and other functions
+    context_id = association_proxy('lti_context', 'context_id')
+    user_id = association_proxy('lti_user', 'user_id')
+
     @classmethod
     def update_membership_for_course(cls, course):
         from . import MembershipNoValidContextsException
@@ -62,7 +72,10 @@ class LTIMembership(DefaultTableMixin, WriteTrackingMixin):
 
     @classmethod
     def _update_membership_for_context(cls, lti_context, members):
-        from compair.models import LTIUser, SystemRole, CourseRole
+        from compair.models import SystemRole, CourseRole, \
+            LTIUser, LTIUserResourceLink
+
+        lti_resource_links = lti_context.lti_resource_links
 
         # remove old membership rows
         LTIMembership.query \
@@ -71,7 +84,7 @@ class LTIMembership(DefaultTableMixin, WriteTrackingMixin):
             ) \
             .delete()
 
-        # retreive existing lti_user rows
+        # retrieve existing lti_user rows
         user_ids = []
         for member in members:
             user_ids.append(member['user_id'])
@@ -83,7 +96,20 @@ class LTIMembership(DefaultTableMixin, WriteTrackingMixin):
             )) \
             .all()
 
+        # get existing lti_user_resource_link if there there exists lti users and known resource links for context
+        existing_lti_user_resource_links = []
+        if len(existing_lti_users) > 0 and len(lti_resource_links) > 0:
+            lti_resource_link_ids = [lti_resource_link.id for lti_resource_link in lti_resource_links]
+            existing_lti_user_ids = [existing_lti_user.id for existing_lti_user in existing_lti_users]
+            existing_lti_user_resource_links = LTIUserResourceLink.query \
+                .filter(and_(
+                    LTIUserResourceLink.lti_resource_link_id.in_(lti_resource_link_ids),
+                    LTIUserResourceLink.lti_user_id.in_(existing_lti_user_ids)
+                )) \
+                .all()
+
         new_lti_users = []
+        new_lti_user_resource_links = []
         lti_memberships = []
         for member in members:
             # get lti user if exists
@@ -120,12 +146,47 @@ class LTIMembership(DefaultTableMixin, WriteTrackingMixin):
                 lti_context=lti_context,
                 roles=text_type(roles),
                 lis_result_sourcedid=member.get('lis_result_sourcedid'),
+                lis_result_sourcedids=json.dumps(member.get('lis_result_sourcedids')) if member.get('lis_result_sourcedids') else None,
                 course_role=course_role
             )
             lti_memberships.append(lti_membership)
 
+            # if membership includes lis_result_sourcedids, create/update lti user resoruce links
+            if member.get('lis_result_sourcedids'):
+                for lis_result_sourcedid_set in member.get('lis_result_sourcedids'):
+                    lti_resource_link = next(
+                        lti_resource_link for lti_resource_link in lti_resource_links
+                        if lti_resource_link.resource_link_id == lis_result_sourcedid_set['resource_link_id']
+                    )
+
+                    if not lti_resource_link:
+                        continue
+
+                    lti_user_resource_link = None
+                    if len(existing_lti_user_resource_links) > 0 and lti_user.id:
+                        # get lti user resource link if exists
+                        lti_user_resource_link = next(
+                            (lti_user_resource_link for lti_user_resource_link in existing_lti_user_resource_links
+                            if lti_user_resource_link.lti_user_id == lti_user.id and lti_user_resource_link.lti_resource_link_id == lti_resource_link.id),
+                            None
+                        )
+
+                    # create new lti user resource link if needed
+                    if not lti_user_resource_link:
+                        lti_user_resource_link = LTIUserResourceLink(
+                            lti_resource_link=lti_resource_link,
+                            lti_user=lti_user,
+                            roles=text_type(roles),
+                            course_role=course_role
+                        )
+                        new_lti_user_resource_links.append(lti_user_resource_link)
+
+                    # finally update the lis_result_sourcedid value for the user resource link
+                    lti_user_resource_link.lis_result_sourcedid = lis_result_sourcedid_set['lis_result_sourcedid']
+
         db.session.add_all(new_lti_users)
         db.session.add_all(lti_memberships)
+        db.session.add_all(new_lti_user_resource_links)
 
         # save new lti users
         db.session.commit()
@@ -220,6 +281,7 @@ class LTIMembership(DefaultTableMixin, WriteTrackingMixin):
             member = {
                 'user_id': record.findtext('user_id'),
                 'roles': roles_text.split(",") if roles_text != None else [],
+                'lis_result_sourcedid': record.findtext('lis_result_sourcedid'),
                 'person_contact_email_primary': record.findtext('person_contact_email_primary'),
                 'person_name_given': record.findtext('person_name_given'),
                 'person_name_family': record.findtext('person_name_family'),
@@ -238,6 +300,7 @@ class LTIMembership(DefaultTableMixin, WriteTrackingMixin):
         # possible parameters are role, lis_result_sourcedid, limit
         lti_consumer = lti_context.lti_consumer
         memberships_url = lti_context.custom_context_memberships_url
+        lti_resource_links = lti_context.lti_resource_links
 
         members = []
 
@@ -295,6 +358,65 @@ class LTIMembership(DefaultTableMixin, WriteTrackingMixin):
             memberships_url = data.get('nextPage')
             if not memberships_url:
                 break
+
+        # get lis_result_sourcedid for all resource links known to the system
+        for lti_resource_link in lti_resource_links:
+            # add rlid ot membership url query string
+            parts = urlparse.urlsplit(lti_context.custom_context_memberships_url)
+            query = urlparse.parse_qs(parts.query)
+            query['rlid'] = lti_resource_link.resource_link_id
+
+            memberships_url = urlparse.urlunsplit((
+                parts.scheme,
+                parts.netloc,
+                parts.path,
+                urlencode(query),
+                parts.fragment
+            ))
+
+            while True:
+                headers = { 'Accept': 'application/vnd.ims.lis.v2.membershipcontainer+json' }
+                request = requests.Request('GET', memberships_url, headers=headers).prepare()
+                # Note: need to use LTIMemerbshipServiceOauthClient since normal client will
+                #       not include oauth_body_hash if there is not content type or the body is None
+                sign = OAuth1(lti_consumer.oauth_consumer_key, lti_consumer.oauth_consumer_secret,
+                    signature_type=SIGNATURE_TYPE_AUTH_HEADER, signature_method=SIGNATURE_HMAC,
+                    client_class=LTIMemerbshipServiceOauthClient)
+                signed_request = sign(request)
+                headers = signed_request.headers
+                data = LTIMembership._get_membership_request(memberships_url, headers)
+
+                membership = data['pageOf']['membershipSubject']['membership']
+
+                if len(membership) == 0:
+                    continue
+
+                for record in membership:
+                    if record.get('status').find("Inactive") >= 0:
+                        continue
+
+                    member = next(
+                        (member for member in members if member['user_id'] == record['member'].get('userId')),
+                        None
+                    )
+
+                    if not member or not 'message' in record:
+                        continue
+
+                    for message in record['message']:
+                        if not message['message_type'] == 'basic-lti-launch-request' or not 'lis_result_sourcedid' in message:
+                            continue
+
+                        lis_result_sourcedid_array = member.setdefault('lis_result_sourcedids', [])
+                        lis_result_sourcedid_array.append({
+                            'resource_link_id': lti_resource_link.resource_link_id,
+                            'lis_result_sourcedid': message['lis_result_sourcedid']
+                        })
+
+                # check if another page or else finish
+                memberships_url = data.get('nextPage')
+                if not memberships_url:
+                    break
 
         return members
 

--- a/compair/models/lti_models/lti_resource_link.py
+++ b/compair/models/lti_models/lti_resource_link.py
@@ -29,6 +29,7 @@ class LTIResourceLink(DefaultTableMixin, WriteTrackingMixin):
     lti_user_resource_links = db.relationship("LTIUserResourceLink", backref="lti_resource_link", lazy="dynamic")
 
     # hyprid and other functions
+    context_id = association_proxy('lti_context', 'context_id')
     compair_assignment_uuid = association_proxy('compair_assignment', 'uuid')
 
     def is_linked_to_assignment(self):

--- a/compair/models/lti_models/lti_user_resource_link.py
+++ b/compair/models/lti_models/lti_user_resource_link.py
@@ -28,6 +28,9 @@ class LTIUserResourceLink(DefaultTableMixin, WriteTrackingMixin):
     # lti_resource_link via LTIResourceLink Model
 
     # hyprid and other functions
+    context_id = association_proxy('lti_resource_link', 'context_id')
+    resource_link_id = association_proxy('lti_resource_link', 'resource_link_id')
+    user_id = association_proxy('lti_user', 'user_id')
     compair_user_id = association_proxy('lti_user', 'compair_user_id')
 
     @classmethod

--- a/compair/tests/api/test_lti_launch.py
+++ b/compair/tests/api/test_lti_launch.py
@@ -811,85 +811,201 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
                 self.assertIn((user_course.user_id, user_course.course_role), current_users)
 
 
-        # test successful membership response (minimual returned data)
+        def minimal_membership_requests(memberships_url, headers=None):
+            if memberships_url == "https://mockmembershipurl.com":
+                return {
+                    "@id":None,
+                    "@type":"Page",
+                    "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
+                    "differences":None,
+                    "nextPage":None,
+                    "pageOf":{
+                        "membershipPredicate":"http://www.w3.org/ns/org#membership",
+                        "membershipSubject":{
+                            "name":"Test Course",
+                            "@type":"Context",
+                            "contextId":"4dde05e8ca1973bcca9bffc13e1548820eee93a3",
+                            "membership":[
+                                {
+                                    "status":"Active",
+                                    "role":[
+                                        "urn:lti:role:ims/lis/Instructor"
+                                    ],
+                                    "member":{
+                                        "userId":lti_user.user_id
+                                    }
+                                },
+                                {
+                                    "status":"liss:Active",
+                                    "role":[
+                                        "urn:lti:role:ims/lis/Learner"
+                                    ],
+                                    "member":{
+                                        "userId":"compair_student_1"
+                                    }
+                                },
+                                {
+                                    "status":"Active",
+                                    "role":[
+                                        "urn:lti:role:ims/lis/Learner"
+                                    ],
+                                    "member":{
+                                        "userId":"compair_student_2"
+                                    }
+                                },
+                                {
+                                    "status":"Active",
+                                    "role":[
+                                        "urn:lti:role:ims/lis/TeachingAssistant"
+                                    ],
+                                    "member":{
+                                        "userId":"compair_student_3"
+                                    }
+                                },
+                                {
+                                    "status":"Active",
+                                    "role":[
+                                        "urn:lti:role:ims/lis/TeachingAssistant"
+                                    ],
+                                    "member":{
+                                        "userId":"compair_instructor_2"
+                                    }
+                                },
+                                {
+                                    "status":"Inactive",
+                                    "role":[
+                                        "urn:lti:role:ims/lis/Learner"
+                                    ],
+                                    "member":{
+                                        "userId":"compair_student_100"
+                                    }
+                                }
+                            ]
+                        },
+                        "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
+                        "@type":"LISMembershipContainer"
+                    }
+                }
+            elif memberships_url == "https://mockmembershipurl.com?rlid="+lti_resource_link.resource_link_id:
+                return {
+                    "@id":None,
+                    "@type":"Page",
+                    "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
+                    "differences":None,
+                    "nextPage":None,
+                    "pageOf":{
+                        "membershipPredicate":"http://www.w3.org/ns/org#membership",
+                        "membershipSubject":{
+                            "name":"Test Course",
+                            "@type":"Context",
+                            "contextId":"4dde05e8ca1973bcca9bffc13e1548820eee93a3",
+                            "membership":[
+                                {
+                                    "status":"Active",
+                                    "role":[
+                                        "urn:lti:role:ims/lis/Instructor"
+                                    ],
+                                    "member":{
+                                        "userId":lti_user.user_id
+                                    },
+                                    "message": [{
+                                        "message_type": "basic-lti-launch-request",
+                                        "lis_result_sourcedid": "lis_result_sourcedid_"+lti_user.user_id
+                                    },{
+                                        "message_type": "other-message-type"
+                                    }]
+                                },
+                                {
+                                    "status":"liss:Active",
+                                    "role":[
+                                        "urn:lti:role:ims/lis/Learner"
+                                    ],
+                                    "member":{
+                                        "userId":"compair_student_1"
+                                    },
+                                    "message": [{
+                                        "message_type": "basic-lti-launch-request",
+                                        "lis_result_sourcedid": "lis_result_sourcedid_compair_student_1"
+                                    },{
+                                        "message_type": "other-message-type"
+                                    }]
+                                },
+                                {
+                                    "status":"Active",
+                                    "role":[
+                                        "urn:lti:role:ims/lis/Learner"
+                                    ],
+                                    "member":{
+                                        "userId":"compair_student_2"
+                                    },
+                                    "message": [{
+                                        "message_type": "basic-lti-launch-request",
+                                        "lis_result_sourcedid": "lis_result_sourcedid_compair_student_2"
+                                    },{
+                                        "message_type": "other-message-type"
+                                    }]
+                                },
+                                {
+                                    "status":"Active",
+                                    "role":[
+                                        "urn:lti:role:ims/lis/TeachingAssistant"
+                                    ],
+                                    "member":{
+                                        "userId":"compair_student_3"
+                                    },
+                                    "message": [{
+                                        "message_type": "basic-lti-launch-request",
+                                        "lis_result_sourcedid": "lis_result_sourcedid_compair_student_3"
+                                    },{
+                                        "message_type": "other-message-type"
+                                    }]
+                                },
+                                {
+                                    "status":"Active",
+                                    "role":[
+                                        "urn:lti:role:ims/lis/TeachingAssistant"
+                                    ],
+                                    "member":{
+                                        "userId":"compair_instructor_2"
+                                    },
+                                    "message": [{
+                                        "message_type": "basic-lti-launch-request",
+                                        "lis_result_sourcedid": "lis_result_sourcedid_compair_instructor_2"
+                                    },{
+                                        "message_type": "other-message-type"
+                                    }]
+                                },
+                                {
+                                    "status":"Inactive",
+                                    "role":[
+                                        "urn:lti:role:ims/lis/Learner"
+                                    ],
+                                    "member":{
+                                        "userId":"compair_student_100"
+                                    },
+                                    "message": [{
+                                        "message_type": "basic-lti-launch-request",
+                                        "lis_result_sourcedid": "lis_result_sourcedid_compair_student_100"
+                                    },{
+                                        "message_type": "other-message-type"
+                                    }]
+                                }
+                            ]
+                        },
+                        "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
+                        "@type":"LISMembershipContainer"
+                    }
+                }
+
+
+        # test successful membership response (minimal returned data)
         with self.lti_launch(lti_consumer, lti_resource_link.resource_link_id,
                 user_id=lti_user.user_id, context_id=lti_context.context_id, roles="Instructor",
                 custom_context_memberships_url="https://mockmembershipurl.com") as rv:
             self.assert200(rv)
 
-            mocked_get_membership_request.return_value = {
-                "@id":None,
-                "@type":"Page",
-                "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                "differences":None,
-                "nextPage":None,
-                "pageOf":{
-                    "membershipPredicate":"http://www.w3.org/ns/org#membership",
-                    "membershipSubject":{
-                        "name":"Test Course",
-                        "@type":"Context",
-                        "contextId":"4dde05e8ca1973bcca9bffc13e1548820eee93a3",
-                        "membership":[
-                            {
-                                "status":"Active",
-                                "role":[
-                                    "urn:lti:role:ims/lis/Instructor"
-                                ],
-                                "member":{
-                                    "userId":lti_user.user_id
-                                }
-                            },
-                            {
-                                "status":"liss:Active",
-                                "role":[
-                                    "urn:lti:role:ims/lis/Learner"
-                                ],
-                                "member":{
-                                    "userId":"compair_student_1"
-                                }
-                            },
-                            {
-                                "status":"Active",
-                                "role":[
-                                    "urn:lti:role:ims/lis/Learner"
-                                ],
-                                "member":{
-                                    "userId":"compair_student_2"
-                                }
-                            },
-                            {
-                                "status":"Active",
-                                "role":[
-                                    "urn:lti:role:ims/lis/TeachingAssistant"
-                                ],
-                                "member":{
-                                    "userId":"compair_student_3"
-                                }
-                            },
-                            {
-                                "status":"Active",
-                                "role":[
-                                    "urn:lti:role:ims/lis/TeachingAssistant"
-                                ],
-                                "member":{
-                                    "userId":"compair_instructor_2"
-                                }
-                            },
-                            {
-                                "status":"Inactive",
-                                "role":[
-                                    "urn:lti:role:ims/lis/Learner"
-                                ],
-                                "member":{
-                                    "userId":"compair_student_100"
-                                }
-                            }
-                        ]
-                    },
-                    "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                    "@type":"LISMembershipContainer"
-                }
-            }
+            mocked_get_membership_request.reset_mock()
+            mocked_get_membership_request.side_effect = minimal_membership_requests
 
             # link course
             rv = self.client.post(url, data={}, content_type='application/json')
@@ -910,13 +1026,318 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
                 .filter_by(compair_course_id=course.id) \
                 .all()
 
+            lti_user_resource_links = LTIUserResourceLink.query \
+                .all()
+
             self.assertEqual(len(lti_memberships), 5)
             for lti_membership in lti_memberships:
                 self.assertIn(lti_membership.lti_user.user_id, [lti_user.user_id, "compair_student_1", "compair_student_2",
                     "compair_student_3", "compair_instructor_2"])
 
+                # ensure the lti_user_resource_link is generated and stores the lis_result_sourcedid
+                lti_user_resource_links = [lti_user_resource_link \
+                    for lti_user_resource_link in lti_membership.lti_user.lti_user_resource_links.all() \
+                    if lti_user_resource_link.lti_resource_link_id == lti_resource_link.id
+                ]
+                self.assertEqual(len(lti_user_resource_links), 1)
+                self.assertEqual(lti_user_resource_links[0].lis_result_sourcedid,
+                    "lis_result_sourcedid_"+lti_membership.lti_user.user_id)
 
-        for user_id_override in [None, "custom_puid", "ext_user_username", "lis_result_sourcedid"]:
+        for user_id_override in [None, "custom_puid", "ext_user_username"]:
+
+            def user_id_override_membership_requests(memberships_url, headers=None):
+                if memberships_url == "https://mockmembershipurl.com":
+                    return {
+                        "@id":None,
+                        "@type":"Page",
+                        "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
+                        "differences":None,
+                        "nextPage":None,
+                        "pageOf":{
+                            "membershipPredicate":"http://www.w3.org/ns/org#membership",
+                            "membershipSubject":{
+                                "name":"Test Course",
+                                "@type":"Context",
+                                "contextId":"4dde05e8ca1973bcca9bffc13e1548820eee93a3",
+                                "membership":[
+                                    {
+                                        "status":"Active",
+                                        "role":[
+                                            "urn:lti:role:ims/lis/Instructor"
+                                        ],
+                                        "member":{
+                                            "userId": lti_user.user_id
+                                        },
+                                        "message" : [
+                                            {
+                                                "message_type": "basic-lti-launch-request",
+                                                "lis_result_sourcedid": lti_user.user_id,
+                                                "custom" : {
+                                                    "puid": lti_user.user_id
+                                                },
+                                                "ext" : {
+                                                    "user_username": lti_user.user_id
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "status":"liss:Active",
+                                        "role":[
+                                            "urn:lti:role:ims/lis/Learner"
+                                        ],
+                                        "member":{
+                                            "userId": "userId_2"
+                                        },
+                                        "message" : [
+                                            {
+                                                "message_type": "basic-lti-launch-request",
+                                                "lis_result_sourcedid": "1234567890-1",
+                                                "custom" : {
+                                                    "puid": "compair_student_1_puid"
+                                                },
+                                                "ext" : {
+                                                    "user_username": "compair_student_1_username",
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "status":"Active",
+                                        "role":[
+                                            "urn:lti:role:ims/lis/Learner"
+                                        ],
+                                        "member":{
+                                            "userId": "userId_3"
+                                        },
+                                        "message" : [
+                                            {
+                                                "message_type": "basic-lti-launch-request",
+                                                "lis_result_sourcedid": "1234567890-2",
+                                                "custom" : {
+                                                    "puid": "compair_student_2_puid"
+                                                },
+                                                "ext" : {
+                                                    "user_username": "compair_student_2_username",
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "status":"Active",
+                                        "role":[
+                                            "urn:lti:role:ims/lis/TeachingAssistant"
+                                        ],
+                                        "member":{
+                                            "userId":"userId_4"
+                                        },
+                                        "message" : [
+                                            {
+                                                "message_type": "basic-lti-launch-request",
+                                                "lis_result_sourcedid": "1234567890-3",
+                                                "custom" : {
+                                                    "puid": "compair_student_3_puid"
+                                                },
+                                                "ext" : {
+                                                    "user_username": "compair_student_3_username",
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "status":"Active",
+                                        "role":[
+                                            "urn:lti:role:ims/lis/TeachingAssistant"
+                                        ],
+                                        "member":{
+                                            "userId":"userId_5"
+                                        },
+                                        "message" : [
+                                            {
+                                                "message_type": "basic-lti-launch-request",
+                                                "lis_result_sourcedid": "1234567890-4",
+                                                "custom" : {
+                                                    "puid": "compair_instructor_2_puid"
+                                                },
+                                                "ext" : {
+                                                    "user_username": "compair_instructor_2_username",
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "status":"Inactive",
+                                        "role":[
+                                            "urn:lti:role:ims/lis/Learner"
+                                        ],
+                                        "member":{
+                                            "userId": "userId_6"
+                                        },
+                                        "message" : [
+                                            {
+                                                "message_type": "basic-lti-launch-request",
+                                                "lis_result_sourcedid": "1234567890-5",
+                                                "custom" : {
+                                                    "puid": "compair_student_100_puid"
+                                                },
+                                                "ext" : {
+                                                    "user_username": "compair_student_100_username",
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
+                            "@type":"LISMembershipContainer"
+                        }
+                    }
+                elif memberships_url == "https://mockmembershipurl.com?rlid="+lti_resource_link.resource_link_id:
+                    return {
+                        "@id":None,
+                        "@type":"Page",
+                        "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
+                        "differences":None,
+                        "nextPage":None,
+                        "pageOf":{
+                            "membershipPredicate":"http://www.w3.org/ns/org#membership",
+                            "membershipSubject":{
+                                "name":"Test Course",
+                                "@type":"Context",
+                                "contextId":"4dde05e8ca1973bcca9bffc13e1548820eee93a3",
+                                "membership":[
+                                    {
+                                        "status":"Active",
+                                        "role":[
+                                            "urn:lti:role:ims/lis/Instructor"
+                                        ],
+                                        "member":{
+                                            "userId": lti_user.user_id
+                                        },
+                                        "message" : [
+                                            {
+                                                "message_type": "basic-lti-launch-request",
+                                                "lis_result_sourcedid": "lis_result_sourcedid_"+lti_user.user_id,
+                                                "custom" : {
+                                                    "puid": lti_user.user_id
+                                                },
+                                                "ext" : {
+                                                    "user_username": lti_user.user_id
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "status":"liss:Active",
+                                        "role":[
+                                            "urn:lti:role:ims/lis/Learner"
+                                        ],
+                                        "member":{
+                                            "userId": "userId_2"
+                                        },
+                                        "message" : [
+                                            {
+                                                "message_type": "basic-lti-launch-request",
+                                                "lis_result_sourcedid": "lis_result_sourcedid_compair_student_1",
+                                                "custom" : {
+                                                    "puid": "compair_student_1_puid"
+                                                },
+                                                "ext" : {
+                                                    "user_username": "compair_student_1_username",
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "status":"Active",
+                                        "role":[
+                                            "urn:lti:role:ims/lis/Learner"
+                                        ],
+                                        "member":{
+                                            "userId": "userId_3"
+                                        },
+                                        "message" : [
+                                            {
+                                                "message_type": "basic-lti-launch-request",
+                                                "lis_result_sourcedid": "lis_result_sourcedid_compair_student_2",
+                                                "custom" : {
+                                                    "puid": "compair_student_2_puid"
+                                                },
+                                                "ext" : {
+                                                    "user_username": "compair_student_2_username",
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "status":"Active",
+                                        "role":[
+                                            "urn:lti:role:ims/lis/TeachingAssistant"
+                                        ],
+                                        "member":{
+                                            "userId":"userId_4"
+                                        },
+                                        "message" : [
+                                            {
+                                                "message_type": "basic-lti-launch-request",
+                                                "lis_result_sourcedid": "lis_result_sourcedid_compair_student_3",
+                                                "custom" : {
+                                                    "puid": "compair_student_3_puid"
+                                                },
+                                                "ext" : {
+                                                    "user_username": "compair_student_3_username",
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "status":"Active",
+                                        "role":[
+                                            "urn:lti:role:ims/lis/TeachingAssistant"
+                                        ],
+                                        "member":{
+                                            "userId":"userId_5"
+                                        },
+                                        "message" : [
+                                            {
+                                                "message_type": "basic-lti-launch-request",
+                                                "lis_result_sourcedid": "lis_result_sourcedid_compair_instructor_2",
+                                                "custom" : {
+                                                    "puid": "compair_instructor_2_puid"
+                                                },
+                                                "ext" : {
+                                                    "user_username": "compair_instructor_2_username",
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "status":"Inactive",
+                                        "role":[
+                                            "urn:lti:role:ims/lis/Learner"
+                                        ],
+                                        "member":{
+                                            "userId": "userId_6"
+                                        },
+                                        "message" : [
+                                            {
+                                                "message_type": "basic-lti-launch-request",
+                                                "lis_result_sourcedid": "lis_result_sourcedid_compair_student_100",
+                                                "custom" : {
+                                                    "puid": "compair_student_100_puid"
+                                                },
+                                                "ext" : {
+                                                    "user_username": "compair_student_100_username",
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
+                            "@type":"LISMembershipContainer"
+                        }
+                    }
 
             lti_consumer.user_id_override = user_id_override
             db.session.commit()
@@ -927,151 +1348,8 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
                     custom_context_memberships_url="https://mockmembershipurl.com") as rv:
                 self.assert200(rv)
 
-                mocked_get_membership_request.return_value = {
-                    "@id":None,
-                    "@type":"Page",
-                    "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                    "differences":None,
-                    "nextPage":None,
-                    "pageOf":{
-                        "membershipPredicate":"http://www.w3.org/ns/org#membership",
-                        "membershipSubject":{
-                            "name":"Test Course",
-                            "@type":"Context",
-                            "contextId":"4dde05e8ca1973bcca9bffc13e1548820eee93a3",
-                            "membership":[
-                                {
-                                    "status":"Active",
-                                    "role":[
-                                        "urn:lti:role:ims/lis/Instructor"
-                                    ],
-                                    "member":{
-                                        "userId": lti_user.user_id
-                                    },
-                                    "message" : [
-                                        {
-                                            "message_type": "basic-lti-launch-request",
-                                            "lis_result_sourcedid": lti_user.user_id,
-                                            "custom" : {
-                                                "puid": lti_user.user_id
-                                            },
-                                            "ext" : {
-                                                "user_username": lti_user.user_id
-                                            }
-                                        }
-                                    ]
-                                },
-                                {
-                                    "status":"liss:Active",
-                                    "role":[
-                                        "urn:lti:role:ims/lis/Learner"
-                                    ],
-                                    "member":{
-                                        "userId": "userId_2"
-                                    },
-                                    "message" : [
-                                        {
-                                            "message_type": "basic-lti-launch-request",
-                                            "lis_result_sourcedid": "1234567890-1",
-                                            "custom" : {
-                                                "puid": "compair_student_1_puid"
-                                            },
-                                            "ext" : {
-                                                "user_username": "compair_student_1_username",
-                                            }
-                                        }
-                                    ]
-                                },
-                                {
-                                    "status":"Active",
-                                    "role":[
-                                        "urn:lti:role:ims/lis/Learner"
-                                    ],
-                                    "member":{
-                                        "userId": "userId_3"
-                                    },
-                                    "message" : [
-                                        {
-                                            "message_type": "basic-lti-launch-request",
-                                            "lis_result_sourcedid": "1234567890-2",
-                                            "custom" : {
-                                                "puid": "compair_student_2_puid"
-                                            },
-                                            "ext" : {
-                                                "user_username": "compair_student_2_username",
-                                            }
-                                        }
-                                    ]
-                                },
-                                {
-                                    "status":"Active",
-                                    "role":[
-                                        "urn:lti:role:ims/lis/TeachingAssistant"
-                                    ],
-                                    "member":{
-                                        "userId":"userId_4"
-                                    },
-                                    "message" : [
-                                        {
-                                            "message_type": "basic-lti-launch-request",
-                                            "lis_result_sourcedid": "1234567890-3",
-                                            "custom" : {
-                                                "puid": "compair_student_3_puid"
-                                            },
-                                            "ext" : {
-                                                "user_username": "compair_student_3_username",
-                                            }
-                                        }
-                                    ]
-                                },
-                                {
-                                    "status":"Active",
-                                    "role":[
-                                        "urn:lti:role:ims/lis/TeachingAssistant"
-                                    ],
-                                    "member":{
-                                        "userId":"userId_5"
-                                    },
-                                    "message" : [
-                                        {
-                                            "message_type": "basic-lti-launch-request",
-                                            "lis_result_sourcedid": "1234567890-4",
-                                            "custom" : {
-                                                "puid": "compair_instructor_2_puid"
-                                            },
-                                            "ext" : {
-                                                "user_username": "compair_instructor_2_username",
-                                            }
-                                        }
-                                    ]
-                                },
-                                {
-                                    "status":"Inactive",
-                                    "role":[
-                                        "urn:lti:role:ims/lis/Learner"
-                                    ],
-                                    "member":{
-                                        "userId": "userId_6"
-                                    },
-                                    "message" : [
-                                        {
-                                            "message_type": "basic-lti-launch-request",
-                                            "lis_result_sourcedid": "1234567890-5",
-                                            "custom" : {
-                                                "puid": "compair_student_100_puid"
-                                            },
-                                            "ext" : {
-                                                "user_username": "compair_student_100_username",
-                                            }
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                        "@type":"LISMembershipContainer"
-                    }
-                }
+                mocked_get_membership_request.reset_mock()
+                mocked_get_membership_request.side_effect = user_id_override_membership_requests
 
                 # link course
                 rv = self.client.post(url, data={}, content_type='application/json')
@@ -1110,180 +1388,114 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
         db.session.commit()
 
         def paginated_membership_requests(memberships_url, headers=None):
+            result = {
+                "@id":None,
+                "@type":"Page",
+                "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
+                "differences":None,
+                "nextPage": None, #fill in
+                "pageOf":{
+                    "membershipPredicate":"http://www.w3.org/ns/org#membership",
+                    "membershipSubject":{
+                        "name":"Test Course",
+                        "@type":"Context",
+                        "contextId":"4dde05e8ca1973bcca9bffc13e1548820eee93a3",
+                        "membership":[
+                            {
+                                "status":"Active",
+                                "role":[], #fill in
+                                "member":{
+                                    "userId": None #fill in
+                                }
+                            }
+                        ]
+                    },
+                    "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
+                    "@type":"LISMembershipContainer"
+                }
+            }
+            result_launch_message = {
+                "message_type" : "basic-lti-launch-request",
+                "lis_result_sourcedid" : None #fill in
+            }
+            rlid = lti_resource_link.resource_link_id
+
             if memberships_url == "https://mockmembershipurl.com":
-                return {
-                    "@id":None,
-                    "@type":"Page",
-                    "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                    "differences":None,
-                    "nextPage":"https://mockmembershipurl.com?page=2&per_page=1",
-                    "pageOf":{
-                        "membershipPredicate":"http://www.w3.org/ns/org#membership",
-                        "membershipSubject":{
-                            "name":"Test Course",
-                            "@type":"Context",
-                            "contextId":"4dde05e8ca1973bcca9bffc13e1548820eee93a3",
-                            "membership":[
-                                {
-                                    "status":"Active",
-                                    "role":[
-                                        "urn:lti:role:ims/lis/Instructor"
-                                    ],
-                                    "member":{
-                                        "userId":lti_user.user_id
-                                    }
-                                }
-                            ]
-                        },
-                        "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                        "@type":"LISMembershipContainer"
-                    }
-                }
+                result['nextPage'] = "https://mockmembershipurl.com?page=2&per_page=1"
+                result['pageOf']['membershipSubject']['membership'][0]['role'] = ["urn:lti:role:ims/lis/Instructor"]
+                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = lti_user.user_id
+
+            elif memberships_url == "https://mockmembershipurl.com?rlid="+rlid:
+                result['nextPage'] = "https://mockmembershipurl.com?rlid="+rlid+"&page=2&per_page=1"
+                result['pageOf']['membershipSubject']['membership'][0]['role'] = ["urn:lti:role:ims/lis/Instructor"]
+                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = lti_user.user_id
+                result_launch_message['lis_result_sourcedid'] = "lis_result_sourcedid_"+lti_user.user_id
+                result['pageOf']['membershipSubject']['membership'][0]['message'] = [result_launch_message]
+
             elif memberships_url == "https://mockmembershipurl.com?page=2&per_page=1":
-                return {
-                    "@id":None,
-                    "@type":"Page",
-                    "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                    "differences":None,
-                    "nextPage":"https://mockmembershipurl.com?page=3&per_page=1",
-                    "pageOf":{
-                        "membershipPredicate":"http://www.w3.org/ns/org#membership",
-                        "membershipSubject":{
-                            "name":"Test Course",
-                            "@type":"Context",
-                            "contextId":"4dde05e8ca1973bcca9bffc13e1548820eee93a3",
-                            "membership":[
-                                {
-                                    "status":"liss:Active",
-                                    "role":[
-                                        "urn:lti:role:ims/lis/Learner"
-                                    ],
-                                    "member":{
-                                        "userId":"compair_student_1"
-                                    }
-                                }
-                            ]
-                        },
-                        "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                        "@type":"LISMembershipContainer"
-                    }
-                }
+                result['nextPage'] = "https://mockmembershipurl.com?page=3&per_page=1"
+                result['pageOf']['membershipSubject']['membership'][0]['role'] = ["urn:lti:role:ims/lis/Learner"]
+                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = "compair_student_1"
+
+            elif memberships_url == "https://mockmembershipurl.com?rlid="+rlid+"&page=2&per_page=1":
+                result['nextPage'] = "https://mockmembershipurl.com?rlid="+rlid+"&page=3&per_page=1"
+                result['pageOf']['membershipSubject']['membership'][0]['role'] = ["urn:lti:role:ims/lis/Learner"]
+                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = "compair_student_1"
+                result_launch_message['lis_result_sourcedid'] = "lis_result_sourcedid_compair_student_1"
+                result['pageOf']['membershipSubject']['membership'][0]['message'] = [result_launch_message]
+
             elif memberships_url == "https://mockmembershipurl.com?page=3&per_page=1":
-                return {
-                    "@id":None,
-                    "@type":"Page",
-                    "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                    "differences":None,
-                    "nextPage":"https://mockmembershipurl.com?page=4&per_page=1",
-                    "pageOf":{
-                        "membershipPredicate":"http://www.w3.org/ns/org#membership",
-                        "membershipSubject":{
-                            "name":"Test Course",
-                            "@type":"Context",
-                            "contextId":"4dde05e8ca1973bcca9bffc13e1548820eee93a3",
-                            "membership":[
-                                {
-                                    "status":"Active",
-                                    "role":[
-                                        "urn:lti:role:ims/lis/Learner"
-                                    ],
-                                    "member":{
-                                        "userId":"compair_student_2"
-                                    }
-                                }
-                            ]
-                        },
-                        "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                        "@type":"LISMembershipContainer"
-                    }
-                }
+                result['nextPage'] = "https://mockmembershipurl.com?page=4&per_page=1"
+                result['pageOf']['membershipSubject']['membership'][0]['role'] = ["urn:lti:role:ims/lis/Instructor"]
+                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = "compair_student_2"
+
+            elif memberships_url == "https://mockmembershipurl.com?rlid="+rlid+"&page=3&per_page=1":
+                result['nextPage'] = "https://mockmembershipurl.com?rlid="+rlid+"&page=4&per_page=1"
+                result['pageOf']['membershipSubject']['membership'][0]['role'] = ["urn:lti:role:ims/lis/Instructor"]
+                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = "compair_student_2"
+                result_launch_message['lis_result_sourcedid'] = "lis_result_sourcedid_compair_student_2"
+                result['pageOf']['membershipSubject']['membership'][0]['message'] = [result_launch_message]
+
             elif memberships_url == "https://mockmembershipurl.com?page=4&per_page=1":
-                return {
-                    "@id":None,
-                    "@type":"Page",
-                    "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                    "differences":None,
-                    "nextPage":"https://mockmembershipurl.com?page=5&per_page=1",
-                    "pageOf":{
-                        "membershipPredicate":"http://www.w3.org/ns/org#membership",
-                        "membershipSubject":{
-                            "name":"Test Course",
-                            "@type":"Context",
-                            "contextId":"4dde05e8ca1973bcca9bffc13e1548820eee93a3",
-                            "membership":[
-                                {
-                                    "status":"Active",
-                                    "role":[
-                                        "urn:lti:role:ims/lis/TeachingAssistant"
-                                    ],
-                                    "member":{
-                                        "userId":"compair_student_3"
-                                    }
-                                }
-                            ]
-                        },
-                        "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                        "@type":"LISMembershipContainer"
-                    }
-                }
+                result['nextPage'] = "https://mockmembershipurl.com?page=5&per_page=1"
+                result['pageOf']['membershipSubject']['membership'][0]['role'] = ["urn:lti:role:ims/lis/TeachingAssistant"]
+                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = "compair_student_3"
+
+            elif memberships_url == "https://mockmembershipurl.com?rlid="+rlid+"&page=4&per_page=1":
+                result['nextPage'] = "https://mockmembershipurl.com?rlid="+rlid+"&page=5&per_page=1"
+                result['pageOf']['membershipSubject']['membership'][0]['role'] = ["urn:lti:role:ims/lis/TeachingAssistant"]
+                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = "compair_student_3"
+                result_launch_message['lis_result_sourcedid'] = "lis_result_sourcedid_compair_student_3"
+                result['pageOf']['membershipSubject']['membership'][0]['message'] = [result_launch_message]
+
             elif memberships_url == "https://mockmembershipurl.com?page=5&per_page=1":
-                return {
-                    "@id":None,
-                    "@type":"Page",
-                    "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                    "differences":None,
-                    "nextPage":"https://mockmembershipurl.com?page=6&per_page=1",
-                    "pageOf":{
-                        "membershipPredicate":"http://www.w3.org/ns/org#membership",
-                        "membershipSubject":{
-                            "name":"Test Course",
-                            "@type":"Context",
-                            "contextId":"4dde05e8ca1973bcca9bffc13e1548820eee93a3",
-                            "membership":[
-                                {
-                                    "status":"Active",
-                                    "role":[
-                                        "urn:lti:role:ims/lis/TeachingAssistant"
-                                    ],
-                                    "member":{
-                                        "userId":"compair_instructor_2"
-                                    }
-                                }
-                            ]
-                        },
-                        "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                        "@type":"LISMembershipContainer"
-                    }
-                }
+                result['nextPage'] = "https://mockmembershipurl.com?page=6&per_page=1"
+                result['pageOf']['membershipSubject']['membership'][0]['role'] = ["urn:lti:role:ims/lis/TeachingAssistant"]
+                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = "compair_instructor_2"
+
+            elif memberships_url == "https://mockmembershipurl.com?rlid="+rlid+"&page=5&per_page=1":
+                result['nextPage'] = "https://mockmembershipurl.com?rlid="+rlid+"&page=6&per_page=1"
+                result['pageOf']['membershipSubject']['membership'][0]['role'] = ["urn:lti:role:ims/lis/TeachingAssistant"]
+                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = "compair_instructor_2"
+                result_launch_message['lis_result_sourcedid'] = "lis_result_sourcedid_compair_instructor_2"
+                result['pageOf']['membershipSubject']['membership'][0]['message'] = [result_launch_message]
+
             elif memberships_url == "https://mockmembershipurl.com?page=6&per_page=1":
-                return {
-                    "@id":None,
-                    "@type":"Page",
-                    "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                    "differences":None,
-                    "nextPage":None,
-                    "pageOf":{
-                        "membershipPredicate":"http://www.w3.org/ns/org#membership",
-                        "membershipSubject":{
-                            "name":"Test Course",
-                            "@type":"Context",
-                            "contextId":"4dde05e8ca1973bcca9bffc13e1548820eee93a3",
-                            "membership":[
-                                {
-                                    "status":"Inactive",
-                                    "role":[
-                                        "urn:lti:role:ims/lis/Learner"
-                                    ],
-                                    "member":{
-                                        "userId":"compair_student_100"
-                                    }
-                                }
-                            ]
-                        },
-                        "@context":"http://purl.imsglobal.org/ctx/lis/v2/MembershipContainer",
-                        "@type":"LISMembershipContainer"
-                    }
-                }
+                result['nextPage'] = None
+                result['pageOf']['membershipSubject']['membership'][0]['status'] = "Inactive"
+                result['pageOf']['membershipSubject']['membership'][0]['role'] = ["urn:lti:role:ims/lis/Learner"]
+                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = "compair_student_100"
+
+            elif memberships_url == "https://mockmembershipurl.com?rlid="+rlid+"&page=6&per_page=1":
+                result['nextPage'] = None
+                result['pageOf']['membershipSubject']['membership'][0]['status'] = "Inactive"
+                result['pageOf']['membershipSubject']['membership'][0]['role'] = ["urn:lti:role:ims/lis/Learner"]
+                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = "compair_student_100"
+                result_launch_message['lis_result_sourcedid'] = "lis_result_sourcedid_compair_student_100"
+                result['pageOf']['membershipSubject']['membership'][0]['message'] = [result_launch_message]
+
+            return result
+
         mocked_get_membership_request.reset_mock()
         mocked_get_membership_request.side_effect = paginated_membership_requests
 
@@ -1297,7 +1509,7 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
             rv = self.client.post(url, data={}, content_type='application/json')
             self.assert200(rv)
 
-            self.assertEqual(mocked_get_membership_request.call_count, 6)
+            self.assertEqual(mocked_get_membership_request.call_count, 12)
 
             # 5 members in minimal_membership (all old users besides instructor should be dropped)
 


### PR DESCRIPTION
membership service will fetch all members and then make additional fetches for each known resource link (in order to get lis_result_sourcedid for each user & resource link combination)
membership extension will still not handle lis_result_sourcedid as there is no resource link id to identify the context fully