### PR TITLE
Fix Read More button

### DIFF
--- a/compair/static/less/assignment.less
+++ b/compair/static/less/assignment.less
@@ -123,15 +123,10 @@
       border-bottom: 1px solid @border-gray;
 
       /* limit how much of answer/comment content is shown */
-      > .content {
+      .comparable .content {
         max-height: 200px;
         overflow: hidden;
       }
-      /* but not for instructors! */
-      > .content.instructor-answer {
-        max-height: none;
-      }
-
     }//closes each-answer, each-comment
 
     /* alternating answer/comment color to match tab color */

--- a/compair/static/modules/assignment/assignment-module.js
+++ b/compair/static/modules/assignment/assignment-module.js
@@ -110,10 +110,10 @@ module.directive(
                     // find the element's scrollHeight (this tells us the full height regardless of max-height set)
                     scope.thisHeight = element.prop('scrollHeight');
                     // when this full height is outside the max-height, display the read more button to the user
-                    if (scope.thisHeight > 200) {
+                    if (scope.thisHeight >= 200) {
                         scope.showReadMore = true;
                     }
-                }, 7000);
+                }, 0);  // use a timeout of 0. will be evaluated at the next digest cycle
             }
         };
     }
@@ -891,7 +891,7 @@ module.controller("AssignmentViewController",
 
         // revealContent function shows full answer content for abbreviated answers (determined by getHeight directive)
         $scope.revealContent = function(contentItem) {
-            var thisClass = '.content.'+contentItem.id;      // class for the content item to show is "content" plus the content item's ID
+            var thisClass = '.' + contentItem.id + ' .content';      // class for the content item to show is the content item's ID plus "content"
             $(thisClass).css({'max-height' : 'none'}); // now remove height restriction for this content item
             this.showReadMore = false;                 // and hide the read more button for this content item
         };

--- a/compair/static/modules/assignment/assignment-view-partial.html
+++ b/compair/static/modules/assignment/assignment-view-partial.html
@@ -206,9 +206,7 @@
                     </div>
 
                     <!-- Instructor Answer -->
-                    <div class="instructor-answer">
-                        <rich-content content="answer.content" attachment="answer.file"></rich-content>
-                    </div>
+                    <rich-content content="answer.content" attachment="answer.file"></rich-content>
 
                 </div><!-- closes each-answer (instructor) -->
 
@@ -272,7 +270,7 @@
                     </div>
 
                     <!-- Student Answer -->
-                    <div class="{{answer.id}}" get-height>
+                    <div class="{{answer.id}} comparable" get-height>
                         <rich-content content="answer.content" attachment="answer.file" ng-click="revealContent(answer)"></rich-content>
                     </div>
                     <!-- Student Answer Read More Button (not used for instructor answers) -->


### PR DESCRIPTION
- dont use "read more" button for non-comparable answers
- display "read more" buttons for comparable answers. fix CSS on matching
the answers.
- change the get-height directive timeout to 0. this should be triggered
in next digest after content loaded

Closes #740 