### PR TITLE
Refactor classlist instructor endpoints

### DIFF
--- a/compair/api/__init__.py
+++ b/compair/api/__init__.py
@@ -324,13 +324,11 @@ def log_events(log):
 
     # classlist events
     from .classlist import on_classlist_get, on_classlist_upload, on_classlist_enrol, on_classlist_unenrol, \
-        on_classlist_instructor_label, on_classlist_instructor, on_classlist_student, \
-        on_classlist_update_users_course_roles
+        on_classlist_instructor, on_classlist_student, on_classlist_update_users_course_roles
     on_classlist_get.connect(log)
     on_classlist_upload.connect(log)
     on_classlist_enrol.connect(log)
     on_classlist_unenrol.connect(log)
-    on_classlist_instructor_label.connect(log)
     on_classlist_instructor.connect(log)
     on_classlist_student.connect(log)
     on_classlist_update_users_course_roles.connect(log)

--- a/compair/api/course_group.py
+++ b/compair/api/course_group.py
@@ -83,6 +83,6 @@ class GroupNameAPI(Resource):
             course_id=course.id,
             data={'group_name': group_name})
 
-        return {'students': [{'id': u.uuid, 'name': u.fullname_sortable} for u in members]}
+        return {'objects': [{'id': u.uuid, 'name': u.fullname_sortable} for u in members]}
 
 api.add_resource(GroupNameAPI, '/<group_name>')

--- a/compair/static/compair-config.js
+++ b/compair/static/compair-config.js
@@ -205,9 +205,9 @@ myApp.factory('RouteResolves',
             var courseId = $route.current.params.courseId;
             return CourseResource.getStudents({'id': courseId}).$promise;
         },
-        instructorLabels: function() {
+        instructors: function() {
             var courseId = $route.current.params.courseId;
-            return CourseResource.getInstructorsLabels({'id': courseId}).$promise;
+            return CourseResource.getInstructors({'id': courseId}).$promise;
         },
         assignment: function() {
             var courseId = $route.current.params.courseId;
@@ -443,10 +443,10 @@ myApp.config(
                             course: RouteResolves.course(),
                             assignment: RouteResolves.assignment(),
                             students: RouteResolves.students(),
-                            instructorLabels: RouteResolves.instructorLabels(),
+                            instructors: RouteResolves.instructors(),
                             loggedInUser: RouteResolves.loggedInUser(),
                             canManageAssignment: RouteResolves.canManageAssignment(),
-                        }, ['course', 'assignment', 'students', 'instructorLabels']);
+                        }, ['course', 'assignment', 'students', 'instructors']);
                     }
                 },
                 reloadOnSearch: false,

--- a/compair/static/modules/assignment/assignment-module_spec.js
+++ b/compair/static/modules/assignment/assignment-module_spec.js
@@ -216,9 +216,11 @@ describe('assignment-module', function () {
         ]
     };
 
-    var mockInstructorLabels = {
-        "instructors": {
-            "1": "Instructor"
+    var mockInstructors = {
+        "objects": {
+            "group_name": null,
+            "name": "UeNV, thkx",
+            "id": "1abcABC123-abcABC123_Z"
         }
     };
     var mockAssignmentComments = {
@@ -769,7 +771,7 @@ describe('assignment-module', function () {
                     course: angular.copy(mockCourse),
                     assignment: angular.copy(mockAssignment),
                     students: angular.copy(mockStudents),
-                    instructorLabels: angular.copy(mockInstructorLabels),
+                    instructors: angular.copy(mockInstructors),
                     loggedInUser: angular.copy(mockUser),
                     canManageAssignment: true,
                 });
@@ -793,20 +795,14 @@ describe('assignment-module', function () {
                 });
                 $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z/groups').respond(mockGroups);
                 $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z/assignments/1abcABC123-abcABC123_Z/answers?page=1&perPage=20').respond(mockAnswers);
-                $httpBackend.expectGET('/api/courses/1abcABC123-abcABC123_Z/users/instructionals').respond({
-                    "objects": [{
-                        "group_name": null,
-                        "id": "1",
-                        "name": "One, Instructor",
-                        "role": "Instructor"
-                    }]
-                });
                 $httpBackend.flush();
             });
 
             it('should be correctly initialized', function () {
+                var expectedInstructors = _.sortBy(angular.copy(mockInstructors.objects), 'name');
                 var expectedStudents = _.sortBy(angular.copy(mockStudents.objects), 'name');
-                expectedStudents.unshift({
+                var expectedUsers = [].concat(expectedInstructors, expectedStudents);
+                expectedUsers.unshift({
                     id: "top-picks",
                     name: "Instructor's top picks"
                 });
@@ -814,8 +810,9 @@ describe('assignment-module', function () {
                 expect($rootScope.assignment.id).toEqual(mockAssignment.id);
                 expect($rootScope.courseId).toEqual(mockCourse.id);
 
+                expect($rootScope.allInstructors).toEqual(mockInstructors.objects);
                 expect($rootScope.allStudents).toEqual(mockStudents.objects);
-                expect($rootScope.students).toEqual(expectedStudents);
+                expect($rootScope.users).toEqual(expectedUsers);
 
                 expect($rootScope.totalNumAnswers).toEqual(mockAnswers.total);
 
@@ -841,8 +838,6 @@ describe('assignment-module', function () {
                 expect($rootScope.warning).toBe(false);
 
                 expect($rootScope.assignment.status.answers.answered).toBe(true);
-
-                expect($rootScope.instructors).toEqual(mockInstructorLabels.instructors);
 
                 expect($rootScope.showTab('answers')).toBe(true);
             });
@@ -1207,7 +1202,7 @@ describe('assignment-module', function () {
                     $rootScope.date.astart.date.setDate($rootScope.date.astart.date.getDate()+1);
                     $rootScope.date.aend.date = new Date();
                     $rootScope.date.aend.date.setDate($rootScope.date.aend.date.getDate()+8);
-                    
+
                     $rootScope.date.aend.date = $rootScope.date.astart.date;
                     $rootScope.date.aend.time = $rootScope.date.astart.time;
                     var currentPath = $location.path();
@@ -1245,7 +1240,7 @@ describe('assignment-module', function () {
                     $rootScope.assignment = angular.copy(mockAssignment);
                     $rootScope.assignment.id = undefined;
                     $rootScope.assignment.availableCheck = true;
-                    
+
                     // no default dates set. populate with values before proceeding
                     $rootScope.date.astart.date = new Date();
                     $rootScope.date.astart.date.setDate($rootScope.date.astart.date.getDate()+1);
@@ -1267,7 +1262,7 @@ describe('assignment-module', function () {
                 it('should enable save button even if save failed', function() {
                     $rootScope.assignment = angular.copy(mockAssignment);
                     $rootScope.assignment.id = undefined;
-                    
+
                     // no default dates set. populate with values before proceeding
                     $rootScope.date.astart.date = new Date();
                     $rootScope.date.astart.date.setDate($rootScope.date.astart.date.getDate()+1);

--- a/compair/static/modules/assignment/assignment-view-partial.html
+++ b/compair/static/modules/assignment/assignment-view-partial.html
@@ -97,7 +97,7 @@
                                     <option value="">All groups</option>
                                 </select>
                                 <select id="answers-filter" ng-model="answerFilters.author" class="nullable" chosen
-                                        ng-options="u.id as u.name for u in [].concat(allInstructionals).concat(students)">
+                                        ng-options="u.id as u.name for u in users">
                                     <option value="">All answers</option>
                                 </select>
                             </span><br />
@@ -160,7 +160,7 @@
                 <p class="intro-text" ng-if="!canManageAssignment && comparisons_left == 0 && !self_evaluation_needed && !see_answers">
                     You have successfully finished comparisons for this assignment! Answers written by your classmates and instructors will be available here beginning <strong>{{ answerAvail | amDateFormat: 'MMM D @ h:mm a'}}</strong>.
                 </p>
-                
+
                 <!-- Students see when answers exist and visible -->
                 <p class="intro-text" ng-if="!canManageAssignment && see_answers && !answerFilters.author">
                     Answers for this assignment submitted by you, your classmates, and instructors are available below. Any public feedback left for other student answers can be found underneath the student answer. Private feedback you receive does not appear to the class.
@@ -171,12 +171,12 @@
             <div class="all-answers">
 
                 <!-- Instructor Answers Section -->
-                <div class="each-answer clearfix" ng-repeat="answer in answers.objects | filter:adminFilter() as adminResults" ng-if="answerFilters.orderBy!='score' && instructors[answer.user_id] && (see_answers || canManageAssignment)">
+                <div class="each-answer clearfix" ng-repeat="answer in answers.objects | filter:adminFilter() as adminResults" ng-if="answerFilters.orderBy!='score' && isInstructor(answer.user_id) && (see_answers || canManageAssignment)">
 
                     <!-- Instructor Answer Metadata Header -->
                     <div class="each-header clearfix">
                         <compair-avatar user-id="answer.user_id" avatar="answer.user.avatar" display-name="answer.user.displayname" full-name="answer.user.fullname"></compair-avatar>
-                        <span class="label label-default" ng-if="instructors[answer.user_id]">{{instructors[answer.user_id]}}</span>
+                        <span class="label label-default" ng-if="isInstructor(answer.user_id)">{{instructorLabel(answer.user_id)}}</span>
                         <strong>said</strong> on {{answer.created | amDateFormat: 'MMM D @ h:mm a'}}:
                         <div class="manager-actions pull-right" ng-if="canManageAssignment">
                             <em>{{instructors[answer.user_id]}} Response</em>
@@ -212,12 +212,13 @@
                 </div><!-- closes each-answer (instructor) -->
 
                 <!-- Student Answers Section -->
-                <div class="each-answer clearfix" ng-repeat="answer in answers.objects | notScoredEnd | excludeInstr:instructors as results" ng-if="(see_answers || canManageAssignment)">
+                <div class="each-answer clearfix" ng-repeat="answer in answers.objects | notScoredEnd | excludeInstr:allInstructors as results" ng-if="(see_answers || canManageAssignment)">
                 <!-- <div class="each-answer clearfix" ng-repeat="(answerKey, answer) in answers" ng-if="!instructors[answer.user_id] && (see_answers || (answer.user_id == loggedInUserId && assignment.answer_period) || canManageAssignment)"> -->
                     <!-- Student Answer Metadata Header -->
                     <div class="each-header clearfix">
                         <compair-avatar ng-show="!answerFilters.anonymous" user-id="answer.user_id" avatar="answer.user.avatar" display-name="answer.user.displayname" full-name="answer.user.fullname" me="!canManageAssignment && answer.user_id == loggedInUserId"></compair-avatar>
                         <span ng-show="answerFilters.anonymous">Student</span>
+                        <span class="label label-default" ng-if="isInstructor(answer.user_id)">{{instructorLabel(answer.user_id)}}</span>
                         <strong>answered</strong> on {{answer.created | amDateFormat: 'MMM D @ h:mm a'}}:
                         <div class="manager-actions pull-right">
                             <!-- Student Score (not used for instructor answers) -->
@@ -300,7 +301,7 @@
                             <!-- Student Reply Metadata Header -->
                             <div class="each-header clearfix">
                                 <compair-avatar user-id="comment.user_id" avatar="comment.user.avatar" display-name="comment.user.displayname" full-name="comment.user.fullname"></compair-avatar>
-                                <span class="label label-default" ng-if="instructors[comment.user_id]">{{instructors[comment.user_id]}}</span>
+                                <span class="label label-default" ng-if="isInstructor(comment.user_id)">{{instructorLabel(comment.user_id)}}</span>
                                 <strong ng-if="comment.comment_type == AnswerCommentType.private || comment.comment_type == AnswerCommentType.evaluation"> gave private feedback <span class="glyphicon glyphicon-lock"></span></strong>
                                 <strong ng-if="comment.comment_type == AnswerCommentType.self_evaluation"> self-evaluated <span class="glyphicon glyphicon-lock"></span></strong>
                                 <strong ng-if="comment.comment_type == AnswerCommentType.public"> gave public feedback <span class="glyphicon glyphicon-eye-open"></span> </strong>
@@ -335,7 +336,7 @@
                 <div class="each-answer clearfix" ng-if="assignment.answer_count == 0 && (see_answers || canManageAssignment)">
                     <p>(No answers submitted yet.)</p>
                 </div>
-                
+
                 <!-- Anyone sees when there are answers, a filter is set, but no answers show in results (and user has permission to view answers) -->
                 <div class="each-answer clearfix" ng-if="assignment.answer_count > 0 && (answerFilters.group || answerFilters.author || answerFilters.orderBy) && (results.length < 1 && adminResults.length < 1) && (see_answers || canManageAssignment)">
                     <p>No answers were found with these filter settings. Try another choice above.</p>
@@ -361,7 +362,7 @@
                     <p class="intro-text">The answer you submitted for this assignment appears below. Any peer, instructor, or self-evaluation feedback&mdash;<strong>{{assignment.status.answers.feedback}} feedback comments</strong> currently&mdash;for your answer can be found underneath the answer. Only feedback marked as public can be seen by other students.</p>
                 </div>
             </div>
-            
+
             <div class="each-evaluation" ng-if="user_answers.objects.length == 0">
                 <p>(You have not submitted an answer.<span ng-if="assignment.answer_period"> Would you like to <span ng-show="!assignment.status.answers.has_draft"><a ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/answer/create" title="Answer the assignment">answer</a></span><span ng-show="assignment.status.answers.has_draft"><a ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/answer/{{assignment.status.answers.draft_ids[0]}}/edit" title="Finish answering the assignment">finish answering</a></span> this assignment?</span>)</p>
             </div>
@@ -370,6 +371,7 @@
             <div class="each-evaluation clearfix" ng-repeat="answer in user_answers.objects">
                 <div class="each-header clearfix">
                     <compair-avatar user-id="answer.user_id" avatar="answer.user.avatar" me="true"></compair-avatar>
+                    <span class="label label-default" ng-if="isInstructor(answer.user_id)">{{instructorLabel(answer.user_id)}}</span>
                     <strong>answered</strong> on {{answer.created | amDateFormat: 'MMM D @ h:mm a'}}:
                     <div class="manager-actions pull-right" ng-if="canManageAssignment || (answer.user_id == loggedInUserId && assignment.answer_period && !assignment.compare_period)">
                         <!--
@@ -416,7 +418,7 @@
                         <!-- Student Reply Metadata Header -->
                         <div class="each-header clearfix">
                             <compair-avatar user-id="comment.user_id" avatar="comment.user.avatar" display-name="comment.user.displayname" full-name="comment.user.fullname"></compair-avatar>
-                            <span class="label label-default" ng-if="instructors[comment.user_id]">{{instructors[comment.user_id]}}</span>
+                            <span class="label label-default" ng-if="isInstructor(comment.user_id)">{{instructorLabel(comment.user_id)}}</span>
                             <strong ng-if="comment.comment_type == AnswerCommentType.private || comment.comment_type == AnswerCommentType.evaluation"> gave private feedback <span class="glyphicon glyphicon-lock"></span></strong>
                             <strong ng-if="comment.comment_type == AnswerCommentType.self_evaluation"> self-evaluated <span class="glyphicon glyphicon-lock"></span></strong>
                             <strong ng-if="comment.comment_type == AnswerCommentType.public"> gave public feedback <span class="glyphicon glyphicon-eye-open"></span></strong>
@@ -442,7 +444,7 @@
             </div>
 
         </div><!-- closes your_feedback-tab -->
-        
+
         <div class="tab-pane" ng-class="{active: showTab('your_comparisons')}" id="your_comparisons-tab" ng-if="!canManageAssignment">
 
             <!-- Your Comparisons Header -->
@@ -451,11 +453,11 @@
                 <br />
                 <p class="intro-text">Comparisons you've submitted for this assignment&mdash;<strong>{{comparison_set.comparisons.length}} comparisons</strong> currently&mdash;appear below. Each comparison shows the answers you compared, the feedback you gave for each answer, and which answer in the pair you chose for each criterion.</p>
             </div>
-            
+
             <div class="each-evaluation" ng-if="comparison_set.comparisons.length == 0">
                 <p>(You have not submitted any comparisons.<span ng-if="assignment.compare_period && comparisons_left > 0 "> Would you like to <a ng-href="#/course/{{courseId}}/assignment/{{assignment.id}}/compare" title="Compare answers">compare answer pairs</a> for this assignment?</span>)</p>
             </div>
-            
+
             <!-- Comparisons Section -->
             <div class="each-evaluation" ng-repeat="comparison in comparison_set.comparisons">
 
@@ -508,7 +510,7 @@
                 </div>
 
             </div><!-- closes each-evaluation -->
-            
+
         </div><!-- closes your_comparisons-tab -->
 
         <!-- <div class="tab-pane" ng-class="{active: showTab('help')}" id="comments-tab">-->
@@ -535,7 +537,7 @@
                 <!-- Comment Metadata Header -->
                 <!-- <div class="each-header clearfix">
                     <compair-avatar user-id="comment.user_id" avatar="comment.user.avatar" display-name="comment.user.displayname" full-name="comment.user.fullname" me="comment.user_id == loggedInUserId"></compair-avatar>
-                    <span class="label label-default" ng-if="instructors[comment.user_id]">{{instructors[comment.user_id]}}</span>
+                    <span class="label label-default" ng-if="isInstructor(comment.user_id)">{{instructorLabel(comment.user_id)}}</span>
                     <strong>commented</strong> on {{comment.created | amDateFormat: 'MMM D @ h:mm a'}}:
                     <div class="manager-actions pull-right" ng-if="canManageAssignment || comment.user_id == loggedInUserId">
                         <a title="Delete this comment" confirmation-needed="deleteComment(commentKey, courseId, assignment.id, comment.id)" keyword="comment" href="">

--- a/compair/static/modules/comparison/comparison-module.js
+++ b/compair/static/modules/comparison/comparison-module.js
@@ -409,23 +409,14 @@ module.controller(
         $scope.WinningAnswer = WinningAnswer;
         breadcrumbs.options = {'Course assignments': $scope.course.name};
 
-        CourseResource.getStudents({'id': $scope.courseId}).$promise.then(
-            function (ret) {
-                $scope.allStudents = ret.objects;
-                $scope.users = ret.objects;
-                userIds = $scope.getUserIds(ret.objects);
-            }
-        );
+        $scope.resetUsers = function(instructors, students) {
+            instructors = _.sortBy(instructors, 'name');
+            students = _.sortBy(students, 'name');
+            $scope.users = [].concat(instructors, students);
+        };
 
-        CourseResource.getInstructionals({'id': $scope.courseId}).$promise.then(
-            function(ret) {
-                $scope.allInstructionals = ret.objects;
-                instructionalIds = $scope.getUserIds(ret.objects);
-            }
-        );
-
-        $scope.isInstructional = function(user_id) {
-            return user_id in instructionalIds;
+        $scope.isInstructor = function(user_id) {
+            return _.find($scope.allInstructors, {id: user_id});
         }
 
         $scope.loadAnswerByAuthor = function(author_id) {
@@ -442,11 +433,11 @@ module.controller(
                 $scope.comparisonFilters.author = null;
                 $scope.comparisonFilters.page = 1;
                 if ($scope.comparisonFilters.group == null) {
-                    $scope.users = $scope.allStudents;
+                    $scope.resetUsers($scope.allInstructors, $scope.allStudents);
                 } else {
                     GroupResource.get({'courseId': $scope.courseId, 'groupName': $scope.comparisonFilters.group}).$promise.then(
                         function (ret) {
-                            $scope.users = ret.students;
+                            $scope.resetUsers([], ret.objects);
                         }
                     );
                 }
@@ -469,6 +460,7 @@ module.controller(
             });
         };
         $scope.updateList();
+        $scope.resetUsers($scope.allInstructors, $scope.allStudents);
     }]
 );
 

--- a/compair/static/modules/comparison/comparison-view-partial.html
+++ b/compair/static/modules/comparison/comparison-view-partial.html
@@ -17,7 +17,7 @@
                         <option value="">All groups</option>
                     </select>
                     <select id="comparison-filter" ng-model="comparisonFilters.author" class="nullable" chosen
-                            ng-options="u.id as u.name for u in [].concat(users).concat(allInstructionals) | orderBy: 'name'">
+                            ng-options="u.id as u.name for u in users">
                         <option value="">All</option>
                     </select>
                 </span>
@@ -50,8 +50,8 @@
                     <p class="content"><a href="" ng-click="loadAnswerByAuthor(comparison.user_id);showMyAnswer = !showMyAnswer;">
                         <i ng-show="showMyAnswer" class="fa fa-chevron-down"></i>
                         <i ng-hide="showMyAnswer" class="fa fa-chevron-right"></i>
-                        <em ng-if="isInstructional(comparison.user_id)">Show instructor/TA's answer</em>
-                        <em ng-if="!isInstructional(comparison.user_id)">Show student's answer</em>
+                        <em ng-if="isInstructor(comparison.user_id)">Show instructor/TA's answer</em>
+                        <em ng-if="!isInstructor(comparison.user_id)">Show student's answer</em>
                     </a></p>
                     <compair-student-answer class="answer" answer="(answers | filter:{user_id:comparison.user_id}:true)[0]" ng-show="showMyAnswer"></compair-student-answer>
                     <br />

--- a/compair/static/modules/course/course-module.js
+++ b/compair/static/modules/course/course-module.js
@@ -43,7 +43,7 @@ var module = angular.module('ubc.ctlt.compair.course',
 
 /***** Directives *****/
 module.directive('courseMetadata', function() {
-    
+
     return {
         restrict : 'E',
         scope: true,
@@ -52,7 +52,7 @@ module.directive('courseMetadata', function() {
         link: function ($scope, $element, $attributes) {
             $scope.metadataName = $attributes.name;
         },
-        controller: ["$scope", "$filter", "CoursePermissions", 
+        controller: ["$scope", "$filter", "CoursePermissions",
             function ($scope, $filter, CoursePermissions) {
                 $scope.$watchCollection("[course, course.status, metadataName]", function(newStatus){
 
@@ -136,7 +136,7 @@ module.directive('courseMetadata', function() {
                                 'label': '<i class="fa fa-trash-o"></i>',
                                 'title' : "Delete",
                                 'confirmationNeeded' : 'deleteCourse(course)' ,
-                                'confirmationWarning': course.delete_warning, 
+                                'confirmationWarning': course.delete_warning,
                                 'keyword' : "course and its assignments",
                                 'show' : {
                                     'user' : false,
@@ -176,7 +176,7 @@ module.directive('courseActionButton', function() {
         link: function ($scope, $element, $attributes) {
             $scope.actionElementName = $attributes.name;
         },
-        controller: ["$scope", "$filter", "CoursePermissions", 
+        controller: ["$scope", "$filter", "CoursePermissions",
             function ($scope, $filter, CoursePermissions) {
                 $scope.$watchCollection("[course, course.status, actionElementName]", function(newStatus){
 
@@ -197,7 +197,7 @@ module.directive('courseActionButton', function() {
                                 }
                             },
                         };
-                        
+
                         if (allButtons[$scope.actionElementName]) {
                             if (course.canManageAssignment && allButtons[$scope.actionElementName].show.instructor) {
                                 $scope.button = allButtons[$scope.actionElementName];
@@ -234,9 +234,8 @@ module.factory('CourseResource',
             'delete': {method: 'DELETE', url: url, interceptor: Interceptors.cache},
             'createDuplicate': {method: 'POST', url: '/api/courses/:id/duplicate'},
             'getCurrentUserStatus': {url: '/api/courses/:id/assignments/status'},
-            'getInstructorsLabels': {url: '/api/courses/:id/users/instructors/labels'},
             'getStudents': {url: '/api/courses/:id/users/students'},
-            'getInstructionals': {url: '/api/courses/:id/users/instructionals'}
+            'getInstructors': {url: '/api/courses/:id/users/instructors'},
         }
     );
     ret.MODEL = "Course"; // add constant to identify the model
@@ -435,7 +434,7 @@ module.controller(
                 $scope.submitted = false;
             });
         };
-        
+
         $scope.closeDuplicate = function(courseId) {
             $scope.selectCourse(courseId);
         };
@@ -467,7 +466,7 @@ module.controller(
     'CourseDuplicateController',
     ["$rootScope", "$scope", "AssignmentResource", "moment", '$routeParams', '$location',
      "Session", "CourseResource", "Toaster", "UserResource",
-    function ($rootScope, $scope, AssignmentResource, moment, $routeParams, $location, 
+    function ($rootScope, $scope, AssignmentResource, moment, $routeParams, $location,
               Session, CourseResource, Toaster, UserResource) {
 
         $scope.showAssignments = false;

--- a/compair/static/modules/gradebook/gradebook-module.js
+++ b/compair/static/modules/gradebook/gradebook-module.js
@@ -44,11 +44,18 @@ module.controller("GradebookController",
         $scope.isNumber = angular.isNumber;
         $scope.gradebook = [];
 
+        $scope.updateUserIds = function(students) {
+            userIds = {};
+            angular.forEach(students, function(s){
+                userIds[s.id] = 1;
+            });
+        };
+
         CourseResource.getStudents({'id': $scope.courseId}).$promise.then(
             function (ret) {
                 $scope.allStudents = ret.objects;
                 $scope.users = ret.objects;
-                userIds = $scope.getUserIds(ret.objects);
+                $scope.updateUserIds(ret.objects);
             }
         );
 
@@ -91,7 +98,7 @@ module.controller("GradebookController",
 
         $scope.groupFilter = function() {
             return function (entry) {
-                return entry.user && entry.user.id in userIds;
+                return entry.user && userIds[entry.user.id];
             }
         };
 
@@ -106,13 +113,11 @@ module.controller("GradebookController",
             if (oldValue.group != newValue.group) {
                 $scope.gradebookFilters.student = null;
                 if ($scope.gradebookFilters.group == null) {
-                    userIds = $scope.getUserIds($scope.allStudents);
-                    $scope.users = $scope.allStudents;
+                    $scope.updateUserIds($scope.allStudents);
                 } else {
                     GroupResource.get({'courseId': $scope.courseId, 'groupName': $scope.gradebookFilters.group}).$promise.then(
                         function (ret) {
-                            $scope.users = ret.students;
-                            userIds = $scope.getUserIds(ret.students);
+                            $scope.updateUserIds(ret.objects);
                         }
                     );
                 }
@@ -120,7 +125,7 @@ module.controller("GradebookController",
             if (oldValue.student != newValue.student) {
                 userIds = {};
                 if ($scope.gradebookFilters.student == null) {
-                    userIds = $scope.getUserIds($scope.users);
+                    $scope.updateUserIds($scope.users);
                 } else {
                     userIds[$scope.gradebookFilters.student.id] = 1;
                 }

--- a/compair/static/modules/route/route-provider_spec.js
+++ b/compair/static/modules/route/route-provider_spec.js
@@ -398,7 +398,7 @@ describe('user-module', function () {
                 $httpBackend.expectGET('/api/courses/'+mockCourseId).respond(404, '');
                 $httpBackend.expectGET('/api/courses/'+mockCourseId+'/assignments/'+mockAssignmentId).respond({});
                 $httpBackend.expectGET('/api/courses/'+mockCourseId+'/users/students').respond({});
-                $httpBackend.expectGET('/api/courses/'+mockCourseId+'/users/instructors/labels').respond({});
+                $httpBackend.expectGET('/api/courses/'+mockCourseId+'/users/instructors').respond({});
                 $httpBackend.expectGET('modules/assignment/assignment-view-partial.html').respond('');
 
                 expect($route.current).toBeUndefined();
@@ -420,7 +420,7 @@ describe('user-module', function () {
                 $httpBackend.expectGET('/api/courses/'+mockCourseId).respond({});
                 $httpBackend.expectGET('/api/courses/'+mockCourseId+'/assignments/'+mockAssignmentId).respond({});
                 $httpBackend.expectGET('/api/courses/'+mockCourseId+'/users/students').respond({});
-                $httpBackend.expectGET('/api/courses/'+mockCourseId+'/users/instructors/labels').respond({});
+                $httpBackend.expectGET('/api/courses/'+mockCourseId+'/users/instructors').respond({});
                 $httpBackend.expectGET('modules/assignment/assignment-view-partial.html').respond('');
 
                 expect($route.current).toBeUndefined();

--- a/compair/static/test/factories/http_backend_mocks.js
+++ b/compair/static/test/factories/http_backend_mocks.js
@@ -471,6 +471,7 @@ module.exports.httpbackendMock = function(storageFixtures) {
                             userList.push({
                                 course_role: userCoruseInfo.courseRole,
                                 id: user.id,
+                                name: user.displayname,
                                 group_name: userCoruseInfo.groupName
                             });
                         }
@@ -481,31 +482,8 @@ module.exports.httpbackendMock = function(storageFixtures) {
             return [200, { 'objects': userList }, {}];
         });
 
-        // get course instructor labels
-        $httpBackend.whenGET(/\/api\/courses\/[A-Za-z0-9_-]{22}\/users\/instructors\/labels$/).respond(function(method, url, data, headers){
-            var courseId = url.replace('/users', '').split('/').pop();
-
-            var userList = {};
-
-            angular.forEach(storageFixture.storage().users, function(user) {
-                if (storageFixture.storage().user_courses[user.id]) {
-                    angular.forEach(storageFixture.storage().user_courses[user.id], function(userCoruseInfo) {
-                        if (courseId == userCoruseInfo.courseId) {
-                            if (userCoruseInfo.courseRole == "Instructor") {
-                                userList[user.id] = "Instructor";
-                            } else if (userCoruseInfo.courseRole == "Teaching Assistant") {
-                                userList[user.id] = "Teaching Assistant";
-                            }
-                        }
-                    });
-                }
-            });
-
-            return [200, { 'objects': userList }, {}];
-        });
-
-        // get course instructor labels
-        $httpBackend.whenGET(/\/api\/courses\/[A-Za-z0-9_-]{22}\/users\/instructionals$/).respond(function(method, url, data, headers){
+        // get course instructors
+        $httpBackend.whenGET(/\/api\/courses\/[A-Za-z0-9_-]{22}\/users\/instructors$/).respond(function(method, url, data, headers){
             var courseId = url.split('/')[3];
             var userList = [];
 
@@ -517,6 +495,7 @@ module.exports.httpbackendMock = function(storageFixtures) {
                                 userList.push({
                                     course_role: userCoruseInfo.courseRole,
                                     id: user.id,
+                                    name: user.displayname,
                                     group_name: userCoruseInfo.groupName
                                 });
                             }

--- a/compair/tests/api/test_classlist.py
+++ b/compair/tests/api/test_classlist.py
@@ -154,38 +154,6 @@ class ClassListAPITest(ComPAIRAPITestCase):
 
         self.app.config['EXPOSE_CAS_USERNAME_TO_INSTRUCTOR'] = False
 
-    def test_get_instructor_labels(self):
-        url = self.url + "/instructors/labels"
-
-        # test login required
-        rv = self.client.get(url)
-        self.assert401(rv)
-
-        # test dropped instructor - unauthorized
-        with self.login(self.data.get_dropped_instructor().username):
-            rv = self.client.get(url)
-            self.assert403(rv)
-
-        # test unauthorized instructor
-        with self.login(self.data.get_unauthorized_instructor().username):
-            rv = self.client.get(url)
-            self.assert403(rv)
-
-        # test invalid course id
-        with self.login(self.data.get_authorized_instructor().username):
-            rv = self.client.get('/api/courses/999/users/instructors/labels')
-            self.assert404(rv)
-
-            # test success
-            rv = self.client.get(url)
-            self.assert200(rv)
-            labels = rv.json['instructors']
-            expected = {
-                self.data.get_authorized_ta().uuid: 'Teaching Assistant',
-                self.data.get_authorized_instructor().uuid: 'Instructor'
-            }
-            self.assertEqual(labels, expected)
-
     def test_get_students_course(self):
         url = self.url + "/students"
 
@@ -242,8 +210,8 @@ class ClassListAPITest(ComPAIRAPITestCase):
             self.assertEqual(students[0]['id'], expected['id'])
             self.assertEqual(students[0]['name'], expected['name'] + ' (You)')
 
-    def test_get_instructional_course(self):
-        url = self.url + "/instructionals"
+    def test_get_instructors_course(self):
+        url = self.url + "/instructors"
 
         # test login required
         rv = self.client.get(url)
@@ -261,13 +229,13 @@ class ClassListAPITest(ComPAIRAPITestCase):
 
         with self.login(self.data.get_authorized_instructor().username):
             # test invalid course id
-            rv = self.client.get('/api/courses/999/users/instructionals')
+            rv = self.client.get('/api/courses/999/users/instructors')
             self.assert404(rv)
 
             # test success - instructor
             rv = self.client.get(url)
             self.assert200(rv)
-            instructionals = rv.json['objects']
+            instructors = rv.json['objects']
             expected = [
                 {
                     'role': 'Teaching Assistant',
@@ -281,10 +249,9 @@ class ClassListAPITest(ComPAIRAPITestCase):
                 }
             ]
 
-            self.assertEqual(len(instructionals), len(expected))
+            self.assertEqual(len(instructors), len(expected))
             for expect in expected:
-                actual = next((x for x in instructionals if x['id'] == expect['id']), None)
-                self.assertIsNotNone(actual)
+                actual = next((x for x in instructors if x['id'] == expect['id']), None)
                 for key in expect:
                     self.assertEqual(actual[key], expect[key])
 
@@ -292,7 +259,7 @@ class ClassListAPITest(ComPAIRAPITestCase):
         with self.login(self.data.get_authorized_student().username):
             rv = self.client.get(url)
             self.assert200(rv)
-            instructionals = rv.json['objects']
+            instructors = rv.json['objects']
             expected = [
                 {
                     'role': 'Teaching Assistant',
@@ -306,10 +273,9 @@ class ClassListAPITest(ComPAIRAPITestCase):
                 }
             ]
 
-            self.assertEqual(len(instructionals), len(expected))
+            self.assertEqual(len(instructors), len(expected))
             for expect in expected:
-                actual = next((x for x in instructionals if x['id'] == expect['id']), None)
-                self.assertIsNotNone(actual)
+                actual = next((x for x in instructors if x['id'] == expect['id']), None)
                 for key in expect:
                     self.assertEqual(actual[key], expect[key])
 

--- a/compair/tests/api/test_course_groups.py
+++ b/compair/tests/api/test_course_groups.py
@@ -69,15 +69,15 @@ class CourseGroupsAPITests(ComPAIRAPITestCase):
             # test authorized instructor
             rv = self.client.get(url)
             self.assert200(rv)
-            self.assertEqual(10, len(rv.json['students']))
-            self.assertEqual(self.fixtures.students[0].uuid, rv.json['students'][0]['id'])
+            self.assertEqual(10, len(rv.json['objects']))
+            self.assertEqual(self.fixtures.students[0].uuid, rv.json['objects'][0]['id'])
 
         # test authorized teaching assistant
         with self.login(self.fixtures.ta.username):
             rv = self.client.get(url)
             self.assert200(rv)
-            self.assertEqual(10, len(rv.json['students']))
-            self.assertEqual(self.fixtures.students[0].uuid, rv.json['students'][0]['id'])
+            self.assertEqual(10, len(rv.json['objects']))
+            self.assertEqual(self.fixtures.students[0].uuid, rv.json['objects'][0]['id'])
 
     def test_group_enrolment(self):
         # frequently used objects


### PR DESCRIPTION
- Rename `/api/courses/,course_uuid>/users/instructionals` to `/api/courses/,course_uuid>/users/instructors`
- Remove `/api/courses/,course_uuid>/users/instructors/labels` in favour of using `/api/courses/,course_uuid>/users/instructors`
- Refactored assignment module, gradebook module, and comparison modules around usage of /students and /instructors endpoints

Depends on #663 