### PR TITLE
Misc fixes for assignments and answers

### DIFF
--- a/compair/static/modules/answer/answer-module.js
+++ b/compair/static/modules/answer/answer-module.js
@@ -151,6 +151,10 @@ module.controller(
                 }
             )
 
+            if ($scope.canManageAssignment) {
+                // preset the user_id if instructors creating new answers
+                $scope.answer.user_id = $scope.loggedInUserId;
+            }
         }
         if ($scope.canManageAssignment) {
             // get list of users in the course
@@ -159,7 +163,6 @@ module.controller(
                     $scope.classlist = ret.objects;
                 }
             );
-            $scope.answer.user_id = $scope.loggedInUserId;
         }
 
         if ($scope.method == "create" || !$scope.answer.draft) {

--- a/compair/static/modules/assignment/assignment-module.js
+++ b/compair/static/modules/assignment/assignment-module.js
@@ -959,9 +959,7 @@ module.controller("AssignmentViewController",
                         $scope.assignment.status.answers.answered = $scope.assignment.status.answers.count > 0;
                     }
                     $scope.updateAnswerList();
-                    $location.hash(null);
-                    $location.search({'tab':'your_feedback'});
-                    $route.reload();
+                    $scope.loadTabData();
                     Toaster.success("Answer Deleted");
                 }
             );

--- a/compair/static/modules/assignment/assignment-view-partial.html
+++ b/compair/static/modules/assignment/assignment-view-partial.html
@@ -179,7 +179,7 @@
                         <span class="label label-default" ng-if="isInstructor(answer.user_id)">{{instructorLabel(answer.user_id)}}</span>
                         <strong>said</strong> on {{answer.created | amDateFormat: 'MMM D @ h:mm a'}}:
                         <div class="manager-actions pull-right" ng-if="canManageAssignment">
-                            <em>{{instructors[answer.user_id]}} Response</em>
+                            <em>{{instructorLabel(answer.user_id)}} Response</em>
                             <span ng-if="canManageAssignment && !answerFilters.anonymous && answer.score && answer.comparable" class="label label-warning score-tooltip" uib-tooltip="Scores are normalized, so the top-ranked answer or&mdash;in the case of a tie&mdash;answers for the assignment receive 100%. All other answers receive a lower percentage based on how well they did compared to the top-ranked answer." tooltip-trigger tooltip-animation="false" tooltip-placement="left">
                                 Score: {{answer.score.normalized_score}}%
                             </span>


### PR DESCRIPTION
- Fix a label issue of non-comparable instructor answers on assignment
screen. Closes #699
- Fix issue of jumping to "your feedback" tab after instructors deleting
answers. Closes #705
- Fix issue of instructors can't edit student answers. Closes #708