### PR TITLE
Fix gulp-clean-css

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ env:
 
 prod:
 	$(DOCKERRUN_PY) pip install -r requirements.txt
-	$(DOCKERRUN_NODE) npm install --production
+	$(DOCKERRUN_NODE) npm install
 	$(DOCKERRUN_NODE) node_modules/gulp/bin/gulp.js
 	$(DOCKERRUN_NODE) node_modules/gulp/bin/gulp.js prod
 

--- a/bower.json
+++ b/bower.json
@@ -54,20 +54,6 @@
       "main": [
         "dist/css/bootstrap.css"
       ]
-    },
-    "highlightjs": {
-      "main": [
-          "highlight.pack.js",
-          "styles/foundation.css"
-      ]
-    },
-    "chosen": {
-      "main": [
-        "chosen.jquery.js",
-        "chosen.css",
-        "chosen-sprite.png",
-        "chosen-sprite@2x.png"
-      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "gulp": "latest",
     "gulp-angular-templatecache": "^1.9.1",
     "gulp-bower": "latest",
-    "gulp-clean-css": "latest",
     "gulp-concat": "latest",
     "gulp-concat-vendor": "latest",
     "gulp-connect": "latest",
@@ -24,6 +23,7 @@
     "less": "latest",
     "main-bower-files": "latest",
     "proxy-middleware": "latest",
+    "gulp-clean-css": "~3.0.4",
     "streamqueue": "^1.1.1",
     "wiredep": "latest"
   },


### PR DESCRIPTION
Latest version of gulp-clean-css or clean-css handles asset urls differently which caused chosen's look for its sprite in ../../../chosen/chosen-sprite.png instead of in same folder

Closes #567 