### PR TITLE
Fix CPU utilization issue

### DIFF
--- a/compair/static/modules/answer/answer-form-partial.html
+++ b/compair/static/modules/answer/answer-form-partial.html
@@ -28,7 +28,7 @@
     <fieldset>
         <legend>Answer Details</legend>
         <div class="h3 text-center" ng-show="!canManageAssignment && showCountDown && comparison_example !== true">
-            <timer end-time="assignment.answer_end">
+            <timer end-time="assignment.answer_end" interval="1000">
                 <span ng-show="minutes > 0 || seconds > 0" title="Official time remaining until deadline" class="bg-danger alert text-danger"><i class="glyphicon glyphicon-time"></i> {{minutes}} minutes {{seconds}} seconds left</span>
                 <span ng-show="minutes == 0 && seconds == 0" class="bg-danger alert text-danger"><i class="glyphicon glyphicon-time"></i> DEADLINE REACHED</span>
             </timer>


### PR DESCRIPTION
- Add interval param to the timer directive on answer form.  This will
slow down the rate $digest being fired causing high CPU usage.

Note that an interval of 1000ms is used.  There is an [existing issue](https://github.com/siddii/angular-timer/issues/106) with `angular-timer` that value < 1000 may cause `setTimeout` to be called with negative values.  While most browsers can handle that gracefully, better to be safe and use 1000.

Timer accuracy isn't a concern here

Closes #755 
