### PR TITLE
Display student names consistently for grading

### DIFF
--- a/compair/api/answer_comment.py
+++ b/compair/api/answer_comment.py
@@ -75,7 +75,7 @@ class AnswerCommentListAPI(Resource):
                 'user_id': 1,
                 'user_displayname': 'John',
                 'user_fullname': 'John Smith',
-                'fullname_sortable': 'Smith, John',
+                'fullname_sortable': 'Smith, John (12345678)',
                 'user_avatar': '12k3jjh24k32jhjksaf',
                 'comment_type': 'self_evaluation',
                 'course_id': 1,

--- a/compair/api/dataformat/__init__.py
+++ b/compair/api/dataformat/__init__.py
@@ -17,6 +17,7 @@ def get_partial_user(restrict_user=True):
         'avatar': fields.String(attribute="user_avatar"),
     }
     if not restrict_user:
+        ret['student_number'] = fields.String(attribute="user_student_number")
         ret['fullname'] = fields.String(attribute="user_fullname")
         ret['fullname_sortable'] = fields.String(attribute="user_fullname_sortable")
 
@@ -303,7 +304,7 @@ def get_comparison(restrict_user=True, with_answers=True, with_feedback=False, i
 
 def get_comparison_set(restrict_user=True, with_user=True):
     ret = {
-        'comparisons': fields.List(fields.Nested(get_comparison(restrict_user, True, True))),
+        'comparisons': fields.List(fields.Nested(get_comparison(restrict_user, with_answers=True, with_feedback=True))),
         'self_evaluations': fields.List(fields.Nested(get_answer_comment(restrict_user)))
     }
 

--- a/compair/models/answer.py
+++ b/compair/models/answer.py
@@ -48,6 +48,7 @@ class Answer(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
     user_avatar = association_proxy('user', 'avatar')
     user_uuid = association_proxy('user', 'uuid')
     user_displayname = association_proxy('user', 'displayname')
+    user_student_number = association_proxy('user', 'student_number')
     user_fullname = association_proxy('user', 'fullname')
     user_fullname_sortable = association_proxy('user', 'fullname_sortable')
     user_system_role = association_proxy('user', 'system_role')

--- a/compair/models/answer_comment.py
+++ b/compair/models/answer_comment.py
@@ -41,6 +41,7 @@ class AnswerComment(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixi
     user_avatar = association_proxy('user', 'avatar')
     user_uuid = association_proxy('user', 'uuid')
     user_displayname = association_proxy('user', 'displayname')
+    user_student_number = association_proxy('user', 'student_number')
     user_fullname = association_proxy('user', 'fullname')
     user_fullname_sortable = association_proxy('user', 'fullname_sortable')
     user_system_role = association_proxy('user', 'system_role')

--- a/compair/models/assignment.py
+++ b/compair/models/assignment.py
@@ -72,6 +72,7 @@ class Assignment(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
     user_avatar = association_proxy('user', 'avatar')
     user_uuid = association_proxy('user', 'uuid')
     user_displayname = association_proxy('user', 'displayname')
+    user_student_number = association_proxy('user', 'student_number')
     user_fullname = association_proxy('user', 'fullname')
     user_fullname_sortable = association_proxy('user', 'fullname_sortable')
     user_system_role = association_proxy('user', 'system_role')

--- a/compair/models/assignment_comment.py
+++ b/compair/models/assignment_comment.py
@@ -32,6 +32,7 @@ class AssignmentComment(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTracking
     user_avatar = association_proxy('user', 'avatar')
     user_uuid = association_proxy('user', 'uuid')
     user_displayname = association_proxy('user', 'displayname')
+    user_student_number = association_proxy('user', 'student_number')
     user_fullname = association_proxy('user', 'fullname')
     user_fullname_sortable = association_proxy('user', 'fullname_sortable')
     user_system_role = association_proxy('user', 'system_role')

--- a/compair/models/comparison.py
+++ b/compair/models/comparison.py
@@ -59,6 +59,7 @@ class Comparison(DefaultTableMixin, UUIDMixin, WriteTrackingMixin):
     user_avatar = association_proxy('user', 'avatar')
     user_uuid = association_proxy('user', 'uuid')
     user_displayname = association_proxy('user', 'displayname')
+    user_student_number = association_proxy('user', 'student_number')
     user_fullname = association_proxy('user', 'fullname')
     user_fullname_sortable = association_proxy('user', 'fullname_sortable')
     user_system_role = association_proxy('user', 'system_role')

--- a/compair/models/user.py
+++ b/compair/models/user.py
@@ -111,7 +111,9 @@ class User(DefaultTableMixin, UUIDMixin, WriteTrackingMixin, UserMixin):
 
     @hybrid_property
     def fullname_sortable(self):
-        if self.firstname and self.lastname:
+        if self.firstname and self.lastname and self.system_role == SystemRole.student and self.student_number:
+            return '%s, %s (%s)' % (self.lastname, self.firstname, self.student_number)
+        elif self.firstname and self.lastname:
             return '%s, %s' % (self.lastname, self.firstname)
         elif self.firstname:  # only first name provided
             return self.firstname

--- a/compair/static/modules/assignment/assignment-module_spec.js
+++ b/compair/static/modules/assignment/assignment-module_spec.js
@@ -257,7 +257,7 @@ describe('assignment-module', function () {
                     "avatar": "27e062bf3df59edebb5db9f89952c8b3",
                     "displayname": "student6",
                     "fullname": "Student Sx",
-                    "fullname_sortable": "Sx, Student",
+                    "fullname_sortable": "Sx, Student (123456)",
                     "id": "8abcABC123-abcABC123_Z",
                 },
                 "user_id": "8abcABC123-abcABC123_Z",
@@ -394,7 +394,7 @@ describe('assignment-module', function () {
                     "avatar": "7c8cd5da17441ff04bf445736964dd16",
                     "displayname": "student9",
                     "fullname": "Student Nine",
-                    "fullname_sortable": "Nine, Student",
+                    "fullname_sortable": "Nine, Student (123456789)",
                     "id": "11bcABC123-abcABC123_Z"
                 },
                 "user_id": "11bcABC123-abcABC123_Z"
@@ -420,7 +420,7 @@ describe('assignment-module', function () {
                     "avatar": "27e062bf3df59edebb5db9f89952c8b3",
                     "displayname": "student6",
                     "fullname": "Student Sx",
-                    "fullname_sortable": "Sx, Student",
+                    "fullname_sortable": "Sx, Student (123456)",
                     "id": "8abcABC123-abcABC123_Z"
                 },
                 "user_id": "8abcABC123-abcABC123_Z"
@@ -446,7 +446,7 @@ describe('assignment-module', function () {
                     "avatar": "2c62e6068c765179e1aed9bc2bfd4689",
                     "displayname": "student10",
                     "fullname": "Student Ten",
-                    "fullname_sortable": "Ten, Student",
+                    "fullname_sortable": "Ten, Student (1234567890)",
                     "id": "12bcABC123-abcABC123_Z"
                 },
                 "user_id": "12abcABC123-abcABC123_Z"
@@ -472,7 +472,7 @@ describe('assignment-module', function () {
                     "avatar": "8aa7fb36a4efbbf019332b4677b528cf",
                     "displayname": "student8",
                     "fullname": "Student Eight",
-                    "fullname_sortable": "Eight, Student",
+                    "fullname_sortable": "Eight, Student (12345678)",
                     "id": "10bcABC123-abcABC123_Z"
                 },
                 "user_id": "10bcABC123-abcABC123_Z"
@@ -498,7 +498,7 @@ describe('assignment-module', function () {
                     "avatar": "9fd9280a7aa3578c8e853745a5fcc18a",
                     "displayname": "student5",
                     "fullname": "Student Five",
-                    "fullname_sortable": "Five, Student",
+                    "fullname_sortable": "Five, Student (12345)",
                     "id": "7abcABC123-abcABC123_Z"
                 },
                 "user_id": "7abcABC123-abcABC123_Z"
@@ -524,7 +524,7 @@ describe('assignment-module', function () {
                     "avatar": "213ee683360d88249109c2f92789dbc3",
                     "displayname": "student2",
                     "fullname": "Student Two",
-                    "fullname_sortable": "Two, Student",
+                    "fullname_sortable": "Two, Student (12)",
                     "id": "4abcABC123-abcABC123_Z"
                 },
                 "user_id": "4abcABC123-abcABC123_Z"
@@ -550,7 +550,7 @@ describe('assignment-module', function () {
                     "avatar": "8e4947690532bc44a8e41e9fb365b76a",
                     "displayname": "student3",
                     "fullname": "Student Three",
-                    "fullname_sortable": "Three, Student",
+                    "fullname_sortable": "Three, Student (123)",
                     "id": "5abcABC123-abcABC123_Z"
                 },
                 "user_id": "5abcABC123-abcABC123_Z"
@@ -576,7 +576,7 @@ describe('assignment-module', function () {
                     "avatar": "72e8744fc2faa17a83dec9bed06b8b65",
                     "displayname": "student7",
                     "fullname": "Student Seven",
-                    "fullname_sortable": "Seven, Student",
+                    "fullname_sortable": "Seven, Student (1234567)",
                     "id": "9abcABC123-abcABC123_Z",
                 },
                 "user_id": "9abcABC123-abcABC123_Z",
@@ -602,7 +602,7 @@ describe('assignment-module', function () {
                     "avatar": "5e5545d38a68148a2d5bd5ec9a89e327",
                     "displayname": "student1",
                     "fullname": "Student One",
-                    "fullname_sortable": "One, Student",
+                    "fullname_sortable": "One, Student (1)",
                     "id": "3abcABC123-abcABC123_Z"
                 },
                 "user_id": "3abcABC123-abcABC123_Z"
@@ -628,7 +628,7 @@ describe('assignment-module', function () {
                     "avatar": "166a50c910e390d922db4696e4c7747b",
                     "displayname": "student4",
                     "fullname": "Student Four",
-                    "fullname_sortable": "Four, Student",
+                    "fullname_sortable": "Four, Student (1234)",
                     "id": "6abcABC123-abcABC123_Z"
                 },
                 "user_id": "6abcABC123-abcABC123_Z"
@@ -653,7 +653,7 @@ describe('assignment-module', function () {
                 "avatar": "27e062bf3df59edebb5db9f89952c8b3",
                 "displayname": "student6",
                 "fullname": "Student Sx",
-                "fullname_sortable": "Sx, Student",
+                "fullname_sortable": "Sx, Student (123456)",
                 "id": "8abcABC123-abcABC123_Z",
             },
             "user_id": "8abcABC123-abcABC123_Z",

--- a/compair/static/modules/assignment/assignment-view-partial.html
+++ b/compair/static/modules/assignment/assignment-view-partial.html
@@ -175,7 +175,7 @@
 
                     <!-- Instructor Answer Metadata Header -->
                     <div class="each-header clearfix">
-                        <compair-avatar user-id="answer.user_id" avatar="answer.user.avatar" display-name="answer.user.displayname" full-name="answer.user.fullname"></compair-avatar>
+                        <compair-avatar user-id="answer.user_id" avatar="answer.user.avatar" main-identifier="answer.user.displayname" secondary-identifier="answer.user.fullname"></compair-avatar>
                         <span class="label label-default" ng-if="instructors[answer.user_id]">{{instructors[answer.user_id]}}</span>
                         <strong>said</strong> on {{answer.created | amDateFormat: 'MMM D @ h:mm a'}}:
                         <div class="manager-actions pull-right" ng-if="canManageAssignment">
@@ -217,7 +217,7 @@
                 <!-- <div class="each-answer clearfix" ng-repeat="(answerKey, answer) in answers" ng-if="!instructors[answer.user_id] && (see_answers || (answer.user_id == loggedInUserId && assignment.answer_period) || canManageAssignment)"> -->
                     <!-- Student Answer Metadata Header -->
                     <div class="each-header clearfix">
-                        <compair-avatar ng-show="!answerFilters.anonymous" user-id="answer.user_id" avatar="answer.user.avatar" display-name="answer.user.displayname" full-name="answer.user.fullname" me="!canManageAssignment && answer.user_id == loggedInUserId"></compair-avatar>
+                        <compair-avatar ng-show="!answerFilters.anonymous" user-id="answer.user_id" avatar="answer.user.avatar" main-identifier="answer.user.displayname" secondary-identifier="answer.user.fullname" me="!canManageAssignment && answer.user_id == loggedInUserId"></compair-avatar>
                         <span ng-show="answerFilters.anonymous">Student</span>
                         <span class="label label-default" ng-show="!answerFilters.anonymous" ng-if="instructors[answer.user_id]">{{instructors[answer.user_id]}}</span>
                         <strong>answered</strong> on {{answer.created | amDateFormat: 'MMM D @ h:mm a'}}:
@@ -301,7 +301,7 @@
 
                             <!-- Student Reply Metadata Header -->
                             <div class="each-header clearfix">
-                                <compair-avatar user-id="comment.user_id" avatar="comment.user.avatar" display-name="comment.user.displayname" full-name="comment.user.fullname"></compair-avatar>
+                                <compair-avatar user-id="comment.user_id" avatar="comment.user.avatar" main-identifier="comment.user.displayname" secondary-identifier="comment.user.fullname"></compair-avatar>
                                 <span class="label label-default" ng-if="instructors[comment.user_id]">{{instructors[comment.user_id]}}</span>
                                 <strong ng-if="comment.comment_type == AnswerCommentType.private || comment.comment_type == AnswerCommentType.evaluation"> gave private feedback <span class="glyphicon glyphicon-lock"></span></strong>
                                 <strong ng-if="comment.comment_type == AnswerCommentType.self_evaluation"> self-evaluated <span class="glyphicon glyphicon-lock"></span></strong>
@@ -417,7 +417,7 @@
 
                         <!-- Student Reply Metadata Header -->
                         <div class="each-header clearfix">
-                            <compair-avatar user-id="comment.user_id" avatar="comment.user.avatar" display-name="comment.user.displayname" full-name="comment.user.fullname"></compair-avatar>
+                            <compair-avatar user-id="comment.user_id" avatar="comment.user.avatar" main-identifier="comment.user.displayname" secondary-identifier="comment.user.fullname"></compair-avatar>
                             <span class="label label-default" ng-if="instructors[comment.user_id]">{{instructors[comment.user_id]}}</span>
                             <strong ng-if="comment.comment_type == AnswerCommentType.private || comment.comment_type == AnswerCommentType.evaluation"> gave private feedback <span class="glyphicon glyphicon-lock"></span></strong>
                             <strong ng-if="comment.comment_type == AnswerCommentType.self_evaluation"> self-evaluated <span class="glyphicon glyphicon-lock"></span></strong>

--- a/compair/static/modules/classlist/classlist-enrol-partial.html
+++ b/compair/static/modules/classlist/classlist-enrol-partial.html
@@ -4,7 +4,7 @@
             <label>Add: </label>
             <div class="input-group">
                 <label class="sr-only" for="user">Name</label>
-                <input type="text" ng-model="$ctrl.user" name="user" required uib-typeahead="u as u.fullname_sortable+' ('+u.system_role+')' for u in $ctrl.getUsersAhead($viewValue)"
+                <input type="text" ng-model="$ctrl.user" name="user" required uib-typeahead="u as u.fullname_sortable+' - '+u.system_role for u in $ctrl.getUsersAhead($viewValue)"
                    placeholder="display or first name" class="form-control" autocomplete="off"
                    typeahead-editable="false" typeahead-min-length="2" typeahead-wait-ms="300">
             </div>

--- a/compair/static/modules/comment/answer.html
+++ b/compair/static/modules/comment/answer.html
@@ -1,5 +1,5 @@
 <div ng-if="answer">
-    <compair-avatar user-id="answer.user_id" avatar="answer.user.avatar" display-name="answer.user.fullname"></compair-avatar>
+    <compair-avatar user-id="answer.user_id" avatar="answer.user.avatar" main-identifier="answer.user.fullname" secondary-identifier="answer.user.student_number"></compair-avatar>
     <strong>answered</strong> on {{ answer.created | amDateFormat: 'MMM D @ h:mm a'}}:
     <rich-content content="answer.content" attachment="answer.file"></rich-content>
 </div>

--- a/compair/static/modules/common/avatar-directive.js
+++ b/compair/static/modules/common/avatar-directive.js
@@ -6,17 +6,17 @@
             scope: {
                 userId: '=',
                 avatar: '=',
-                displayName: '=?',
-                fullName: '=?',
+                mainIdentifier: '=?',
+                secondaryIdentifier: '=?',
                 me: '=?'
             },
             template: '<a ng-href="#/user/{{ userId }}">' +
                         '<img src="//www.gravatar.com/avatar/{{ avatar }}?s=32&d=retro" alt="" /> ' +
                       '</a>' +
                       '<a ng-href="#/user/{{ userId }}">' +
-                        '{{ displayName }}' +
-                        '<span ng-if="me">{{ displayName ? " (You)" : "You" }}</span>' +
-                        '<span ng-if="fullName"> ({{ fullName }})</span>' +
+                        '{{ mainIdentifier }}' +
+                        '<span ng-if="me">{{ mainIdentifier ? " (You)" : "You" }}</span>' +
+                        '<span ng-if="secondaryIdentifier"> ({{ secondaryIdentifier }})</span>' +
                       '</a>'
         };
     });

--- a/compair/static/modules/common/avatar-directive_spec.js
+++ b/compair/static/modules/common/avatar-directive_spec.js
@@ -15,7 +15,7 @@ describe('avatar-directive', function () {
             $rootScope.displayName = 'Optimus Prime';
         });
         element = angular.element(
-            '<compair-avatar user-id="userId" avatar="avatar" display-name="displayName"></compair-avatar>'
+            '<compair-avatar user-id="userId" avatar="avatar" main-identifier="displayName"></compair-avatar>'
         );
         $compile(element)($rootScope);
         $rootScope.$digest();
@@ -35,7 +35,7 @@ describe('avatar-directive', function () {
             $rootScope.displayName = 'Optimus Prime';
         });
         element = angular.element(
-            '<compair-avatar user-id="userId" avatar="avatar" display-name="displayName" me="true"></compair-avatar>'
+            '<compair-avatar user-id="userId" avatar="avatar" main-identifier="displayName" me="true"></compair-avatar>'
         );
         $compile(element)($rootScope);
         $rootScope.$digest();
@@ -68,7 +68,7 @@ describe('avatar-directive', function () {
             $rootScope.fullName = 'John Smith';
         });
         element = angular.element(
-            '<compair-avatar user-id="userId" avatar="avatar" display-name="displayName" full-name="fullName"></compair-avatar>'
+            '<compair-avatar user-id="userId" avatar="avatar" main-identifier="displayName" secondary-identifier="fullName"></compair-avatar>'
         );
         $compile(element)($rootScope);
         $rootScope.$digest();
@@ -84,7 +84,7 @@ describe('avatar-directive', function () {
             $rootScope.displayName = 'Optimus Prime';
         });
         element = angular.element(
-            '<compair-avatar user-id="userId" avatar="avatar" display-name="displayName" full-name="fullName"></compair-avatar>'
+            '<compair-avatar user-id="userId" avatar="avatar" main-identifier="displayName" secondary-identifier="fullName"></compair-avatar>'
         );
         $compile(element)($rootScope);
         $rootScope.$digest();

--- a/compair/static/modules/comparison/comparison-view-partial.html
+++ b/compair/static/modules/comparison/comparison-view-partial.html
@@ -58,7 +58,7 @@
                     <div class="" ng-if="comparison_set.self_evaluations.length > 0">
                         <div ng-repeat="self_evaluation in comparison_set.self_evaluations">
                             <div class="each-header">
-                                <compair-avatar user-id="self_evaluation.user_id" avatar="self_evaluation.user.avatar" display-name="self_evaluation.user.fullname"></compair-avatar>
+                                <compair-avatar user-id="self_evaluation.user_id" avatar="self_evaluation.user.avatar" main-identifier="self_evaluation.user.fullname" secondary-identifier="self_evaluation.user.student_number"></compair-avatar>
                                 <strong>self-evaluated</strong> on {{ self_evaluation.created | amDateFormat: 'MMM D @ h:mm a'}}:
                             </div>
                             <div class="content" mathjax hljs ng-bind-html="self_evaluation.content"></div>
@@ -68,7 +68,7 @@
 
                 <!-- Comparison Header -->
                 <div class="each-header">
-                    <compair-avatar user-id="comparison.user_id" avatar="comparison.user.avatar" display-name="comparison.user.fullname"></compair-avatar>
+                    <compair-avatar user-id="comparison.user_id" avatar="comparison.user.avatar" main-identifier="comparison.user.fullname" secondary-identifier="comparison.user.student_number"></compair-avatar>
                     <strong>compared</strong> on {{ comparison.created | amDateFormat: 'MMM D @ h:mm a'}}:
                 </div>
 

--- a/compair/static/modules/gradebook/gradebook-partial.html
+++ b/compair/static/modules/gradebook/gradebook-partial.html
@@ -30,13 +30,13 @@
         <thead>
             <tr>
                 <th>
-                    <a href="" ng-click="updateTableOrderBy('user.displayname')">Display Name</a>
-                </th>
-                <th>
                     <a href="" ng-click="updateTableOrderBy('user.firstname')">First Name</a>
                 </th>
                 <th>
                     <a href="" ng-click="updateTableOrderBy('user.lastname')">Last Name</a>
+                </th>
+                <th>
+                    <a href="" ng-click="updateTableOrderBy('user.student_number')">Student Number</a>
                 </th>
                 <th class="text-center" ng-if="!includeScores">
                     <a href="" ng-click="updateTableOrderBy('num_answers')">Answered</a>
@@ -65,9 +65,9 @@
         </thead>
         <tbody>
             <tr ng-repeat="entry in gradebook | filter:groupFilter() | orderBy:predicate:reverse">
-                <td><i class="fa fa-user"></i> {{entry.user.displayname}}</td>
                 <td>{{entry.user.firstname}}</td>
                 <td>{{entry.user.lastname}}</td>
+                <td>{{entry.user.student_number}}</td>
                 <td class="text-center text-success" ng-if="!includeScores && entry.num_answers > 0"><strong>Yes</strong></td>
                 <td class="text-center text-danger" ng-if="!includeScores && entry.num_answers == 0"><strong>No</strong></td>
                 <td class="text-center" ng-if="includeScores">

--- a/compair/static/test/factories/http_backend_mocks.js
+++ b/compair/static/test/factories/http_backend_mocks.js
@@ -175,6 +175,9 @@ module.exports.httpbackendMock = function(storageFixtures) {
             newUser = angular.merge({}, newUser, data);
             newUser.fullname = newUser.firstname + " " + newUser.lastname;
             newUser.fullname_sortable = newUser.lastname + ", " + newUser.firstname;
+            if (newUser.student_number) {
+                newUser.fullname_sortable += " ("+newUser.student_number+")";
+            }
 
             storageFixture.storage().users[newUser.id] = newUser;
 

--- a/compair/static/test/fixtures/admin/default_fixture.js
+++ b/compair/static/test/fixtures/admin/default_fixture.js
@@ -69,7 +69,8 @@ var student1 = userFactory.generateUser("3abcABC123-abcABC123_Z", "Student", {
     firstname: "First",
     lastname: "Student",
     fullname: "First Student",
-    fullname_sortable: "Student, First",
+    fullname_sortable: "Student, First (12345678)",
+    student_number: "12345678",
     email: "first.student@exmple.com"
 });
 storage.users[student1.id] = student1;
@@ -80,7 +81,8 @@ var student2 = userFactory.generateUser("4abcABC123-abcABC123_Z", "Student", {
     firstname: "Second",
     lastname: "Student",
     fullname: "Second Student",
-    fullname_sortable: "Student, Second",
+    fullname_sortable: "Student, Second (123456789)",
+    student_number: "123456789",
     email: "second.student@exmple.com"
 });
 storage.users[student2.id] = student2;

--- a/compair/static/test/fixtures/instructor/default_fixture.js
+++ b/compair/static/test/fixtures/instructor/default_fixture.js
@@ -52,7 +52,8 @@ var student1 = userFactory.generateUser("3abcABC123-abcABC123_Z", "Student", {
     firstname: "First",
     lastname: "Student",
     fullname: "First Student",
-    fullname_sortable: "Student, First",
+    fullname_sortable: "Student, First (12345678)",
+    student_number: "12345678",
     email: "first.student@exmple.com"
 });
 storage.users[student1.id] = student1;
@@ -63,7 +64,8 @@ var student2 = userFactory.generateUser("4abcABC123-abcABC123_Z", "Student", {
     firstname: "Second",
     lastname: "Student",
     fullname: "Second Student",
-    fullname_sortable: "Student, Second",
+    fullname_sortable: "Student, Second (123456789)",
+    student_number: "123456789",
     email: "second.student@exmple.com"
 });
 storage.users[student2.id] = student2;

--- a/compair/static/test/fixtures/student/default_fixture.js
+++ b/compair/static/test/fixtures/student/default_fixture.js
@@ -57,7 +57,8 @@ var student = userFactory.generateUser("3abcABC123-abcABC123_Z", "Student", {
     firstname: "First",
     lastname: "Student",
     fullname: "First Student",
-    fullname_sortable: "Student, First",
+    fullname_sortable: "Student, First (12345678)",
+    student_number: "12345678",
     email: "first.student@exmple.com"
 });
 storage.users[student.id] = student;

--- a/compair/tests/test_models.py
+++ b/compair/tests/test_models.py
@@ -26,6 +26,17 @@ class TestUsersModel(ComPAIRTestCase):
     def test_fullname_sortable(self):
         self.assertEqual(self.user.fullname_sortable, "Smith, John")
 
+        # test with student number
+        self.user.student_number = '123456789'
+        self.user.system_role = SystemRole.sys_admin
+        self.assertEqual(self.user.fullname_sortable, "Smith, John")
+
+        self.user.system_role = SystemRole.instructor
+        self.assertEqual(self.user.fullname_sortable, "Smith, John")
+
+        self.user.system_role = SystemRole.student
+        self.assertEqual(self.user.fullname_sortable, "Smith, John (123456789)")
+
     def test_avatar(self):
         # role != student
         self.user.email = "myemailaddress@example.com"


### PR DESCRIPTION
- Participation tab: add student number column and remove display name column
- Comparison tab: use "FirstName LastName (StudentNumber)" for comparison, answer, and self-eval labels
- Changed fullname_sortable to include student number for users with system role student and who have student numbers. This was done as an easy way to integrate student number in multiple places for students like in user search selects in assignment screen.
- modified compairAvatar directive to be more ambiguous with its primary and secondary identifiers (so its easier to reuse in the comparisons tab without being confusing)

Closes #690