### PR TITLE
Fix answer criterion stats

### DIFF
--- a/compair/manage/score.py
+++ b/compair/manage/score.py
@@ -1,0 +1,26 @@
+"""
+    Recalculate Scores
+"""
+
+from flask_script import Manager, prompt_bool
+from compair.models import Comparison, Assignment
+
+
+manager = Manager(usage="Recalculate Assignment Answer Scores")
+
+
+@manager.option('-a', '--assignment', dest='assignment_id', help='Specify a Assignment ID to generate report from.')
+def recalculate(assignment_id):
+    if not assignment_id:
+        raise RuntimeError("Assignment with ID {} is not found.".format(assignment_id))
+
+    assignment = Assignment.query.filter_by(id=assignment_id).first()
+    if not assignment:
+        raise RuntimeError("Assignment with ID {} is not found.".format(assignment_id))
+
+    if prompt_bool("""All current answer scores and anwer criterion scores will be overwritten.
+Final scores may differ slightly due to floating point rounding (especially if recalculating on different systems).
+Are you sure?"""):
+        print ('Recalculating scores...')
+        Comparison.calculate_scores(assignment.id)
+        print ('Recalculate scores successful.')

--- a/compair/tests/api/test_assignment.py
+++ b/compair/tests/api/test_assignment.py
@@ -567,7 +567,7 @@ class AssignmentEditComparedAPITests(ComPAIRAPITestCase):
             submit_count += 1
             db.session.commit()
 
-            Comparison.calculate_scores(self.assignment.id)
+            Comparison.update_scores_1vs1(comparison)
         return submit_count
 
     def test_edit_compared_assignment(self):
@@ -677,7 +677,7 @@ class AssignmentStatusComparisonsAPITests(ComPAIRAPITestCase):
             submit_count += 1
             db.session.commit()
 
-            Comparison.calculate_scores(self.assignment.id)
+            Comparison.update_scores_1vs1(comparison)
         return submit_count
 
     def test_get_all_status(self):

--- a/compair/tests/api/test_users.py
+++ b/compair/tests/api/test_users.py
@@ -1125,7 +1125,7 @@ class UsersCourseStatusAPITests(ComPAIRAPITestCase):
             submit_count += 1
             db.session.commit()
 
-            Comparison.calculate_scores(assignment.id)
+            Comparison.update_scores_1vs1(comparison)
         return submit_count
 
     def test_get_course_list(self):

--- a/manage.py
+++ b/manage.py
@@ -6,6 +6,7 @@ from flask_script import Manager, Server
 from compair.manage.database import manager as database_manager
 from compair.manage.report import manager as report_generator
 from compair.manage.grades import manager as grades_generator
+from compair.manage.score import manager as score_generator
 from compair.manage.user import manager as user_manager
 from compair.manage.utils import manager as util_manager
 from compair import create_app
@@ -15,6 +16,7 @@ manager = Manager(create_app)
 manager.add_command("database", database_manager)
 manager.add_command("report", report_generator)
 manager.add_command("grades", grades_generator)
+manager.add_command("score", score_generator)
 manager.add_command("runserver", Server(port=8080))
 manager.add_command("user", user_manager)
 manager.add_command("util", util_manager)


### PR DESCRIPTION
Answer criterion wins, loses, opponents, and round counts were not incrementing properly
Also added a new management function for recalculating scores
Note: this doesn't really effect anything besides reporting