### PR TITLE
Fix rich content attachment refresh

### DIFF
--- a/compair/static/modules/rich-content/rich-content-directive.js
+++ b/compair/static/modules/rich-content/rich-content-directive.js
@@ -318,7 +318,9 @@ module.directive('richContent',
 
                     // needs to be compiled by dynamic
                     $scope.richContent = '<div mathjax hljs >'+content+'</div>';
+                };
 
+                var processAttachment = function() {
                     $scope.attachmentContent = [];
                     if ($scope.attachment) {
                         $scope.attachmentContent.push(
@@ -328,7 +330,9 @@ module.directive('richContent',
                 };
 
                 $scope.$watchCollection('content', processContent);
-                processContent()
+                $scope.$watchCollection('attachment', processAttachment);
+                processContent();
+                processAttachment();
             }
         };
     }


### PR DESCRIPTION
The attachment part of the rich content was not updating when the only the attachment changes (not content). separated it out into two different functions with a watcher on each.