### PR TITLE
Upgrade lti user system roles automatically

### DIFF
--- a/compair/api/login.py
+++ b/compair/api/login.py
@@ -39,7 +39,8 @@ def login():
 
         if sess.get('LTI') and sess.get('oauth_create_user_link'):
             lti_user = LTIUser.query.get_or_404(sess['lti_user'])
-            lti_user.compair_user_id = user.id
+            lti_user.compair_user = user
+            lti_user.upgrade_system_role()
             sess.pop('oauth_create_user_link')
 
         if sess.get('LTI') and sess.get('lti_context') and sess.get('lti_user_resource_link'):
@@ -155,7 +156,8 @@ def cas_auth():
 
                 if sess.get('LTI') and sess.get('oauth_create_user_link'):
                     lti_user = LTIUser.query.get_or_404(sess['lti_user'])
-                    lti_user.compair_user_id = thirdpartyuser.user_id
+                    lti_user.compair_user = thirdpartyuser.user
+                    lti_user.upgrade_system_role()
                     sess.pop('oauth_create_user_link')
 
                 if sess.get('LTI') and sess.get('lti_context') and sess.get('lti_user_resource_link'):

--- a/compair/api/lti_launch.py
+++ b/compair/api/lti_launch.py
@@ -86,6 +86,9 @@ class LTIAuthAPI(Resource):
                 if lti_user.is_linked_to_user():
                     authenticate(lti_user.compair_user, login_method='LTI')
 
+                    # upgrade user system role if needed
+                    lti_user.upgrade_system_role()
+
                     # create/update enrollment if context exists
                     if lti_context and lti_context.is_linked_to_course():
                         lti_context.update_enrolment(lti_user.compair_user_id, lti_user_resource_link.course_role)

--- a/compair/models/lti_models/lti_user.py
+++ b/compair/models/lti_models/lti_user.py
@@ -55,7 +55,7 @@ class LTIUser(DefaultTableMixin, WriteTrackingMixin):
             lti_user = LTIUser(
                 lti_consumer_id=lti_consumer.id,
                 user_id=tool_provider.user_id,
-                system_role= SystemRole.instructor  \
+                system_role=SystemRole.instructor  \
                     if tool_provider.is_instructor() \
                     else SystemRole.student
             )
@@ -69,6 +69,16 @@ class LTIUser(DefaultTableMixin, WriteTrackingMixin):
         db.session.commit()
 
         return lti_user
+
+    def upgrade_system_role(self):
+        # upgrade system role is needed
+        if self.is_linked_to_user():
+            if self.compair_user.system_role == SystemRole.student and self.system_role in [SystemRole.instructor, SystemRole.sys_admin]:
+                self.compair_user.system_role = self.system_role
+            elif self.compair_user.system_role == SystemRole.instructor and self.system_role == SystemRole.sys_admin:
+                self.compair_user.system_role = self.system_role
+
+            db.session.commit()
 
     @classmethod
     def __declare_last__(cls):


### PR DESCRIPTION
- Upgrade user's system role when launching an LTI request (system roles only gain more permission, never lose permissions)
- Upgrade user's system role when linking an LTI account to an existing account (CAS or App login)

Closes #589 (issue was caused by instructor having the student system role. this will force proper system roles when launching lti requests)