### PR TITLE
Generate direct link to Kaltura media

### DIFF
--- a/alembic/versions/8b4e3c1d8c41_create_unique_index_for_attachment_file_.py
+++ b/alembic/versions/8b4e3c1d8c41_create_unique_index_for_attachment_file_.py
@@ -1,0 +1,26 @@
+"""Create unique index for attachment file name
+
+Revision ID: 8b4e3c1d8c41
+Revises: bbf7d7f7da06
+Create Date: 2018-07-23 16:36:20.186728
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '8b4e3c1d8c41'
+down_revision = 'bbf7d7f7da06'
+
+import logging
+from alembic import op
+
+from compair.models import convention
+
+def upgrade():
+    # create unique index for file.name
+    with op.batch_alter_table('file', naming_convention=convention) as batch_op:
+        batch_op.create_unique_constraint(op.f('uq_file_name'), ['name'])
+
+def downgrade():
+    # drop the unique index
+    with op.batch_alter_table('file', naming_convention=convention) as batch_op:
+        batch_op.drop_constraint('uq_file_name', type_='unique')

--- a/compair/models/mixins/uuid_mixin.py
+++ b/compair/models/mixins/uuid_mixin.py
@@ -1,6 +1,8 @@
 import uuid
 import base64
 
+from sqlalchemy.orm import joinedload
+
 from compair.core import db, abort
 
 class UUIDMixin(db.Model):


### PR DESCRIPTION
- enhance the `/attachment` api to handle downloading media from Kaltura
- add logic to generate short-lived Kalutra Session to allow direct
download

Closes #808 