### PR TITLE
Fix back button issue after save draft

### DIFF
--- a/compair/static/modules/answer/answer-module.js
+++ b/compair/static/modules/answer/answer-module.js
@@ -240,6 +240,7 @@ module.controller(
                     if (ret.draft) {
                         Toaster.success("Answer Draft Saved", "Remember to submit your answer before the deadline.");
                         $location.path('/course/' + $scope.courseId + '/assignment/' + $scope.assignmentId + '/answer/' + $scope.answer.id + '/edit');
+                        $location.replace();
                     } else {
                         Toaster.success("Answer Submitted");
                         $location.path('/course/' + $scope.courseId + '/assignment/' +$scope.assignmentId);


### PR DESCRIPTION
When a user click the browser back button after saving an answer as draft, the user will be on the "new answer" page and get a warning message.

Replace the browser history so the back button will bring user back to the page before entering the answer page.

Closes #615 
