### PR TITLE
Allow comparison of instructor answers

### DIFF
--- a/alembic/versions/2561c39ac4d9_allow_instructor_answers_to_be_included_.py
+++ b/alembic/versions/2561c39ac4d9_allow_instructor_answers_to_be_included_.py
@@ -1,0 +1,53 @@
+"""Allow instructor answers to be included in comparisons
+
+Revision ID: 2561c39ac4d9
+Revises: f6145781f130
+Create Date: 2017-12-06 21:07:23.219244
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2561c39ac4d9'
+down_revision = 'f6145781f130'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+
+from compair.models import convention
+
+def upgrade():
+    # add a new "comparable" column. default as true
+    with op.batch_alter_table('answer', naming_convention=convention) as batch_op:
+        batch_op.add_column(sa.Column('comparable', sa.Integer(), nullable=False, default='1', server_default='1'))
+
+    # Patch existing answers from instructors and TAs as non-comparable.
+    # Note that existing answers from sys admin are considered comparable (i.e. no need to patch).
+    # sqlite doesn't support in-clause with multiple columns...
+    # update = text(
+    #     "UPDATE answer SET comparable = 0 "
+    #     "WHERE (assignment_id, user_id) IN ( "
+    #     "  SELECT a.id, uc.user_id "
+    #     "  FROM user_course uc "
+    #     "  JOIN assignment a "
+    #     "    ON a.course_id = uc.course_id "
+    #     "  WHERE uc.course_role IN ('Instructor', 'Teaching Assistant'))"
+    # )
+    # ... use a potentially slower query
+    update = text(
+        "UPDATE answer SET comparable = 0 "
+        "WHERE EXISTS ( "
+        "  SELECT 1 "
+        "  FROM user_course "
+        "  JOIN assignment "
+        "    ON assignment.course_id = user_course.course_id "
+        "  WHERE "
+        "    assignment.id = answer.assignment_id "
+        "    AND user_course.user_id = answer.user_id "
+        "    AND user_course.course_role IN ('Instructor', 'Teaching Assistant'))"
+    )
+    op.get_bind().execute(update)
+
+def downgrade():
+    with op.batch_alter_table('answer', naming_convention=convention) as batch_op:
+        batch_op.drop_column('comparable')

--- a/compair/api/assignment.py
+++ b/compair/api/assignment.py
@@ -484,8 +484,8 @@ class AssignmentIdStatusAPI(Resource):
 
         comparison_count = assignment.completed_comparison_count_for_user(current_user.id)
         comparison_draft_count = assignment.draft_comparison_count_for_user(current_user.id)
-        other_student_answers = assignment.student_answer_count - answer_count
-        comparison_available = comparison_count < other_student_answers * (other_student_answers - 1) / 2
+        other_comparable_answers = assignment.comparable_answer_count - answer_count
+        comparison_available = comparison_count < other_comparable_answers * (other_comparable_answers - 1) / 2
 
         status = {
             'answers': {
@@ -659,8 +659,8 @@ class AssignmentRootStatusAPI(Resource):
             assignment_drafts = [draft for draft in drafts if draft.assignment_id == assignment.id]
             comparison_count = assignment.completed_comparison_count_for_user(current_user.id)
             comparison_draft_count = assignment.draft_comparison_count_for_user(current_user.id)
-            other_student_answers = assignment.student_answer_count - answer_count
-            comparison_available = comparison_count < other_student_answers * (other_student_answers - 1) / 2
+            other_comparable_answers = assignment.comparable_answer_count - answer_count
+            comparison_available = comparison_count < other_comparable_answers * (other_comparable_answers - 1) / 2
 
             statuses[assignment.uuid] = {
                 'answers': {

--- a/compair/api/comparison.py
+++ b/compair/api/comparison.py
@@ -104,7 +104,7 @@ class CompareRootAPI(Resource):
                 abort(500, title="Comparisons Unavailable", message="Generating scored pairs failed, this really shouldn't happen.")
 
         return {
-            'comparison': marshal(comparison, dataformat.get_comparison(restrict_user)),
+            'comparison': marshal(comparison, dataformat.get_comparison(restrict_user, include_answer_user=False, include_score=False)),
             'new_pair': new_pair,
             'current': comparison_count+1
         }
@@ -248,6 +248,6 @@ class CompareRootAPI(Resource):
             is_comparison_example=is_comparison_example,
             data=marshal(comparison, dataformat.get_comparison(restrict_user)))
 
-        return {'comparison': marshal(comparison, dataformat.get_comparison(restrict_user))}
+        return {'comparison': marshal(comparison, dataformat.get_comparison(restrict_user, include_answer_user=False, include_score=False))}
 
 api.add_resource(CompareRootAPI, '')

--- a/compair/api/dataformat/__init__.py
+++ b/compair/api/dataformat/__init__.py
@@ -178,12 +178,11 @@ def get_assignment(restrict_user=True):
         'created': fields.DateTime(dt_format='iso8601', attribute=lambda x: replace_tzinfo(x.created))
     }
 
-def get_answer(restrict_user=True):
-    return {
+def get_answer(restrict_user=True, include_answer_user=True, include_score=True):
+    ret = {
         'id': fields.String(attribute="uuid"),
         'course_id': fields.String(attribute="course_uuid"),
         'assignment_id': fields.String(attribute="assignment_uuid"),
-        'user_id': fields.String(attribute="user_uuid"),
 
         'content': fields.String,
         'file': fields.Nested(get_file(), allow_null=True),
@@ -191,15 +190,22 @@ def get_answer(restrict_user=True):
         'draft': fields.Boolean,
         'top_answer': fields.Boolean,
 
-        'score': fields.Nested(get_score(restrict_user), allow_null=True),
-
         'comment_count': fields.Integer,
         'private_comment_count': fields.Integer,
         'public_comment_count': fields.Integer,
 
-        'user': get_partial_user(restrict_user),
-        'created': fields.DateTime(dt_format='iso8601', attribute=lambda x: replace_tzinfo(x.created))
+        'created': fields.DateTime(dt_format='iso8601', attribute=lambda x: replace_tzinfo(x.created)),
+        'comparable': fields.Boolean
     }
+
+    if include_score:
+        ret['score'] = fields.Nested(get_score(restrict_user), allow_null=True)
+
+    if include_answer_user:
+        ret['user_id'] = fields.String(attribute="user_uuid")
+        ret['user'] = get_partial_user(restrict_user)
+
+    return ret
 
 
 def get_assignment_comment(restrict_user=True):
@@ -253,7 +259,7 @@ def get_kaltura_media():
     }
 
 
-def get_comparison(restrict_user=True, with_answers=True, with_feedback=False):
+def get_comparison(restrict_user=True, with_answers=True, with_feedback=False, include_answer_user=True, include_score=True):
     ret = {
         'id': fields.String(attribute="uuid"),
         'course_id': fields.String(attribute="course_uuid"),
@@ -269,8 +275,8 @@ def get_comparison(restrict_user=True, with_answers=True, with_feedback=False):
     }
 
     if with_answers:
-        ret['answer1'] = fields.Nested(get_answer(restrict_user))
-        ret['answer2'] = fields.Nested(get_answer(restrict_user))
+        ret['answer1'] = fields.Nested(get_answer(restrict_user, include_answer_user, include_score))
+        ret['answer2'] = fields.Nested(get_answer(restrict_user, include_answer_user, include_score))
 
     if with_feedback:
         ret['answer1_feedback'] = fields.List(fields.Nested(get_answer_comment(restrict_user)))

--- a/compair/models/answer.py
+++ b/compair/models/answer.py
@@ -27,6 +27,7 @@ class Answer(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
         nullable=True)
     draft = db.Column(db.Boolean(name='draft'), default=False, nullable=False, index=True)
     top_answer = db.Column(db.Boolean(name='top_answer'), default=False, nullable=False, index=True)
+    comparable = db.Column(db.Boolean(name='comparable'), default=True, nullable=False)
 
     # relationships
     # assignment via Assignment Model

--- a/compair/models/assignment.py
+++ b/compair/models/assignment.py
@@ -278,6 +278,28 @@ class Assignment(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
             group="counts"
         )
 
+        # Comparable answer count
+        # To be consistent with student_answer_count, we are not counting
+        # answers from sys admin here
+        cls.comparable_answer_count = column_property(
+            select([func.count(Answer.id)]).
+            select_from(join(Answer, UserCourse, UserCourse.user_id == Answer.user_id)).
+            where(and_(
+                Answer.assignment_id == cls.id,
+                Answer.active == True,
+                Answer.draft == False,
+                Answer.practice == False,
+                UserCourse.course_id == cls.course_id,
+                UserCourse.course_role.in_(
+                    [CourseRole.student, CourseRole.instructor, \
+                        CourseRole.teaching_assistant]
+                ),
+                Answer.comparable == True
+            )),
+            deferred=True,
+            group="counts"
+        )
+
         cls.top_answer_count = column_property(
             select([func.count(Answer.id)]).
             select_from(join(Answer, UserCourse, UserCourse.user_id == Answer.user_id)).

--- a/compair/static/modules/answer/answer-form-partial.html
+++ b/compair/static/modules/answer/answer-form-partial.html
@@ -37,7 +37,7 @@
         </div>
 
         <div class="instructional-text">
-                <p ng-if="canManageAssignment && !comparison_example">Answers submitted as an instructor or TA will <strong>not be included in comparisons</strong> and appear to students only after they answer/compare.</p>
+                <p ng-if="canManageAssignment && !comparison_example">Answers submitted as an instructor or TA <strong>will be included</strong> in comparisons unless this option is unchecked below. All answers will appear to students when the assignment completes.</p>
                 <p>Allowed file types for attachments include {{ UploadValidator.getAttachmentExtensionsForDisplay() }}, with a maximum file size of <strong>{{UploadValidator.getAttachmentUploadLimit() | filesize }}</strong>. Any files you upload will be attached when you <strong>save or submit this answer</strong> but not before.</p>
         </div>
 
@@ -45,9 +45,20 @@
             <label class="required-star" for="user_id">Submit As</label>
             <select id="user_id" name="user_id" required
                     ng-model="answer.user_id" class="form-control" chosen width="'100%'"
-                    ng-options="u.id as u.fullname_sortable for u in classlist">
+                    ng-options="u.id as u.fullname_sortable for u in classlist"
+                    ng-change="onSubmitAsChanged(answer.user_id)">
                 <option value="">- Select a user -</option>
             </select>
+        </div>
+
+        <div class="form-group" ng-if="canManageAssignment && submitAsInstructorOrTA && comparison_example !== true">
+            <label for="comparable" ng-class="!answer.draft ? 'text-muted not-bold' : ''">
+                <input type="checkbox" id="comparable" name="comparable"
+                    ng-model="answer.comparable"
+                    ng-false-value="false"
+                    ng-disabled="!answer.draft" >&nbsp;
+                Allow this instructor answer to appear in comparison pairings (when the algorithm selects it)
+            </label>
         </div>
 
         <div>

--- a/compair/static/modules/assignment/assignment-module_spec.js
+++ b/compair/static/modules/assignment/assignment-module_spec.js
@@ -793,6 +793,14 @@ describe('assignment-module', function () {
                 });
                 $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z/groups').respond(mockGroups);
                 $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z/assignments/1abcABC123-abcABC123_Z/answers?page=1&perPage=20').respond(mockAnswers);
+                $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z/users/instructionals').respond({
+                    "objects": [{
+                        "group_name": null,
+                        "id": "1",
+                        "name": "One, Instructor",
+                        "role": "Instructor"
+                    }]
+                });
                 $httpBackend.flush();
             });
 

--- a/compair/static/modules/assignment/assignment-view-partial.html
+++ b/compair/static/modules/assignment/assignment-view-partial.html
@@ -97,7 +97,7 @@
                                     <option value="">All groups</option>
                                 </select>
                                 <select id="answers-filter" ng-model="answerFilters.author" class="nullable" chosen
-                                        ng-options="u.id as u.name for u in students">
+                                        ng-options="u.id as u.name for u in [].concat(allInstructionals).concat(students)">
                                     <option value="">All answers</option>
                                 </select>
                             </span><br />
@@ -171,7 +171,7 @@
             <div class="all-answers">
 
                 <!-- Instructor Answers Section -->
-                <div class="each-answer clearfix" ng-repeat="answer in answers.objects | filter:adminFilter() as adminResults" ng-if="instructors[answer.user_id] && (see_answers || canManageAssignment)">
+                <div class="each-answer clearfix" ng-repeat="answer in answers.objects | filter:adminFilter() as adminResults" ng-if="answerFilters.orderBy!='score' && instructors[answer.user_id] && (see_answers || canManageAssignment)">
 
                     <!-- Instructor Answer Metadata Header -->
                     <div class="each-header clearfix">
@@ -180,12 +180,27 @@
                         <strong>said</strong> on {{answer.created | amDateFormat: 'MMM D @ h:mm a'}}:
                         <div class="manager-actions pull-right" ng-if="canManageAssignment">
                             <em>{{instructors[answer.user_id]}} Response</em>
+                            <span ng-if="canManageAssignment && !answerFilters.anonymous && answer.score && answer.comparable" class="label label-warning score-tooltip" uib-tooltip="Scores are normalized, so the top-ranked answer or&mdash;in the case of a tie&mdash;answers for the assignment receive 100%. All other answers receive a lower percentage based on how well they did compared to the top-ranked answer." tooltip-trigger tooltip-animation="false" tooltip-placement="left">
+                                Score: {{answer.score.normalized_score}}%
+                            </span>
                             <a title="Delete this answer" href="" confirmation-needed="deleteAnswer(answer)" keyword="instructor answer">
                                 <i class="fa fa-trash-o"></i>
                             </a>
                             <a href="" title="Edit this answer" ng-click="editAnswer(answer)">
                                 Edit
                             </a>
+                        </div>
+                        <div class="manager-actions pull-right" ng-if="!canManageAssignment">
+                            <!-- Ranking for Instructor Answers -->
+                            <span class="students-ranked" ng-if="!canManageAssignment && !answerFilters.anonymous && answerFilters.orderBy=='score' && answer.score">
+                                <span ng-if="answer.score.rank <= rankLimit">
+                                    Students Ranked: <strong>#{{answer.score.rank}} <span ng-if="rankCount[answer.score.rank] > 1">(tied)</span></strong>
+                                </span>
+                                <span class="score-tooltip" ng-if="answer.score.rank > 0 && answer.score.rank > rankLimit" uib-tooltip="Answers that are ranked outside the top {{rankLimit}} do not receive a rank number for this assignment." tooltip-trigger tooltip-animation="false" tooltip-placement="left">
+                                    Students Ranked: <strong>N/A</strong>
+                                </span>
+                                <i class="fa fa-arrow-down"></i>
+                            </span>
                         </div>
                     </div>
 

--- a/compair/static/modules/comparison/comparison-module.js
+++ b/compair/static/modules/comparison/comparison-module.js
@@ -417,6 +417,17 @@ module.controller(
             }
         );
 
+        CourseResource.getInstructionals({'id': $scope.courseId}).$promise.then(
+            function(ret) {
+                $scope.allInstructionals = ret.objects;
+                instructionalIds = $scope.getUserIds(ret.objects);
+            }
+        );
+
+        $scope.isInstructional = function(user_id) {
+            return user_id in instructionalIds;
+        }
+
         $scope.loadAnswerByAuthor = function(author_id) {
             if (_.find($scope.answers, {user_id: author_id})) return;
             AnswerResource.get({'courseId': $scope.courseId, 'assignmentId': $scope.assignmentId, 'author': author_id}, function(response) {

--- a/compair/static/modules/comparison/comparison-view-partial.html
+++ b/compair/static/modules/comparison/comparison-view-partial.html
@@ -17,8 +17,8 @@
                         <option value="">All groups</option>
                     </select>
                     <select id="comparison-filter" ng-model="comparisonFilters.author" class="nullable" chosen
-                            ng-options="u.id as u.name for u in users | orderBy: 'name'">
-                        <option value="">All students</option>
+                            ng-options="u.id as u.name for u in [].concat(users).concat(allInstructionals) | orderBy: 'name'">
+                        <option value="">All</option>
                     </select>
                 </span>
 
@@ -50,7 +50,8 @@
                     <p class="content"><a href="" ng-click="loadAnswerByAuthor(comparison.user_id);showMyAnswer = !showMyAnswer;">
                         <i ng-show="showMyAnswer" class="fa fa-chevron-down"></i>
                         <i ng-hide="showMyAnswer" class="fa fa-chevron-right"></i>
-                        Show student's answer
+                        <em ng-if="isInstructional(comparison.user_id)">Show instructor/TA's answer</em>
+                        <em ng-if="!isInstructional(comparison.user_id)">Show student's answer</em>
                     </a></p>
                     <compair-student-answer class="answer" answer="(answers | filter:{user_id:comparison.user_id}:true)[0]" ng-show="showMyAnswer"></compair-student-answer>
                     <br />

--- a/compair/static/modules/course/course-module.js
+++ b/compair/static/modules/course/course-module.js
@@ -235,7 +235,8 @@ module.factory('CourseResource',
             'createDuplicate': {method: 'POST', url: '/api/courses/:id/duplicate'},
             'getCurrentUserStatus': {url: '/api/courses/:id/assignments/status'},
             'getInstructorsLabels': {url: '/api/courses/:id/users/instructors/labels'},
-            'getStudents': {url: '/api/courses/:id/users/students'}
+            'getStudents': {url: '/api/courses/:id/users/students'},
+            'getInstructionals': {url: '/api/courses/:id/users/instructionals'}
         }
     );
     ret.MODEL = "Course"; // add constant to identify the model

--- a/data/fixtures/test_data.py
+++ b/data/fixtures/test_data.py
@@ -452,6 +452,7 @@ class ComparisonTestData(CriterionTestData):
         self.authorized_student_with_no_answers = self.create_normal_user()
         self.enrol_student(self.authorized_student_with_no_answers, self.get_course())
         self.student_answers = copy.copy(self.answers)
+        self.comparable_answers = copy.copy(self.answers)
         self.comparisons_examples = []
         for assignment in self.get_assignments():
             # make sure we're allowed to compare existing assignments
@@ -459,15 +460,28 @@ class ComparisonTestData(CriterionTestData):
             answer = self.create_answer(assignment, self.secondary_authorized_student)
             self.answers.append(answer)
             self.student_answers.append(answer)
+            self.comparable_answers.append(answer)
             self.answers.append(answer)
             answer = self.create_answer(assignment, self.get_authorized_student())
             self.answers.append(answer)
             self.student_answers.append(answer)
-            # add a TA and Instructor answer
+            self.comparable_answers.append(answer)
+            # add a TA and Instructor answer - not comparable
             answer = self.create_answer(assignment, self.get_authorized_ta())
+            answer.comparable = False
             self.answers.append(answer)
             answer = self.create_answer(assignment, self.get_authorized_instructor())
+            answer.comparable = False
             self.answers.append(answer)
+            # add a TA and Instructor answer - comparable
+            answer = self.create_answer(assignment, self.get_authorized_ta())
+            answer.comparable = True
+            self.answers.append(answer)
+            self.comparable_answers.append(answer)
+            answer = self.create_answer(assignment, self.get_authorized_instructor())
+            answer.comparable = True
+            self.answers.append(answer)
+            self.comparable_answers.append(answer)
             # add a comparison example
             answer1 = self.create_answer(assignment, self.get_authorized_ta())
             self.answers.append(answer)
@@ -494,6 +508,9 @@ class ComparisonTestData(CriterionTestData):
 
     def get_student_answers(self):
         return self.student_answers
+
+    def get_comparable_answers(self):
+        return self.comparable_answers
 
     def get_assignment_in_answer_period(self):
         return self.answer_period_assignment


### PR DESCRIPTION
- Add new column in db to mark if the answer is comparable
- Show a checkbox when an instructor / TA creating a new answer to indicate whether it should be included for student comparisons
- Modify Participation Report for Research Teams to include
instructors/TAs. Dispaly rank and score. Handle multiple answers from
same user.
- Hide user info of answers from Comparison API calls
- Hide answer scores from Comparison API calls
- Add a new API endpoint `/api/courses/:course_id/users/instructionals` to retrieve instructors/TAs of the course

Closes #251, closes #653 
  