### PR TITLE
Allow instructor create answer when student has draft

### DIFF
--- a/data/fixtures/test_data.py
+++ b/data/fixtures/test_data.py
@@ -732,10 +732,11 @@ class TestFixture:
 
         return self
 
-    def add_answer(self, assignment, user):
+    def add_answer(self, assignment, user, draft=False):
         answer = AnswerFactory(
             assignment=assignment,
-            user=user
+            user=user,
+            draft=draft
         )
         db.session.commit()
         self.answers.append(answer)


### PR DESCRIPTION
Instructor can now create answers for students as long as they do not have an active non-draft answer. If the student has a draft already, it is automatically soft deleted

Closes  #711