### PR TITLE
Handle unicode in cas and lti membership

### DIFF
--- a/compair/models/lti_models/lti_membership.py
+++ b/compair/models/lti_models/lti_membership.py
@@ -265,7 +265,7 @@ class LTIMembership(DefaultTableMixin, WriteTrackingMixin):
         params = parse_qs(signed_request.body.decode('utf-8'))
 
         data = LTIMembership._post_membership_request(memberships_url, params)
-        root = ElementTree.fromstring(data)
+        root = ElementTree.fromstring(data.encode('utf-8'))
 
         codemajor = root.find('statusinfo/codemajor')
         if codemajor is not None and codemajor.text in ['Failure', 'Unsupported']:

--- a/compair/tests/api/test_lti_launch.py
+++ b/compair/tests/api/test_lti_launch.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import json
 import mock
 
@@ -698,7 +700,7 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
                     <roles>Learner</roles>
                     </member>
                     <member>
-                    <user_id>compair_student_3</user_id>
+                    <user_id>compair_student_3è</user_id>
                     <roles>TeachingAssistant</roles>
                     </member>
                     <member>
@@ -731,7 +733,7 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
             self.assertEqual(len(lti_memberships), 5)
             for lti_membership in lti_memberships:
                 self.assertIn(lti_membership.lti_user.user_id, [lti_user.user_id, "compair_student_1", "compair_student_2",
-                    "compair_student_3", "compair_instructor_2"])
+                    "compair_student_3è", "compair_instructor_2"])
 
         # test successful membership response (with user_id_override)
         with self.lti_launch(lti_consumer, lti_resource_link.resource_link_id,
@@ -765,9 +767,9 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
                     <custom_puid>compair_student_2</custom_puid>
                     </member>
                     <member>
-                    <user_id>ignore_4</user_id>
+                    <user_id>ignore_4è</user_id>
                     <roles>TeachingAssistant</roles>
-                    <custom_puid>compair_student_3</custom_puid>
+                    <custom_puid>compair_student_3è</custom_puid>
                     </member>
                     <member>
                     <user_id>ignore_5</user_id>
@@ -800,7 +802,7 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
             self.assertEqual(len(lti_memberships), 5)
             for lti_membership in lti_memberships:
                 self.assertIn(lti_membership.lti_user.user_id, [lti_user.user_id, "compair_student_1", "compair_student_2",
-                    "compair_student_3", "compair_instructor_2"])
+                    "compair_student_3è", "compair_instructor_2"])
 
 
     @mock.patch('compair.models.lti_models.lti_membership.LTIMembership._get_membership_request')
@@ -903,7 +905,7 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
                                         "urn:lti:role:ims/lis/TeachingAssistant"
                                     ],
                                     "member":{
-                                        "userId":"compair_student_3"
+                                        "userId":"compair_student_3è"
                                     }
                                 },
                                 {
@@ -995,11 +997,11 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
                                         "urn:lti:role:ims/lis/TeachingAssistant"
                                     ],
                                     "member":{
-                                        "userId":"compair_student_3"
+                                        "userId":"compair_student_3è"
                                     },
                                     "message": [{
                                         "message_type": "basic-lti-launch-request",
-                                        "lis_result_sourcedid": "lis_result_sourcedid_compair_student_3"
+                                        "lis_result_sourcedid": "lis_result_sourcedid_compair_student_3è"
                                     },{
                                         "message_type": "other-message-type"
                                     }]
@@ -1076,7 +1078,7 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
             self.assertEqual(len(lti_memberships), 5)
             for lti_membership in lti_memberships:
                 self.assertIn(lti_membership.lti_user.user_id, [lti_user.user_id, "compair_student_1", "compair_student_2",
-                    "compair_student_3", "compair_instructor_2"])
+                    "compair_student_3è", "compair_instructor_2"])
 
                 # ensure the lti_user_resource_link is generated and stores the lis_result_sourcedid
                 lti_user_resource_links = [lti_user_resource_link \
@@ -1180,10 +1182,10 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
                                                 "message_type": "basic-lti-launch-request",
                                                 "lis_result_sourcedid": "1234567890-3",
                                                 "custom" : {
-                                                    "puid": "compair_student_3_puid"
+                                                    "puid": "compair_student_3è_puid"
                                                 },
                                                 "ext" : {
-                                                    "user_username": "compair_student_3_username",
+                                                    "user_username": "compair_student_3è_username",
                                                 }
                                             }
                                         ]
@@ -1324,12 +1326,12 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
                                         "message" : [
                                             {
                                                 "message_type": "basic-lti-launch-request",
-                                                "lis_result_sourcedid": "lis_result_sourcedid_compair_student_3",
+                                                "lis_result_sourcedid": "lis_result_sourcedid_compair_student_3è",
                                                 "custom" : {
-                                                    "puid": "compair_student_3_puid"
+                                                    "puid": "compair_student_3è_puid"
                                                 },
                                                 "ext" : {
-                                                    "user_username": "compair_student_3_username",
+                                                    "user_username": "compair_student_3è_username",
                                                 }
                                             }
                                         ]
@@ -1420,10 +1422,10 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
                         self.assertIn(lti_membership.lti_user.user_id, [lti_user.user_id, "userId_2", "userId_3", "userId_4", "userId_5"])
                     elif user_id_override == "custom_puid":
                         self.assertIn(lti_membership.lti_user.user_id, [lti_user.user_id, "compair_student_1_puid", "compair_student_2_puid",
-                            "compair_student_3_puid", "compair_instructor_2_puid"])
+                            "compair_student_3è_puid", "compair_instructor_2_puid"])
                     elif user_id_override == "ext_user_username":
                         self.assertIn(lti_membership.lti_user.user_id, [lti_user.user_id, "compair_student_1_username", "compair_student_2_username",
-                            "compair_student_3_username", "compair_instructor_2_username"])
+                            "compair_student_3è_username", "compair_instructor_2_username"])
                     elif user_id_override == "lis_result_sourcedid":
                         self.assertIn(lti_membership.lti_user.user_id, [lti_user.user_id, "1234567890-1", "1234567890-2",
                             "1234567890-3", "1234567890-4"])
@@ -1503,13 +1505,13 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
             elif memberships_url == "https://mockmembershipurl.com?page=4&per_page=1":
                 result['nextPage'] = "https://mockmembershipurl.com?page=5&per_page=1"
                 result['pageOf']['membershipSubject']['membership'][0]['role'] = ["urn:lti:role:ims/lis/TeachingAssistant"]
-                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = "compair_student_3"
+                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = "compair_student_3è"
 
             elif memberships_url == "https://mockmembershipurl.com?rlid="+rlid+"&page=4&per_page=1":
                 result['nextPage'] = "https://mockmembershipurl.com?rlid="+rlid+"&page=5&per_page=1"
                 result['pageOf']['membershipSubject']['membership'][0]['role'] = ["urn:lti:role:ims/lis/TeachingAssistant"]
-                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = "compair_student_3"
-                result_launch_message['lis_result_sourcedid'] = "lis_result_sourcedid_compair_student_3"
+                result['pageOf']['membershipSubject']['membership'][0]['member']['userId'] = "compair_student_3è"
+                result_launch_message['lis_result_sourcedid'] = "lis_result_sourcedid_compair_student_3è"
                 result['pageOf']['membershipSubject']['membership'][0]['message'] = [result_launch_message]
 
             elif memberships_url == "https://mockmembershipurl.com?page=5&per_page=1":
@@ -1573,7 +1575,7 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
             self.assertEqual(len(lti_memberships), 5)
             for lti_membership in lti_memberships:
                 self.assertIn(lti_membership.lti_user.user_id, [lti_user.user_id, "compair_student_1", "compair_student_2",
-                    "compair_student_3", "compair_instructor_2"])
+                    "compair_student_3è", "compair_instructor_2"])
 
     @mock.patch('compair.models.lti_models.lti_membership.LTIMembership._post_membership_request')
     def test_lti_membership_for_consumer_with_membership_ext(self, mocked_post_membership_request):
@@ -1694,11 +1696,11 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
                     <lis_result_sourcedid>:_676_1::compai:compair_student_2</lis_result_sourcedid>
                     </member>
                     <member>
-                    <user_id>compair_student_3</user_id>
+                    <user_id>compair_student_3è</user_id>
                     <user_image>http://www.gravatar.com/avatar/4</user_image>
                     <roles>TeachingAssistant</roles>
-                    <person_sourcedid>compair_student_3</person_sourcedid>
-                    <person_contact_email_primary>compair_student_3@test.com</person_contact_email_primary>
+                    <person_sourcedid>compair_student_3è</person_sourcedid>
+                    <person_contact_email_primary>compair_student_3è@test.com</person_contact_email_primary>
                     <person_name_given>Student</person_name_given>
                     <person_name_family>Six</person_name_family>
                     <person_name_full>Student Six</person_name_full>
@@ -1739,7 +1741,7 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
             self.assertEqual(len(lti_memberships), 5)
             for lti_membership in lti_memberships:
                 self.assertIn(lti_membership.lti_user.user_id, [lti_user_instructor.user_id, lti_user_student_1.user_id,
-                    "compair_student_2", "compair_student_3", "compair_instructor_2"])
+                    "compair_student_2", "compair_student_3è", "compair_instructor_2"])
 
             # test minimual membership response
             mocked_post_membership_request.return_value = """
@@ -1765,7 +1767,7 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
                     <roles>Learner</roles>
                     </member>
                     <member>
-                    <user_id>compair_student_3</user_id>
+                    <user_id>compair_student_3è</user_id>
                     <roles>TeachingAssistant</roles>
                     </member>
                     <member>
@@ -1798,7 +1800,7 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
             self.assertEqual(len(lti_memberships), 5)
             for lti_membership in lti_memberships:
                 self.assertIn(lti_membership.lti_user.user_id, [lti_user_instructor.user_id, lti_user_student_1.user_id,
-                    "compair_student_2", "compair_student_3", "compair_instructor_2"])
+                    "compair_student_2", "compair_student_3è", "compair_instructor_2"])
 
 
             # test ensure current user is not unenrolled from course on membership fetch
@@ -1993,12 +1995,12 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
                                     "@id":None,
                                     "name":"Student Six",
                                     "img":"http://www.gravatar.com/avatar/4",
-                                    "email":"compair_student_3@test.com",
+                                    "email":"compair_student_3è@test.com",
                                     "familyName":"Six",
                                     "givenName":"Student",
                                     "resultSourcedId":None,
-                                    "sourcedId":"compair_student_3",
-                                    "userId":"compair_student_3"
+                                    "sourcedId":"compair_student_3è",
+                                    "userId":"compair_student_3è"
                                 }
                             },
                             {
@@ -2067,7 +2069,7 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
             self.assertEqual(len(lti_memberships), 5)
             for lti_membership in lti_memberships:
                 self.assertIn(lti_membership.lti_user.user_id, [lti_user_instructor.user_id, lti_user_student_1.user_id,
-                    "compair_student_2", "compair_student_3", "compair_instructor_2", "compair_student_100"])
+                    "compair_student_2", "compair_student_3è", "compair_instructor_2", "compair_student_100"])
 
             # test minimual membership response
             mocked_get_membership_request.return_value = {
@@ -2116,7 +2118,7 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
                                 "urn:lti:role:ims/lis/TeachingAssistant"
                             ],
                             "member":{
-                                "userId":"compair_student_3"
+                                "userId":"compair_student_3è"
                             }
                             },
                             {
@@ -2166,7 +2168,7 @@ class LTILaunchAPITests(ComPAIRAPITestCase):
             self.assertEqual(len(lti_memberships), 5)
             for lti_membership in lti_memberships:
                 self.assertIn(lti_membership.lti_user.user_id, [lti_user_instructor.user_id, lti_user_student_1.user_id,
-                    "compair_student_2", "compair_student_3", "compair_instructor_2"])
+                    "compair_student_2", "compair_student_3è", "compair_instructor_2"])
 
 
             # test ensure current user is not unenrolled from course on membership fetch


### PR DESCRIPTION
CAS library overrides should be handled better in the future