### PR TITLE
Make filters sticky on assignment screen

### DIFF
--- a/compair/static/modules/assignment/assignment-view-partial.html
+++ b/compair/static/modules/assignment/assignment-view-partial.html
@@ -561,18 +561,17 @@
 
         <!-- </div> --><!-- closes comments-tab -->
 
-        <div class="tab-pane" ng-class="{active: showTab('comparisons')}" id="comparisons-tab" ng-if="canManageAssignment && showTab('comparisons')">
-            <div ng-controller="ComparisonViewController">
+        <div ng-controller="ComparisonViewController" ng-if="::canManageAssignment">
+            <div class="tab-pane" ng-class="{active: showTab('comparisons')}" id="comparisons-tab" ng-if="canManageAssignment && showTab('comparisons')">
                 <ng-include src="'modules/comparison/comparison-view-partial.html'"></ng-include>
-            </div>
-        </div><!-- closes comparisons-tab -->
+            </div><!-- closes comparisons-tab -->
+        </div>
 
-        <div class="tab-pane" ng-class="{active: showTab('participation')}" id="participation-tab" ng-if="canManageAssignment && showTab('participation')">
-            <div ng-controller="GradebookController">
+        <div ng-controller="GradebookController" ng-if="::canManageAssignment">
+            <div class="tab-pane" ng-class="{active: showTab('participation')}" id="participation-tab" ng-if="canManageAssignment && showTab('participation')">
                 <ng-include src="'modules/gradebook/gradebook-partial.html'"></ng-include>
-            </div>
-        </div><!-- closes gradebook-tab -->
-
+            </div> <!-- closes gradebook-tab -->
+        </div>
     </div><!-- closes tab-content -->
 
 </div>


### PR DESCRIPTION
Make filters sticky when switching tabs on assignment screen

- re-arrange the controllers to wrap around tabs so controllers are not
re-initialized
- also use one-time binding `ng-if="::canManageAssignment"` on
controllers to avoid re-initializing

Closes #738