### PR TITLE
Prevent students from seeing same answer

### DIFF
--- a/compair/algorithms/pair/adaptive_min_delta/pair_generator.py
+++ b/compair/algorithms/pair/adaptive_min_delta/pair_generator.py
@@ -12,12 +12,8 @@ class AdaptiveMinDeltaPairGenerator(PairGenerator):
     def __init__(self):
         PairGenerator.__init__(self)
 
-        # holds comparison pairs the user has already completed
-        self.comparison_pairs = []
-        self.scored_objects = []
-
-        self.rounds = []
-        self.round_objects = {}
+        self.criterion_scores = {}
+        self.criterion_weights = {}
 
     def generate_pair(self, scored_objects, comparison_pairs, criterion_scores={}, criterion_weights={}):
         """
@@ -29,29 +25,15 @@ class AdaptiveMinDeltaPairGenerator(PairGenerator):
         param criterion_weights: dictionary of criterion key to weight
         """
 
-        self.comparison_pairs = comparison_pairs
-        self.scored_objects = scored_objects
         self.criterion_scores = criterion_scores
         self.criterion_weights = criterion_weights
-        self.rounds = []
-        self.round_objects = {}
 
-        # change None value scores to zero
-        for (index, scored_object) in enumerate(self.scored_objects):
-            if scored_object.score == None:
-                self.scored_objects[index] = scored_object._replace(score=0)
+        for key, criterion_score in criterion_scores.items():
+            for criterion_key, score in criterion_score.items():
+                if score == None:
+                    criterion_scores[key][criterion_key] = 0
 
-        self.rounds = list(set([a.rounds for a in self.scored_objects]))
-        self.rounds.sort()
-
-        for scored_object in self.scored_objects:
-            round = self.round_objects.setdefault(scored_object.rounds, [])
-            round.append(scored_object)
-
-        # check valid
-        if len(self.scored_objects) < 2:
-            raise InsufficientObjectsForPairException
-
+        self._setup_rounds(comparison_pairs, scored_objects)
         comparison_pair = self._find_pair()
 
         if comparison_pair == None:
@@ -61,7 +43,7 @@ class AdaptiveMinDeltaPairGenerator(PairGenerator):
 
     def _find_pair(self):
         """
-        Returns an comparison pair by matching them up by criteria score.
+        Returns a comparison pair by matching them up by criteria score.
         - First key is selected by random within the lowest round possible
         - First key must have a valid opponent with the current user or else its skipped
         - Second key candidates are filters by previous opponents to first key
@@ -130,6 +112,13 @@ class AdaptiveMinDeltaPairGenerator(PairGenerator):
             winner=None
         )
 
+    def _setup_rounds(self, comparison_pairs, scored_objects):
+        # change None value scores to zero
+        for (index, scored_object) in enumerate(scored_objects):
+            if scored_object.score == None:
+                scored_objects[index] = scored_object._replace(score=0)
+        PairGenerator._setup_rounds(self, comparison_pairs, scored_objects)
+
     def _criterion_score_delta_sum(self, scored_object_key1, scored_object_key2):
         """
         Returns the sum of delta of criterion scores between the the scored obj
@@ -137,59 +126,13 @@ class AdaptiveMinDeltaPairGenerator(PairGenerator):
         theSum = 0
         criterion_scores_1 = self.criterion_scores.setdefault(scored_object_key1, {})
         criterion_scores_2 = self.criterion_scores.setdefault(scored_object_key2, {})
+        criterion_key_list = set(criterion_scores_1.keys()) | set(criterion_scores_2.keys())
 
-        criterion_key_list = list(criterion_scores_1.keys())
-        criterion_key_list.extend(list(criterion_scores_2.keys()))
-        criterion_key_list = set(criterion_key_list)
+        for criterion_key in criterion_key_list:
+            score1 = criterion_scores_1.get(criterion_key, 0)
+            score2 = criterion_scores_2.get(criterion_key, 0)
+            weight = self.criterion_weights.get(criterion_key, 0)
 
-        for criterion in criterion_key_list:
-            score1 = criterion_scores_1.get(criterion, 0)
-            score2 = criterion_scores_2.get(criterion, 0)
-            weight = self.criterion_weights.get(criterion, 0)
-
-            theSum += math.fabs((score1 - score2)) * weight
+            theSum += math.fabs(score1 - score2) * weight
 
         return theSum
-
-    def _has_valid_opponent(self, key):
-        """
-        Returns True if scored object has at least one other scored object it
-        hasn't been compared to by the current user, False otherwise.
-        """
-        compared_keys = set()
-        compared_keys.add(key)
-        for comparison_pair in self.comparison_pairs:
-            # add opponents of key to compared_keys set
-            if comparison_pair.key1 == key:
-                compared_keys.add(comparison_pair.key2)
-            elif comparison_pair.key2 == key:
-                compared_keys.add(comparison_pair.key1)
-
-        all_keys = set([scored_object.key for scored_object in self.scored_objects])
-
-        # some comparison keys may have been soft deleted hence we need to use
-        # the set subtraction operation instead of comparing sizes
-        all_keys -= compared_keys
-
-        return all_keys
-
-    def _remove_invalid_opponents(self, key):
-        """
-        removes key and all opponents of key from score objects lists
-        """
-        filter_keys = set()
-        filter_keys.add(key)
-        for comparison_pair in self.comparison_pairs:
-            # add opponents of key to compared_keys set
-            if comparison_pair.key1 == key:
-                filter_keys.add(comparison_pair.key2)
-            elif comparison_pair.key2 == key:
-                filter_keys.add(comparison_pair.key1)
-
-        self.scored_objects = [so for so in self.scored_objects if so.key not in filter_keys]
-
-        # reinit round_objects
-        self.round_objects = {}
-        for scored_object in self.scored_objects:
-            round = self.round_objects.setdefault(scored_object.rounds, [])
-            round.append(scored_object)

--- a/compair/algorithms/pair/pair_generator.py
+++ b/compair/algorithms/pair/pair_generator.py
@@ -1,4 +1,6 @@
 from abc import ABCMeta, abstractmethod
+from compair.algorithms.exceptions import InsufficientObjectsForPairException, \
+    UserComparedAllObjectsException, UnknownPairGeneratorException
 
 class PairGenerator:
     __metaclass__ = ABCMeta
@@ -6,11 +8,91 @@ class PairGenerator:
     def __init__(self):
         self.log = None
 
+        # holds comparison pairs the user has already completed
+        self.comparison_pairs = []
+        self.scored_objects = []
+
+        self.rounds = []
+        self.round_objects = {}
+
     def _debug(self, message):
         if self.log != None:
             self.log.debug(message)
 
     @abstractmethod
-    def generate_pair(self, scored_objects, completed_comparison_pairs, criterion_scores={}, criterion_weights={}):
+    def generate_pair(self, scored_objects, completed_comparison_pairs):
         pass
 
+    def _setup_rounds(self, comparison_pairs, scored_objects):
+        """
+        set rounds using all existing scored objects instead (allows up to n(n-1)/2 comparsions)
+        forces user to have previously seen all scored objects almost all scored objects at least
+        once before they will be assigned a scored object again
+        """
+
+        self.comparison_pairs = comparison_pairs
+        self.scored_objects = scored_objects
+        self.rounds = []
+        self.round_objects = {}
+
+        # check valid
+        if len(self.scored_objects) < 2:
+            raise InsufficientObjectsForPairException
+
+        # check if there are any scored objects that haven't been previously used
+        all_keys = set([a.key for a in self.scored_objects])
+        used_keys = set([cp.key1 for cp in self.comparison_pairs]) | set([cp.key2 for cp in self.comparison_pairs])
+        unused_keys = all_keys - used_keys
+        if len(unused_keys) >= 2:
+            # set rounds using only unused scored objects (available for up to n/2 comparsions)
+            self.scored_objects = [a for a in self.scored_objects if a.key in unused_keys]
+
+        self.rounds = list(set([a.rounds for a in self.scored_objects]))
+        self.rounds.sort()
+
+        for scored_object in self.scored_objects:
+            round = self.round_objects.setdefault(scored_object.rounds, [])
+            round.append(scored_object)
+
+    def _has_valid_opponent(self, key):
+        """
+        Returns True if scored object has at least one other scored object it
+        hasn't been compared to by the current user, False otherwise.
+        """
+        compared_keys = set()
+        compared_keys.add(key)
+        for comparison_pair in self.comparison_pairs:
+            # add opponents of key to compared_keys set
+            if comparison_pair.key1 == key:
+                compared_keys.add(comparison_pair.key2)
+            elif comparison_pair.key2 == key:
+                compared_keys.add(comparison_pair.key1)
+
+        all_keys = set([scored_object.key for scored_object in self.scored_objects])
+
+        # some comparison keys may have been soft deleted hence we need to use
+        # the set subtraction operation instead of comparing sizes
+        all_keys -= compared_keys
+
+        return all_keys
+
+    def _remove_invalid_opponents(self, key):
+        """
+        removes key and all opponents of key from score objects lists
+        """
+        filter_keys = set()
+        filter_keys.add(key)
+        for comparison_pair in self.comparison_pairs:
+            # add opponents of key to compared_keys set
+            if comparison_pair.key1 == key:
+                filter_keys.add(comparison_pair.key2)
+            elif comparison_pair.key2 == key:
+                filter_keys.add(comparison_pair.key1)
+
+        self.scored_objects = [so for so in self.scored_objects if so.key not in filter_keys]
+
+        # reinit round_objects
+        self.round_objects = {}
+        for scored_object in self.scored_objects:
+            round = self.round_objects.setdefault(scored_object.rounds, [])
+            round.append(scored_object)

--- a/compair/api/assignment.py
+++ b/compair/api/assignment.py
@@ -451,6 +451,7 @@ class AssignmentIdStatusAPI(Resource):
             .filter_by(
                 user_id=current_user.id,
                 assignment_id=assignment.id,
+                comparable=True,
                 active=True,
                 practice=False,
                 draft=False
@@ -485,7 +486,13 @@ class AssignmentIdStatusAPI(Resource):
         comparison_count = assignment.completed_comparison_count_for_user(current_user.id)
         comparison_draft_count = assignment.draft_comparison_count_for_user(current_user.id)
         other_comparable_answers = assignment.comparable_answer_count - answer_count
-        comparison_available = comparison_count < other_comparable_answers * (other_comparable_answers - 1) / 2
+
+        # students can only begin comparing there there are enough answers submitted that they can do
+        # comparisons without seeing the same answer more than once
+        comparison_available = other_comparable_answers >= assignment.number_of_comparisons * 2
+        # instructors and tas can compare as long as there are new possible comparisons
+        if allow(EDIT, assignment):
+            comparison_available = comparison_count < other_comparable_answers * (other_comparable_answers - 1) / 2
 
         status = {
             'answers': {
@@ -568,6 +575,7 @@ class AssignmentRootStatusAPI(Resource):
             ) \
             .filter_by(
                 user_id=current_user.id,
+                comparable=True,
                 active=True,
                 practice=False,
                 draft=False
@@ -660,7 +668,13 @@ class AssignmentRootStatusAPI(Resource):
             comparison_count = assignment.completed_comparison_count_for_user(current_user.id)
             comparison_draft_count = assignment.draft_comparison_count_for_user(current_user.id)
             other_comparable_answers = assignment.comparable_answer_count - answer_count
-            comparison_available = comparison_count < other_comparable_answers * (other_comparable_answers - 1) / 2
+
+            # students can only begin comparing there there are enough answers submitted that they can do
+            # comparisons without seeing the same answer more than once
+            comparison_available = other_comparable_answers >= assignment.number_of_comparisons * 2
+            # instructors and tas can compare as long as there are new possible comparisons
+            if allow(EDIT, assignment):
+                comparison_available = comparison_count < other_comparable_answers * (other_comparable_answers - 1) / 2
 
             statuses[assignment.uuid] = {
                 'answers': {

--- a/compair/static/modules/assignment/assignment-module.js
+++ b/compair/static/modules/assignment/assignment-module.js
@@ -452,7 +452,7 @@ module.directive('assignmentMetadata', function() {
                                 'label': "You " +
                                         (!permissions.needsAnswer ? "<strong>answered</strong>" +
                                         (permissions.hasCompared ? " and " : "") : "") +
-                                        (permissions.hasCompared ? "<strong>compared " + assignment.status.comparisons.count + " pair" + (assignment.status.comparisons.count != 0 ? "s" : "") + "</strong>" : ""),
+                                        (permissions.hasCompared ? "<strong>compared " + assignment.status.comparisons.count + " pair" + (assignment.status.comparisons.count != 1 ? "s" : "") + "</strong>" : ""),
                                 'show' : {
                                     'user' : permissions.hasCompared || !permissions.needsAnswer,
                                     'instructor'  : false,
@@ -462,16 +462,16 @@ module.directive('assignmentMetadata', function() {
                                 'label': "You missed " +
                                         (permissions.hasMissedAnswer ? "answering " +
                                         (permissions.hasMissedCompare ? " and " : "") : "") +
-                                        (permissions.hasMissedCompare ? "comparing " + (permissions.needsCompare ? assignment.steps_left + " pair" + (assignment.steps_left != 0 ? "s" : "") : "") : ""),
+                                        (permissions.hasMissedCompare ? "comparing " + (permissions.needsCompare ? assignment.steps_left + " pair" + (assignment.steps_left != 1 ? "s" : "") : "") : ""),
                                 'show' : {
                                     'user' : permissions.hasMissedAnswer || permissions.hasMissedCompare,
                                     'instructor'  : false,
                                 }
                             },
                             'missingFeedback' : {
-                                'label': (permissions.canAnswer && permissions.needsAnswer ? "1 answer " +
+                                'label': (permissions.canAnswer && permissions.needsAnswer ? "1 answer" +
                                          (permissions.isComparePeriod && permissions.needsCompareOrSelfEval > 0 ? ", " : "") : "") +
-                                         (permissions.isComparePeriod && permissions.needsCompareOrSelfEval > 0 ? assignment.steps_left + " comparison" + (assignment.steps_left != 0 ? "s" : "") : "") + " needed",
+                                         (permissions.isComparePeriod && permissions.needsCompareOrSelfEval > 0 ? assignment.steps_left + " comparison" + (assignment.steps_left != 1 ? "s" : "") : "") + " needed",
                                 'class': 'label label-warning',
                                 'show' : {
                                             // suggested: (canAnswer && needsAnswer) || (>>>> canCompare <<<< && needsCompareOrSelfEval)
@@ -848,9 +848,6 @@ module.controller("AssignmentViewController",
                     // if an comparison period is NOT set - answers can be seen after req met
                     $scope.see_answers = $scope.assignment.after_comparing && $scope.comparisons_left == 0;
                 }
-                var diff = $scope.assignment.answer_count - $scope.assignment.status.answers.count;
-                var possible_comparisons_left = ((diff * (diff - 1)) / 2);
-                $scope.warning = $scope.assignment.status.comparisons.left > possible_comparisons_left;
             }
         )
 

--- a/compair/static/modules/assignment/assignment-module_spec.js
+++ b/compair/static/modules/assignment/assignment-module_spec.js
@@ -784,7 +784,6 @@ describe('assignment-module', function () {
 
                 expect($rootScope.comparisons_left).toEqual(mockAssignment.total_comparisons_required);
                 expect($rootScope.see_answers).toBe(false);
-                expect($rootScope.warning).toBe(false);
 
                 expect($rootScope.assignment.status.answers.answered).toBe(true);
 

--- a/compair/tests/algorithms/test_pair_adaptive.py
+++ b/compair/tests/algorithms/test_pair_adaptive.py
@@ -212,7 +212,8 @@ class TestPairAdaptive(unittest.TestCase):
             )
         ]
         comparisons = [
-            ComparisonPair(1,2,None)
+            ComparisonPair(1,2,None),
+            ComparisonPair(3,4,None)
         ]
 
         results = self.pair_algorithm.generate_pair(scored_objects, comparisons)
@@ -221,3 +222,86 @@ class TestPairAdaptive(unittest.TestCase):
         self.assertEqual(results.key1, 1)
         # object 4 should be selected as 0.4 is the closest value to 0.5
         self.assertEqual(results.key2, 4)
+
+        # ensure that all scored objects are seen only once until they have almost all been seen
+        # (even number of scored objects)
+        scored_objects = [ScoredObject(
+            key=index, score=None, variable1=None, variable2=None,
+            rounds=0, wins=None, loses=None, opponents=None
+        ) for index in range(30)]
+        comparisons = []
+
+        used_keys = set()
+        all_keys = set(range(30))
+
+        # n/2 comparisons = 15
+        for _ in range(15):
+            results = self.pair_algorithm.generate_pair(scored_objects, comparisons)
+            # neither key should have been seen before
+            self.assertNotIn(results.key1, used_keys)
+            self.assertNotIn(results.key2, used_keys)
+
+            comparisons.append(results)
+            used_keys.add(results.key1)
+            used_keys.add(results.key2)
+
+        self.assertEqual(used_keys, all_keys)
+
+        # remaining comparisons for n(n-1)/2 = 435
+        for _ in range(435 - 15):
+            results = self.pair_algorithm.generate_pair(scored_objects, comparisons)
+            # both keys should have been seen before
+            self.assertIn(results.key1, used_keys)
+            self.assertIn(results.key2, used_keys)
+            comparisons.append(results)
+
+        # next comparison should be an UserComparedAllObjectsException error
+        with self.assertRaises(UserComparedAllObjectsException):
+            results = self.pair_algorithm.generate_pair(scored_objects, comparisons)
+
+        # make sure all pairs are distinct
+        self.assertEqual(
+            len(comparisons),
+            len(set([tuple(sorted([c.key1, c.key2])) for c in comparisons])))
+
+        # ensure that all scored objects are seen only once until they have almost all been seen
+        # (odd number of scored objects)
+        scored_objects = [ScoredObject(
+            key=index, score=None, variable1=None, variable2=None,
+            rounds=0, wins=None, loses=None, opponents=None
+        ) for index in range(31)]
+        comparisons = []
+
+        used_keys = set()
+        all_keys = set(range(31))
+
+        # floor(n/2) comparisons = 15
+        for _ in range(15):
+            results = self.pair_algorithm.generate_pair(scored_objects, comparisons)
+            # neither key should have been seen before
+            self.assertNotIn(results.key1, used_keys)
+            self.assertNotIn(results.key2, used_keys)
+
+            comparisons.append(results)
+            used_keys.add(results.key1)
+            used_keys.add(results.key2)
+
+        # there should be only one key missing
+        self.assertEqual(len(all_keys - used_keys), 1)
+
+        # remaining comparisons for n(n-1)/2 = 435
+        for _ in range(465 - 15):
+            results = self.pair_algorithm.generate_pair(scored_objects, comparisons)
+            # both keys should have been seen before
+            self.assertIn(results.key1, all_keys)
+            self.assertIn(results.key2, all_keys)
+            comparisons.append(results)
+
+        # next comparison should be an UserComparedAllObjectsException error
+        with self.assertRaises(UserComparedAllObjectsException):
+            results = self.pair_algorithm.generate_pair(scored_objects, comparisons)
+
+        # make sure all pairs are distinct
+        self.assertEqual(
+            len(comparisons),
+            len(set([tuple(sorted([c.key1, c.key2])) for c in comparisons])))

--- a/compair/tests/algorithms/test_pair_random.py
+++ b/compair/tests/algorithms/test_pair_random.py
@@ -211,7 +211,8 @@ class TestPairAdaptive(unittest.TestCase):
             )
         ]
         comparisons = [
-            ComparisonPair(1,2,None)
+            ComparisonPair(1,2,None),
+            ComparisonPair(3,4,None)
         ]
 
         results = self.pair_algorithm.generate_pair(scored_objects, comparisons)
@@ -221,3 +222,86 @@ class TestPairAdaptive(unittest.TestCase):
         # object 3 should be selected since random shuffle is disabled
         # and object 2 has already been compared with object 1
         self.assertEqual(results.key2, 3)
+
+        # ensure that all scored objects are seen only once until they have almost all been seen
+        # (even number of scored objects)
+        scored_objects = [ScoredObject(
+            key=index, score=None, variable1=None, variable2=None,
+            rounds=0, wins=None, loses=None, opponents=None
+        ) for index in range(30)]
+        comparisons = []
+
+        used_keys = set()
+        all_keys = set(range(30))
+
+        # n/2 comparisons = 15
+        for _ in range(15):
+            results = self.pair_algorithm.generate_pair(scored_objects, comparisons)
+            # neither key should have been seen before
+            self.assertNotIn(results.key1, used_keys)
+            self.assertNotIn(results.key2, used_keys)
+
+            comparisons.append(results)
+            used_keys.add(results.key1)
+            used_keys.add(results.key2)
+
+        self.assertEqual(used_keys, all_keys)
+
+        # remaining comparisons for n(n-1)/2 = 435
+        for _ in range(435 - 15):
+            results = self.pair_algorithm.generate_pair(scored_objects, comparisons)
+            # both keys should have been seen before
+            self.assertIn(results.key1, used_keys)
+            self.assertIn(results.key2, used_keys)
+            comparisons.append(results)
+
+        # next comparison should be an UserComparedAllObjectsException error
+        with self.assertRaises(UserComparedAllObjectsException):
+            results = self.pair_algorithm.generate_pair(scored_objects, comparisons)
+
+        # make sure all pairs are distinct
+        self.assertEqual(
+            len(comparisons),
+            len(set([tuple(sorted([c.key1, c.key2])) for c in comparisons])))
+
+        # ensure that all scored objects are seen only once until they have almost all been seen
+        # (odd number of scored objects)
+        scored_objects = [ScoredObject(
+            key=index, score=None, variable1=None, variable2=None,
+            rounds=0, wins=None, loses=None, opponents=None
+        ) for index in range(31)]
+        comparisons = []
+
+        used_keys = set()
+        all_keys = set(range(31))
+
+        # floor(n/2) comparisons = 15
+        for _ in range(15):
+            results = self.pair_algorithm.generate_pair(scored_objects, comparisons)
+            # neither key should have been seen before
+            self.assertNotIn(results.key1, used_keys)
+            self.assertNotIn(results.key2, used_keys)
+
+            comparisons.append(results)
+            used_keys.add(results.key1)
+            used_keys.add(results.key2)
+
+        # there should be only one key missing
+        self.assertEqual(len(all_keys - used_keys), 1)
+
+        # remaining comparisons for n(n-1)/2 = 435
+        for _ in range(465 - 15):
+            results = self.pair_algorithm.generate_pair(scored_objects, comparisons)
+            # both keys should have been seen before
+            self.assertIn(results.key1, all_keys)
+            self.assertIn(results.key2, all_keys)
+            comparisons.append(results)
+
+        # next comparison should be an UserComparedAllObjectsException error
+        with self.assertRaises(UserComparedAllObjectsException):
+            results = self.pair_algorithm.generate_pair(scored_objects, comparisons)
+
+        # make sure all pairs are distinct
+        self.assertEqual(
+            len(comparisons),
+            len(set([tuple(sorted([c.key1, c.key2])) for c in comparisons])))

--- a/compair/tests/api/test_assignment.py
+++ b/compair/tests/api/test_assignment.py
@@ -720,7 +720,7 @@ class AssignmentStatusComparisonsAPITests(ComPAIRAPITestCase):
                     self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
                     self.assertFalse(status['comparisons']['has_draft'])
                     self.assertTrue(status['answers']['answered'])
-                    self.assertEqual(status['answers']['count'], 2)  # one comparable, one non-comparable
+                    self.assertEqual(status['answers']['count'], 1) # one comparable, one non-comparable
                     self.assertEqual(status['answers']['feedback'], 0)
                 elif assignments[1].id == assignment.id:
                     self.assertTrue(status['comparisons']['available'])
@@ -728,7 +728,7 @@ class AssignmentStatusComparisonsAPITests(ComPAIRAPITestCase):
                     self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
                     self.assertFalse(status['comparisons']['has_draft'])
                     self.assertTrue(status['answers']['answered'])
-                    self.assertEqual(status['answers']['count'], 2) # one comparable, one non-comparable
+                    self.assertEqual(status['answers']['count'], 1) # one comparable, one non-comparable
                     self.assertEqual(status['answers']['feedback'], 0)
                 else:
                     self.assertFalse(status['comparisons']['available'])
@@ -740,7 +740,48 @@ class AssignmentStatusComparisonsAPITests(ComPAIRAPITestCase):
                     self.assertEqual(status['answers']['feedback'], 0)
 
         with self.login(self.data.get_authorized_student().username):
-            # test authorized student - when haven't compared
+            # test authorized student - when haven't compared and not enough answers
+            rv = self.client.get(url)
+            self.assert200(rv)
+            for assignment in assignments:
+                self.assertTrue(assignment.uuid in rv.json['statuses'])
+                status = rv.json['statuses'][assignment.uuid]
+                if assignments[0].id == assignment.id:
+                    self.assertFalse(status['comparisons']['available'])
+                    self.assertEqual(status['comparisons']['count'], 0)
+                    self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
+                    self.assertFalse(status['comparisons']['has_draft'])
+                    self.assertTrue(status['answers']['answered'])
+                    self.assertEqual(status['answers']['count'], 1)
+                    self.assertEqual(status['answers']['feedback'], 0)
+                elif assignments[1].id == assignment.id:
+                    self.assertFalse(status['comparisons']['available'])
+                    self.assertEqual(status['comparisons']['count'], 0)
+                    self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
+                    self.assertFalse(status['comparisons']['has_draft'])
+                    self.assertTrue(status['answers']['answered'])
+                    self.assertEqual(status['answers']['count'], 1)
+                    self.assertEqual(status['answers']['feedback'], 0)
+                else:
+                    self.assertFalse(status['comparisons']['available'])
+                    self.assertEqual(status['comparisons']['count'], 0)
+                    self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
+                    self.assertFalse(status['comparisons']['has_draft'])
+                    self.assertFalse(status['answers']['answered'])
+                    self.assertEqual(status['answers']['count'], 0)
+                    self.assertEqual(status['answers']['feedback'], 0)
+
+            while(assignments[0].comparable_answer_count - 1 < assignments[0].number_of_comparisons * 2):
+                # test authorized instructor
+                rv = self.client.get(url)
+                self.assert200(rv)
+                self.assertFalse(rv.json['statuses'][assignments[0].uuid]['comparisons']['available'])
+
+                new_student = self.data.create_normal_user()
+                self.data.enrol_student(new_student, self.data.get_course())
+                self.data.create_answer(self.assignment, new_student)
+
+            # test authorized student - when haven't compared and enough enough answers
             rv = self.client.get(url)
             self.assert200(rv)
             for assignment in assignments:
@@ -755,7 +796,7 @@ class AssignmentStatusComparisonsAPITests(ComPAIRAPITestCase):
                     self.assertEqual(status['answers']['count'], 1)
                     self.assertEqual(status['answers']['feedback'], 0)
                 elif assignments[1].id == assignment.id:
-                    self.assertTrue(status['comparisons']['available'])
+                    self.assertFalse(status['comparisons']['available'])
                     self.assertEqual(status['comparisons']['count'], 0)
                     self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
                     self.assertFalse(status['comparisons']['has_draft'])
@@ -793,7 +834,7 @@ class AssignmentStatusComparisonsAPITests(ComPAIRAPITestCase):
                     self.assertEqual(status['answers']['feedback'], 0)
                     self.assertEqual(status['answers']['feedback'], 0)
                 elif assignments[1].id == assignment.id:
-                    self.assertTrue(status['comparisons']['available'])
+                    self.assertFalse(status['comparisons']['available'])
                     self.assertEqual(status['comparisons']['count'], 0)
                     self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
                     self.assertFalse(status['comparisons']['has_draft'])
@@ -836,7 +877,7 @@ class AssignmentStatusComparisonsAPITests(ComPAIRAPITestCase):
                 elif assignments[1].id == assignment.id:
                     self.assertFalse(status['comparisons']['self_evaluation_completed'])
                     self.assertFalse(status['comparisons']['self_evaluation_draft'])
-                    self.assertTrue(status['comparisons']['available'])
+                    self.assertFalse(status['comparisons']['available'])
                     self.assertEqual(status['comparisons']['count'], 0)
                     self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
                     self.assertFalse(status['comparisons']['has_draft'])
@@ -890,7 +931,7 @@ class AssignmentStatusComparisonsAPITests(ComPAIRAPITestCase):
                 elif assignments[1].id == assignment.id:
                     self.assertFalse(status['comparisons']['self_evaluation_completed'])
                     self.assertTrue(status['comparisons']['self_evaluation_draft'])
-                    self.assertTrue(status['comparisons']['available'])
+                    self.assertFalse(status['comparisons']['available'])
                     self.assertEqual(status['comparisons']['count'], 0)
                     self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
                     self.assertFalse(status['comparisons']['has_draft'])
@@ -933,7 +974,7 @@ class AssignmentStatusComparisonsAPITests(ComPAIRAPITestCase):
                 elif assignments[1].id == assignment.id:
                     self.assertTrue(status['comparisons']['self_evaluation_completed'])
                     self.assertFalse(status['comparisons']['self_evaluation_draft'])
-                    self.assertTrue(status['comparisons']['available'])
+                    self.assertFalse(status['comparisons']['available'])
                     self.assertEqual(status['comparisons']['count'], 0)
                     self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
                     self.assertFalse(status['comparisons']['has_draft'])
@@ -986,7 +1027,7 @@ class AssignmentStatusComparisonsAPITests(ComPAIRAPITestCase):
                 elif assignments[1].id == assignment.id:
                     self.assertTrue(status['comparisons']['self_evaluation_completed'])
                     self.assertFalse(status['comparisons']['self_evaluation_draft'])
-                    self.assertTrue(status['comparisons']['available'])
+                    self.assertFalse(status['comparisons']['available'])
                     self.assertEqual(status['comparisons']['count'], 0)
                     self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
                     self.assertFalse(status['comparisons']['has_draft'])
@@ -1077,11 +1118,33 @@ class AssignmentStatusComparisonsAPITests(ComPAIRAPITestCase):
             self.assertTrue(status['comparisons']['available'])
             self.assertFalse(status['comparisons']['has_draft'])
             self.assertTrue(status['answers']['answered'])
-            self.assertEqual(status['answers']['count'], 2) # one comparable, one not comparable
+            self.assertEqual(status['answers']['count'], 1) # one comparable, one not comparable
             self.assertEqual(status['answers']['feedback'], 0)
 
         with self.login(self.data.get_authorized_student().username):
-            # test authorized student - when haven't compared
+            # test authorized student - when haven't compared without enough answers
+            rv = self.client.get(url)
+            self.assert200(rv)
+            status = rv.json['status']
+            self.assertEqual(status['comparisons']['count'], 0)
+            self.assertEqual(status['comparisons']['left'], self.assignment.total_comparisons_required)
+            self.assertFalse(status['comparisons']['available'])
+            self.assertFalse(status['comparisons']['has_draft'])
+            self.assertTrue(status['answers']['answered'])
+            self.assertEqual(status['answers']['count'], 1)
+            self.assertEqual(status['answers']['feedback'], 0)
+
+            while(self.assignment.comparable_answer_count - 1 < self.assignment.number_of_comparisons * 2):
+                # test authorized instructor
+                rv = self.client.get(url)
+                self.assert200(rv)
+                self.assertFalse(rv.json['status']['comparisons']['available'])
+
+                new_student = self.data.create_normal_user()
+                self.data.enrol_student(new_student, self.data.get_course())
+                self.data.create_answer(self.assignment, new_student)
+
+            # test authorized student - when haven't compared with enough answers
             rv = self.client.get(url)
             self.assert200(rv)
             status = rv.json['status']
@@ -1258,8 +1321,8 @@ class AssignmentStatusAnswersAPITests(ComPAIRAPITestCase):
                     self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
                     self.assertFalse(status['comparisons']['has_draft'])
                     # by default, the test data created a non-comparable answer for instructor in add_course
-                    self.assertTrue(status['answers']['answered'])
-                    self.assertEqual(status['answers']['count'], 1)
+                    self.assertFalse(status['answers']['answered'])
+                    self.assertEqual(status['answers']['count'], 0)
                     self.assertEqual(status['answers']['feedback'], 0)
                 else:
                     self.assertTrue(status['comparisons']['available'])
@@ -1267,8 +1330,8 @@ class AssignmentStatusAnswersAPITests(ComPAIRAPITestCase):
                     self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
                     self.assertFalse(status['comparisons']['has_draft'])
                     # by default, the test data created a non-comparable answer for instructor in add_course
-                    self.assertTrue(status['answers']['answered'])
-                    self.assertEqual(status['answers']['count'], 1)
+                    self.assertFalse(status['answers']['answered'])
+                    self.assertEqual(status['answers']['count'], 0)
                     self.assertEqual(status['answers']['feedback'], 0)
 
             # test authorized instructor - multiple answers
@@ -1289,7 +1352,7 @@ class AssignmentStatusAnswersAPITests(ComPAIRAPITestCase):
                     self.assertFalse(status['comparisons']['has_draft'])
                     # 1 non-comparable answer added by default in add_course, plus 3 added above
                     self.assertTrue(status['answers']['answered'])
-                    self.assertEqual(status['answers']['count'], 4)
+                    self.assertEqual(status['answers']['count'], 3)
                     self.assertEqual(status['answers']['feedback'], 0)
                 else:
                     self.assertTrue(status['comparisons']['available'])
@@ -1297,8 +1360,8 @@ class AssignmentStatusAnswersAPITests(ComPAIRAPITestCase):
                     self.assertEqual(status['comparisons']['left'], assignment.total_comparisons_required)
                     self.assertFalse(status['comparisons']['has_draft'])
                     # by default, the test data created a non-comparable answer for instructor in add_course
-                    self.assertTrue(status['answers']['answered'])
-                    self.assertEqual(status['answers']['count'], 1)
+                    self.assertFalse(status['answers']['answered'])
+                    self.assertEqual(status['answers']['count'], 0)
                     self.assertEqual(status['answers']['feedback'], 0)
 
         self.fixtures.add_students(1)
@@ -1384,8 +1447,8 @@ class AssignmentStatusAnswersAPITests(ComPAIRAPITestCase):
             self.assertEqual(status['comparisons']['left'], self.fixtures.assignment.total_comparisons_required)
             self.assertFalse(status['comparisons']['has_draft'])
             # by default, the test data created a non-comparable answer for instructor in add_course
-            self.assertTrue(status['answers']['answered'])
-            self.assertEqual(status['answers']['count'], 1)
+            self.assertFalse(status['answers']['answered'])
+            self.assertEqual(status['answers']['count'], 0)
             self.assertEqual(status['answers']['feedback'], 0)
 
             # test authorized instructor - multiple answers
@@ -1402,7 +1465,7 @@ class AssignmentStatusAnswersAPITests(ComPAIRAPITestCase):
             self.assertFalse(status['comparisons']['has_draft'])
             self.assertTrue(status['answers']['answered'])
             # 1 non-comparable answer created by default in add_course, plus 3 created above
-            self.assertEqual(status['answers']['count'], 4)
+            self.assertEqual(status['answers']['count'], 3)
             self.assertEqual(status['answers']['feedback'], 0)
 
         self.fixtures.add_students(1)

--- a/compair/tests/api/test_comparisons.py
+++ b/compair/tests/api/test_comparisons.py
@@ -1,4 +1,5 @@
 import json
+import math
 import copy
 import operator
 import datetime
@@ -229,6 +230,7 @@ class ComparisonAPITests(ComPAIRAPITestCase):
         for user in users:
             max_comparisons = self.assignment.number_of_comparisons
             other_people_answers = 0
+            seen_answer_uuids = set()
             valid_answer_uuids = set()
             for answer in self.data.get_comparable_answers():
                 if answer.assignment.id == self.assignment.id and answer.user_id != user.id:
@@ -277,6 +279,15 @@ class ComparisonAPITests(ComPAIRAPITestCase):
                     self.assertIn(answer1_uuid, valid_answer_uuids)
                     self.assertIn(answer2_uuid, valid_answer_uuids)
                     self.assertNotEqual(answer1_uuid, answer2_uuid)
+
+                    # ensure that answers are not seen more than once
+                    # until almost all answers have already been seen
+                    if current <= math.floor(other_people_answers / 2):
+                        self.assertNotIn(answer1_uuid, seen_answer_uuids)
+                        self.assertNotIn(answer2_uuid, seen_answer_uuids)
+                        seen_answer_uuids.add(answer1_uuid)
+                        seen_answer_uuids.add(answer2_uuid)
+
                     self.assertTrue(rv.json['new_pair'])
                     self.assertEqual(rv.json['current'], current)
                     # no user info should be included in the answer


### PR DESCRIPTION
- Enhanced the pair selection algorithm by:
    - first pairing only answers the user hasn't seen yet until almost all answers have been seen (will not handle odd answer out). This handles floor(n/2) pairs.
    - second allowing all remaining possible pairs. Allows remaining n(n-1)/2 pairs
    - The algorithm change is mostly to continue to support instructors and teaching assistants to perform as many comparisons as are possible in the system
- In addition students will not be allowed to being comparing until there are `number_of_comparisons`*2 other comparable answers available
- Refactored pairing algorithms to reduce co repeating. Also added zero score handling to adaptive_min_delta algorithm
- Fixed some labeling in `assignmentMetadata`
- Fixed answer count for instructors for assignment status (shouldn't include non comparable answers)

Closes #683