### PR TITLE
Fix LTI new course permissions issue

### DIFF
--- a/compair/static/modules/course/course-module.js
+++ b/compair/static/modules/course/course-module.js
@@ -227,9 +227,8 @@ module.controller(
             CourseResource.save({}, $scope.course, function (ret) {
                 Toaster.success("Course Saved");
                 // refresh permissions
-                Session.refresh().then(function() {
-                    $scope.selectCourse(ret.id);
-                });
+                Session.expirePermissions();
+                $scope.selectCourse(ret.id);
             }).$promise.finally(function() {
                 $scope.submitted = false;
             });

--- a/compair/static/modules/lti/lti-module.js
+++ b/compair/static/modules/lti/lti-module.js
@@ -121,6 +121,8 @@ module.controller("LTIController",
                 modalInstance.result.then(function (selectedCourseId) {
                     LTIResource.linkCourse({id: selectedCourseId}, {},
                         function(ret) {
+                            // refresh permissions
+                            Session.expirePermissions();
                             Toaster.success("Course Linked", "Successfully linked your course as requested.");
                             // reload to refresh status and check what to do next
                             $route.reload();


### PR DESCRIPTION
course permissions where not being properly refreshed on the front-end after adding a new course.

Closes #590