### PR TITLE
Show not-yet-compared answers in ranked list

### DIFF
--- a/compair/models/answer.py
+++ b/compair/models/answer.py
@@ -58,11 +58,11 @@ class Answer(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
 
     @hybrid_property
     def saved(self):
-        return self.modified != self.created
+        return self.modified != self.created or not self.draft
 
     @saved.expression
     def saved(cls):
-        return cls.modified != cls.created
+        return or_(cls.modified != cls.created, cls.draft == False)
 
     @classmethod
     def get_by_uuid_or_404(cls, model_uuid, joinedloads=[], title=None, message=None):

--- a/compair/static/modules/assignment/assignment-module.js
+++ b/compair/static/modules/assignment/assignment-module.js
@@ -1207,7 +1207,7 @@ module.controller("AssignmentViewController",
                 }
                 $scope.answerFilters.page = 1;
             }
-            if (oldValue.top != newValue.top) {
+            if (oldValue.top != newValue.top || oldValue.orderBy != newValue.orderBy) {
                 $scope.answerFilters.page = 1;
             }
 

--- a/compair/static/modules/assignment/assignment-view-partial.html
+++ b/compair/static/modules/assignment/assignment-view-partial.html
@@ -170,7 +170,7 @@
 
             <div class="all-answers">
 
-                <!-- Instructor Answers Section -->
+                <!-- Instructor non-comparable Answers Section -->
                 <div class="each-answer clearfix" ng-repeat="answer in answers.objects | filter:adminFilter() as adminResults" ng-if="answerFilters.orderBy!='score' && instructors[answer.user_id] && (see_answers || canManageAssignment)">
 
                     <!-- Instructor Answer Metadata Header -->
@@ -179,7 +179,7 @@
                         <span class="label label-default" ng-if="instructors[answer.user_id]">{{instructors[answer.user_id]}}</span>
                         <strong>said</strong> on {{answer.created | amDateFormat: 'MMM D @ h:mm a'}}:
                         <div class="manager-actions pull-right" ng-if="canManageAssignment">
-                            <em>{{instructors[answer.user_id]}} Response</em>
+                            <em>{{instructors[answer.user_id]}} Answer (not compared)</em>
                             <span ng-if="canManageAssignment && !answerFilters.anonymous && answer.score && answer.comparable" class="label label-warning score-tooltip" uib-tooltip="Scores are normalized, so the top-ranked answer or&mdash;in the case of a tie&mdash;answers for the assignment receive 100%. All other answers receive a lower percentage based on how well they did compared to the top-ranked answer." tooltip-trigger tooltip-animation="false" tooltip-placement="left">
                                 Score: {{answer.score.normalized_score}}%
                             </span>
@@ -191,6 +191,7 @@
                             </a>
                         </div>
                         <div class="manager-actions pull-right" ng-if="!canManageAssignment">
+                            <em>{{instructors[answer.user_id]}} Answer (not compared)</em>
                             <!-- Ranking for Instructor Answers -->
                             <span class="students-ranked" ng-if="!canManageAssignment && !answerFilters.anonymous && answerFilters.orderBy=='score' && answer.score">
                                 <span ng-if="answer.score.rank <= rankLimit">
@@ -211,13 +212,14 @@
 
                 </div><!-- closes each-answer (instructor) -->
 
-                <!-- Student Answers Section -->
-                <div class="each-answer clearfix" ng-repeat="answer in answers.objects | notScoredEnd | excludeInstr:instructors as results" ng-if="(see_answers || canManageAssignment)">
+                <!-- Comparable Answers Section -->
+                <div class="each-answer clearfix" ng-repeat="answer in answers.objects | excludeInstr:instructors as results" ng-if="(see_answers || canManageAssignment)">
                 <!-- <div class="each-answer clearfix" ng-repeat="(answerKey, answer) in answers" ng-if="!instructors[answer.user_id] && (see_answers || (answer.user_id == loggedInUserId && assignment.answer_period) || canManageAssignment)"> -->
                     <!-- Student Answer Metadata Header -->
                     <div class="each-header clearfix">
                         <compair-avatar ng-show="!answerFilters.anonymous" user-id="answer.user_id" avatar="answer.user.avatar" display-name="answer.user.displayname" full-name="answer.user.fullname" me="!canManageAssignment && answer.user_id == loggedInUserId"></compair-avatar>
                         <span ng-show="answerFilters.anonymous">Student</span>
+                        <span class="label label-default" ng-show="!answerFilters.anonymous" ng-if="instructors[answer.user_id]">{{instructors[answer.user_id]}}</span>
                         <strong>answered</strong> on {{answer.created | amDateFormat: 'MMM D @ h:mm a'}}:
                         <div class="manager-actions pull-right">
                             <!-- Student Score (not used for instructor answers) -->

--- a/compair/tests/api/test_assignment.py
+++ b/compair/tests/api/test_assignment.py
@@ -1257,16 +1257,18 @@ class AssignmentStatusAnswersAPITests(ComPAIRAPITestCase):
                     self.assertEqual(status['comparisons']['count'], 0)
                     self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
                     self.assertFalse(status['comparisons']['has_draft'])
-                    self.assertFalse(status['answers']['answered'])
-                    self.assertEqual(status['answers']['count'], 0)
+                    # by default, the test data created a non-comparable answer for instructor in add_course
+                    self.assertTrue(status['answers']['answered'])
+                    self.assertEqual(status['answers']['count'], 1)
                     self.assertEqual(status['answers']['feedback'], 0)
                 else:
                     self.assertTrue(status['comparisons']['available'])
                     self.assertEqual(status['comparisons']['count'], 0)
                     self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
                     self.assertFalse(status['comparisons']['has_draft'])
-                    self.assertFalse(status['answers']['answered'])
-                    self.assertEqual(status['answers']['count'], 0)
+                    # by default, the test data created a non-comparable answer for instructor in add_course
+                    self.assertTrue(status['answers']['answered'])
+                    self.assertEqual(status['answers']['count'], 1)
                     self.assertEqual(status['answers']['feedback'], 0)
 
             # test authorized instructor - multiple answers
@@ -1285,16 +1287,18 @@ class AssignmentStatusAnswersAPITests(ComPAIRAPITestCase):
                     self.assertEqual(status['comparisons']['count'], 0)
                     self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
                     self.assertFalse(status['comparisons']['has_draft'])
+                    # 1 non-comparable answer added by default in add_course, plus 3 added above
                     self.assertTrue(status['answers']['answered'])
-                    self.assertEqual(status['answers']['count'], 3)
+                    self.assertEqual(status['answers']['count'], 4)
                     self.assertEqual(status['answers']['feedback'], 0)
                 else:
                     self.assertTrue(status['comparisons']['available'])
                     self.assertEqual(status['comparisons']['count'], 0)
                     self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
                     self.assertFalse(status['comparisons']['has_draft'])
-                    self.assertFalse(status['answers']['answered'])
-                    self.assertEqual(status['answers']['count'], 0)
+                    # by default, the test data created a non-comparable answer for instructor in add_course
+                    self.assertTrue(status['answers']['answered'])
+                    self.assertEqual(status['answers']['count'], 1)
                     self.assertEqual(status['answers']['feedback'], 0)
 
         self.fixtures.add_students(1)
@@ -1379,8 +1383,9 @@ class AssignmentStatusAnswersAPITests(ComPAIRAPITestCase):
             self.assertEqual(status['comparisons']['count'], 0)
             self.assertEqual(status['comparisons']['left'], self.fixtures.assignment.total_comparisons_required)
             self.assertFalse(status['comparisons']['has_draft'])
-            self.assertFalse(status['answers']['answered'])
-            self.assertEqual(status['answers']['count'], 0)
+            # by default, the test data created a non-comparable answer for instructor in add_course
+            self.assertTrue(status['answers']['answered'])
+            self.assertEqual(status['answers']['count'], 1)
             self.assertEqual(status['answers']['feedback'], 0)
 
             # test authorized instructor - multiple answers
@@ -1396,7 +1401,8 @@ class AssignmentStatusAnswersAPITests(ComPAIRAPITestCase):
             self.assertEqual(status['comparisons']['left'], self.fixtures.assignment.total_comparisons_required)
             self.assertFalse(status['comparisons']['has_draft'])
             self.assertTrue(status['answers']['answered'])
-            self.assertEqual(status['answers']['count'], 3)
+            # 1 non-comparable answer created by default in add_course, plus 3 created above
+            self.assertEqual(status['answers']['count'], 4)
             self.assertEqual(status['answers']['feedback'], 0)
 
         self.fixtures.add_students(1)

--- a/compair/tests/api/test_report.py
+++ b/compair/tests/api/test_report.py
@@ -564,7 +564,8 @@ class ReportAPITest(ComPAIRAPITestCase):
                 assignment_id=assignment.id,
                 draft=False,
                 practice=False,
-                active=True
+                active=True,
+                comparable=True
             ) \
             .first()
 

--- a/data/fixtures/test_data.py
+++ b/data/fixtures/test_data.py
@@ -545,6 +545,7 @@ class TestFixture:
         self.dropped_answers = []
         self.removed_answers = []
         self.draft_answers = []
+        self.non_comparable_answers =[]
         self.groups = []
         self.unauthorized_instructor = UserFactory(system_role=SystemRole.instructor)
         self.unauthorized_student = UserFactory(system_role=SystemRole.student)
@@ -556,7 +557,7 @@ class TestFixture:
         db.session.commit()
 
     def add_course(self, num_students=5, num_assignments=1, num_additional_criteria=0, num_groups=0, num_answers='#',
-            with_comments=False, with_draft_student=False, with_comparisons=False, with_self_eval=False):
+            with_comments=False, with_draft_student=False, with_comparisons=False, with_self_eval=False, num_non_comparable_ans=1):
         self.course = CourseFactory()
         self.instructor = UserFactory(system_role=SystemRole.instructor)
         self.enrol_user(self.instructor, self.course, CourseRole.instructor)
@@ -572,6 +573,7 @@ class TestFixture:
         self.assignment = self.assignments[0]
 
         self.add_answers(num_answers, with_comments=with_comments)
+        self.add_non_comparable_answers(num_non_comparable_ans)
 
         if with_comparisons:
             self.add_comparisons(with_comments=with_comments, with_self_eval=with_self_eval)
@@ -671,9 +673,21 @@ class TestFixture:
                     user=dropped_student
                 )
                 self.dropped_answers.append(answer)
+
         db.session.commit()
 
         return self
+
+    def add_non_comparable_answers(self, num_non_comparable_ans):
+        for assignment in self.assignments:
+            for i in range(num_non_comparable_ans):
+                answer = AnswerFactory(
+                    assignment=assignment,
+                    user=self.instructor,
+                    comparable=False)
+                self.answers.append(answer)
+                self.non_comparable_answers.append(answer)
+        db.session.commit()
 
     def add_comparisons(self, with_comments=False, with_self_eval=False):
         for assignment in self.assignments:


### PR DESCRIPTION
When viewing ranked answers:
- for instructors, all comparable answers (including those
not-yet-compared) should be included
- for students, only ranked answers within the display limit will be
shown

Fix GET `/api/courses/:course_id/assignments/:assignment_id/answers`
API:
- instructors and TAs can see ranks/scores no matter what `orderBy` is
specified
- students can only see ranks if:
  (1) assignment has `rank_display_limit` set; and,
  (2) `orderBy` equals `score`

When retrieving specific answer by ID, don't include rank/score if user
is restricted.

Closes #662, closes #657