### PR TITLE
Cleanup downloadable reports

### DIFF
--- a/compair/static/modules/gradebook/gradebook-partial.html
+++ b/compair/static/modules/gradebook/gradebook-partial.html
@@ -50,7 +50,7 @@
                     <a href="" ng-click="updateTableOrderBy('attachments')">Attachments</a>
                 </th>
                 <th class="text-center">
-                    <a href="" ng-click="updateTableOrderBy('num_comparisons')">Evaluations</a>
+                    <a href="" ng-click="updateTableOrderBy('num_comparisons')">Comparisons</a>
                 </th>
                 <th class="text-center" ng-if="includeSelfEval">
                     <a href="" ng-click="updateTableOrderBy('num_self_evaluation')">Self-Evaluation</a>

--- a/compair/tests/api/test_report.py
+++ b/compair/tests/api/test_report.py
@@ -7,10 +7,11 @@ import unicodecsv as csv
 import re
 import six
 
+from sqlalchemy import or_
 from data.fixtures import DefaultFixture
 from data.fixtures.test_data import TestFixture
 from compair.tests.test_compair import ComPAIRAPITestCase
-from compair.models import CourseRole, Answer, Comparison, AnswerComment, AnswerCommentType
+from compair.models import CourseRole, Answer, Comparison, AnswerComment, AnswerCommentType, AssignmentGrade
 from compair.core import db
 from flask import current_app
 
@@ -267,15 +268,20 @@ class ReportAPITest(ComPAIRAPITestCase):
 
                 course_users = sorted(self.fixtures.students + [self.fixtures.instructor, self.fixtures.ta],
                     key=lambda u: (u.lastname, u.firstname, u.id))
+                user_rows = {}   # structure: user_uuid / [rows from report]
+                overall_rows = {}  # structure: user_uuid / row
+                for next_row in reader:
+                    if next_row[0] == '(Overall in Course)':
+                        overall_rows[next_row[4]] = next_row
+                    else:
+                        user_rows.setdefault(next_row[4], []).append(next_row)
                 for assignment in assignments:
                     for user in course_users:
-                        next_row = next(reader)
-                        user_stats = self._check_participation_stat_report_user_row(assignment, user, next_row, overall_stats)
+                        user_stats = self._check_participation_stat_report_user_row(assignment, user, [row for row in user_rows[user.uuid] if row[0]==assignment.name], overall_stats)
 
                 # overall
                 for user in course_users:
-                    next_row = next(reader)
-                    self._check_participation_stat_report_user_overall_row(user, next_row, overall_stats)
+                    self._check_participation_stat_report_user_overall_row(user, overall_rows[user.uuid], overall_stats)
 
             # test authorized user one assignment
             single_assignment_params = params.copy()
@@ -298,9 +304,11 @@ class ReportAPITest(ComPAIRAPITestCase):
                 course_users = sorted(self.fixtures.students + [self.fixtures.instructor, self.fixtures.ta],
                     key=lambda u: (u.lastname, u.firstname, u.id))
 
+                user_rows = {}   # structure: user_uuid / [rows from report]
+                for next_row in reader:
+                    user_rows.setdefault(next_row[4], []).append(next_row)
                 for user in course_users:
-                    next_row = next(reader)
-                    user_stats = self._check_participation_stat_report_user_row(self.fixtures.assignments[0], user, next_row, overall_stats)
+                    user_stats = self._check_participation_stat_report_user_row(self.fixtures.assignments[0], user, user_rows[user.uuid], overall_stats)
 
             # test authorized user entire course with group_id filter
             group_params = params.copy()
@@ -324,15 +332,20 @@ class ReportAPITest(ComPAIRAPITestCase):
                 group_members = [u for u in self.fixtures.students if u.user_courses[0].group_id == self.fixtures.groups[0].id]
                 group_members = sorted(group_members, key=lambda m: (m.lastname, m.firstname, m.id))
 
+                user_rows = {}   # structure: user_uuid / [rows from report]
+                overall_rows = {}  # structure: user_uuid / row
+                for next_row in reader:
+                    if next_row[0] == '(Overall in Course)':
+                        overall_rows[next_row[4]] = next_row
+                    else:
+                        user_rows.setdefault(next_row[4], []).append(next_row)
                 for assignment in assignments:
                     for member in group_members:
-                        next_row = next(reader)
-                        user_stats = self._check_participation_stat_report_user_row(assignment, member, next_row, overall_stats)
+                        user_stats = self._check_participation_stat_report_user_row(assignment, member, [row for row in user_rows[member.uuid] if row[0]==assignment.name], overall_stats)
 
                 # overall
                 for member in group_members:
-                    next_row = next(reader)
-                    self._check_participation_stat_report_user_overall_row(member, next_row, overall_stats)
+                    self._check_participation_stat_report_user_overall_row(member, overall_rows[member.uuid], overall_stats)
 
             # test authorized user one assignment
             group_params = params.copy()
@@ -356,9 +369,11 @@ class ReportAPITest(ComPAIRAPITestCase):
                 group_members = [u for u in self.fixtures.students if u.user_courses[0].group_id == self.fixtures.groups[0].id]
                 group_members = sorted(group_members, key=lambda m: (m.lastname, m.firstname, m.id))
 
+                user_rows = {}   # structure: user_uuid / [rows from report]
+                for next_row in reader:
+                    user_rows.setdefault(next_row[4], []).append(next_row)
                 for member in group_members:
-                    next_row = next(reader)
-                    user_stats = self._check_participation_stat_report_user_row(self.fixtures.assignments[0], member, next_row, overall_stats)
+                    user_stats = self._check_participation_stat_report_user_row(self.fixtures.assignments[0], member, user_rows[member.uuid], overall_stats)
 
         # peer_feedback with valid instructor
         with self.login(self.fixtures.instructor.username):
@@ -534,10 +549,11 @@ class ReportAPITest(ComPAIRAPITestCase):
 
     def _check_participation_stat_report_heading_rows(self, heading):
         expected_heading = [
-            'Assignment', 'User UUID', 'Last Name', 'First Name', 'Answer Submitted', 'Answer ID',
-            'Answer', 'Overall Rank', 'Overall Score',
-            'Evaluations Submitted', 'Evaluations Required', 'Evaluation Requirements Met',
-            'Replies Submitted']
+            'Assignment', 'Last Name', 'First Name', 'Student Number', 'User UUID',
+            'Answer', 'Answer ID', 'Answer Deleted', 'Answer Last Modified',
+            'Answer Score (Normalized)', 'Overall Rank',
+            'Comparisons Submitted', 'Comparisons Required', 'Comparison Requirements Met',
+            'Self-Evaluation Submitted', 'Feedback Submitted (During Comparisons)', 'Feedback Submitted (Outside Comparisons)']
 
         self.assertEqual(expected_heading, heading)
 
@@ -549,15 +565,19 @@ class ReportAPITest(ComPAIRAPITestCase):
             'evaluations_submitted': 0,
             'evaluations_required': 0,
             'evaluation_requirements_met': True,
-            'replies_submitted': 0
+            'comparison_feedback_submitted': 0,
+            'standalone_feedback_submitted': 0,
+            'self_evaluation_count': 0
         })
         user_stats = overall_stats[student.id]
 
         expected_row.append("(Overall in Course)")
-        expected_row.append(student.uuid)
         expected_row.append(student.lastname)
         expected_row.append(student.firstname)
+        expected_row.append(student.student_number)
+        expected_row.append(student.uuid)
         expected_row.append(str(user_stats["answers_submitted"]))
+        expected_row.append("")
         expected_row.append("")
         expected_row.append("")
         expected_row.append("")
@@ -565,70 +585,59 @@ class ReportAPITest(ComPAIRAPITestCase):
         expected_row.append(str(user_stats["evaluations_submitted"]))
         expected_row.append(str(user_stats["evaluations_required"]))
         expected_row.append("Yes" if user_stats["evaluation_requirements_met"] else "No")
-        expected_row.append(str(user_stats["replies_submitted"]))
+        expected_row.append(str(user_stats["self_evaluation_count"]))
+        expected_row.append(str(user_stats["comparison_feedback_submitted"]))
+        expected_row.append(str(user_stats["standalone_feedback_submitted"]))
 
         self.assertEqual(row, expected_row)
 
 
-    def _check_participation_stat_report_user_row(self, assignment, student, row, overall_stats):
+    def _check_participation_stat_report_user_row(self, assignment, student, rows, overall_stats):
         expected_row = []
+        current_row = 0
 
         overall_stats.setdefault(student.id, {
             'answers_submitted': 0,
             'evaluations_submitted': 0,
             'evaluations_required': 0,
             'evaluation_requirements_met': True,
-            'replies_submitted': 0
+            'comparison_feedback_submitted': 0,
+            'standalone_feedback_submitted': 0,
+            'self_evaluation_count': 0
         })
         user_stats = overall_stats[student.id]
 
-        expected_row.append(assignment.name)
-        expected_row.append(student.uuid)
-        expected_row.append(student.lastname)
-        expected_row.append(student.firstname)
-
         if not assignment.enable_group_answers:
-            answer = Answer.query \
+            answers = Answer.query \
                 .filter_by(
                     user_id=student.id,
                     assignment_id=assignment.id,
                     draft=False,
                     practice=False,
-                    active=True,
                     comparable=True
                 ) \
-                .first()
+                .order_by(Answer.active.desc()) \
+                .all()
         else:
             group = student.get_course_group(self.fixtures.course.id)
-            answer = Answer.query \
+            answers = Answer.query \
                 .filter_by(
                     group_id=group.id,
                     assignment_id=assignment.id,
                     draft=False,
                     practice=False,
-                    active=True,
                     comparable=True
                 ) \
-                .first() if group else None
+                .order_by(Answer.active.desc()) \
+                .all() if group else []
 
-        if answer:
-            user_stats["answers_submitted"] += 1
-            expected_row.append("1")
-            expected_row.append(answer.uuid)
-            expected_row.append(self._snippet(answer.content))
-        else:
-            expected_row.append("0")
-            expected_row.append("N/A")
-            expected_row.append("N/A")
+        active_answer_submitted = len([ans for ans in answers if ans.active])
+        if active_answer_submitted == 0:
+            answers = [None] + answers
 
-        if answer and answer.score:
-            expected_row.append(str(answer.score.rank))
-            expected_row.append(str(round(answer.score.normalized_score, 3)))   # round the floating point value for comparison
-            row[8] = str(round(float(row[8]), 3))
-        else:
-            expected_row.append("Not Evaluated")
-            expected_row.append("Not Evaluated")
-
+        # per assignment stats: evaluation required
+        user_stats["evaluations_required"] += assignment.total_comparisons_required
+        # per assignment stats: evaluation submitted
         comparisons = Comparison.query \
             .filter(
                 Comparison.completed == True,
@@ -637,47 +646,109 @@ class ReportAPITest(ComPAIRAPITestCase):
             ) \
             .all()
         evaluations_submitted = len(comparisons)
-
         user_stats["evaluations_submitted"] += evaluations_submitted
-        expected_row.append(str(evaluations_submitted))
-
-        user_stats["evaluations_required"] += assignment.total_comparisons_required
-        expected_row.append(str(assignment.total_comparisons_required))
-
+        # per assignment stats: evaluation requirement met
         if assignment.total_comparisons_required > evaluations_submitted:
             user_stats["evaluation_requirements_met"] = False
-            expected_row.append("No")
-        else:
-            expected_row.append("Yes")
-
+        # per assignment stats: feedback submitted
         answer_comments = AnswerComment.query \
             .filter(
                 AnswerComment.user_id == student.id,
-                AnswerComment.assignment_id == assignment.id
+                AnswerComment.assignment_id == assignment.id,
+                AnswerComment.draft == False,
+                AnswerComment.comment_type == AnswerCommentType.evaluation
             ) \
             .all()
+        comparison_feedback_submitted = len(answer_comments)
+        user_stats["comparison_feedback_submitted"] += comparison_feedback_submitted
+        answer_comments = AnswerComment.query \
+            .filter(
+                AnswerComment.user_id == student.id,
+                AnswerComment.assignment_id == assignment.id,
+                AnswerComment.draft == False,
+                or_(AnswerComment.comment_type == AnswerCommentType.private,
+                    AnswerComment.comment_type == AnswerCommentType.public) \
+            ) \
+            .all()
+        standalone_feedback_submitted = len(answer_comments)
+        user_stats["standalone_feedback_submitted"] += standalone_feedback_submitted
+        # per assignment stats: self-eval submitted
+        self_evaluation = AnswerComment.query \
+            .filter_by(comment_type=AnswerCommentType.self_evaluation) \
+            .join(Answer) \
+            .filter(Answer.assignment_id == assignment.id) \
+            .filter(AnswerComment.user_id == student.id) \
+            .filter(AnswerComment.draft == False) \
+            .with_entities(Answer.assignment_id, AnswerComment.user_id) \
+            .all()
+        self_evaluation_count = len(self_evaluation)
+        user_stats["self_evaluation_count"] += self_evaluation_count
 
-        replies_submitted = len(answer_comments)
+        for answer in answers:
+            expected_row = []
+            expected_row.append(assignment.name)
+            expected_row.append(student.lastname)
+            expected_row.append(student.firstname)
+            expected_row.append(student.student_number)
+            expected_row.append(student.uuid)
 
-        user_stats["replies_submitted"] += replies_submitted
-        expected_row.append(str(replies_submitted))
+            if answer:
+                expected_row.append(self._snippet(answer.content))
+                expected_row.append(answer.uuid)
+                expected_row.append('N' if answer.active else 'Y')
+                if answer.active:
+                    user_stats["answers_submitted"] += 1
+                expected_row.append(answer.modified.strftime("%Y-%m-%d %H:%M:%S") if answer.modified else "N/A")
+            else:
+                expected_row.append("N/A")
+                expected_row.append("N/A")
+                expected_row.append("N/A")
+                expected_row.append("N/A")
 
-        self.assertEqual(row, expected_row)
+            if answer and answer.score:
+                expected_row.append(str(round(answer.score.normalized_score, 0)))   # round the floating point value for comparison
+                expected_row.append(str(answer.score.rank) if answer.score.rank else '')
+            else:
+                expected_row.append("Not Evaluated")
+                expected_row.append("Not Evaluated")
+
+            expected_row.append(str(evaluations_submitted))
+
+            expected_row.append(str(assignment.total_comparisons_required))
+
+            if assignment.total_comparisons_required > evaluations_submitted:
+                expected_row.append("No")
+            else:
+                expected_row.append("Yes")
+
+            expected_row.append(str(self_evaluation_count))
+            expected_row.append(str(comparison_feedback_submitted))
+            expected_row.append(str(standalone_feedback_submitted))
+
+            self.assertEqual(rows[current_row], expected_row)
+            current_row += 1
 
 
     def _check_participation_report_heading_rows(self, assignments, heading1, heading2):
         expected_heading1 = ['', '', '']
         for assignment in assignments:
             expected_heading1.append(assignment.name)
-            for criterion in assignment.criteria:
-                expected_heading1.append("")
+            expected_heading1.append("")
+            expected_heading1.append("")
+            expected_heading1.append("")
+            expected_heading1.append("")
+            expected_heading1.append("")
+            expected_heading1.append("")
 
-        expected_heading2 = ['Last Name', 'First Name', 'Student No']
+        expected_heading2 = ['Last Name', 'First Name', 'Student Number']
         for assignment in assignments:
-            expected_heading2.append("Percentage score for answer overall")
-            for criterion in assignment.criteria:
-                expected_heading2.append("Percentage score for \""+criterion.name+"\"")
-            expected_heading2.append("Evaluations Submitted ("+str(assignment.total_comparisons_required)+" required)")
+            expected_heading2.append("Participation Grade")
+            expected_heading2.append("Answer")
+            expected_heading2.append("Attachment")
+            expected_heading2.append("Answer Score (Normalized)")
+            expected_heading2.append("Comparisons Submitted ("+str(assignment.total_comparisons_required)+" required)")
+            expected_heading2.append("Feedback Submitted (During Comparisons)")
+            expected_heading2.append("Feedback Submitted (Outside Comparisons)")
 
         self.assertEqual(expected_heading1, heading1)
         self.assertEqual(expected_heading2, heading2)
@@ -690,59 +761,99 @@ class ReportAPITest(ComPAIRAPITestCase):
         index = 3
         for assignment in assignments:
             answer = None
+            answer_count = 0
             if not assignment.enable_group_answers:
-                answer = Answer.query \
+                answer_query = Answer.query \
                     .filter(
                         Answer.user_id == student.id,
                         Answer.assignment_id == assignment.id,
                         Answer.draft == False,
                         Answer.active == True
-                    ) \
-                    .first()
+                    )
+                answer = answer_query.first()
+                answer_count = answer_query.count()
             else:
                 group = student.get_course_group(self.fixtures.course.id)
-                answer = Answer.query \
+                answer_query = Answer.query \
                     .filter(
                         Answer.group_id == group.id,
                         Answer.assignment_id == assignment.id,
                         Answer.draft == False,
                         Answer.active == True
-                    ) \
-                    .first() if group else None
+                    )
+                answer = answer_query.first() if group else None
+                answer_count = answer_query.count() if group else 0
 
+            # Participation Grade
+            grade = AssignmentGrade.query \
+                .filter(
+                    AssignmentGrade.user_id == student.id,
+                    AssignmentGrade.assignment_id == assignment.id,
+                ).first()
+            self.assertEqual(float(row[index]), round(grade.grade*100, 0))
+            index += 1
+
+            # Answer Submitted
+            # self.assertEqual(row[index], str(answer_count))
+            # index += 1
+
+            # Answer
+            if answer:
+                self.assertEqual(row[index], answer.content)
+            else:
+                self.assertEqual(row[index], "")
+            index += 1
+
+            # Attachment
+            if answer and answer.file:
+                self.assertTrue(row[index].startswith("=HYPERLINK"))
+            else:
+                self.assertEqual(row[index], "")
+            index += 1
+
+            # Answer Score
             if answer:
                 if answer.score:
-                    self.assertAlmostEqual(float(row[index]), answer.score.normalized_score)
+                    self.assertAlmostEqual(float(row[index]), round(answer.score.normalized_score, 0))
                 else:
                     self.assertEqual(row[index], "Not Evaluated")
-
             else:
                 self.assertEqual(row[index], "No Answer")
             index += 1
 
-            for criterion in assignment.criteria:
-                if answer:
-                    criterion_score = next((
-                        criterion_score for criterion_score in answer.criteria_scores if \
-                        criterion_score.criterion_id == criterion.id
-                    ), None)
-
-                    if criterion_score:
-                        self.assertAlmostEqual(float(row[index]), criterion_score.normalized_score)
-                    else:
-                        self.assertEqual(row[index], "Not Evaluated")
-                else:
-                    self.assertEqual(row[index], "No Answer")
-                index += 1
-
+            # Evaluation Submitted
             evaluations_submitted = Comparison.query \
                 .filter(
                     Comparison.user_id == student.id,
                     Comparison.assignment_id == assignment.id
                 ) \
                 .count()
-
             self.assertEqual(row[index], str(evaluations_submitted))
+            index += 1
+
+            # comparison feedback submitted
+            comparison_feedback_submitted = AnswerComment.query \
+                .join(Answer, AnswerComment.answer_id == Answer.id) \
+                .filter(
+                    Answer.assignment_id == assignment.id,
+                    AnswerComment.user_id == student.id,
+                    AnswerComment.draft == False,
+                    AnswerComment.comment_type == AnswerCommentType.evaluation
+                ).count()
+            self.assertEqual(row[index], str(comparison_feedback_submitted))
+            index += 1
+
+            # standalone feedback submitted
+            standalone_feedback_submitted = AnswerComment.query \
+                .join(Answer, AnswerComment.answer_id == Answer.id) \
+                .filter(
+                    Answer.assignment_id == assignment.id,
+                    AnswerComment.user_id == student.id,
+                    AnswerComment.draft == False,
+                    or_(AnswerComment.comment_type == AnswerCommentType.public,
+                    AnswerComment.comment_type == AnswerCommentType.private) \
+                ).count()
+            self.assertEqual(row[index], str(standalone_feedback_submitted))
             index += 1
 
     def _check_peer_feedback_report_heading_rows(self, heading1, heading2):
@@ -755,9 +866,9 @@ class ReportAPITest(ComPAIRAPITestCase):
         self.assertEqual(expected_heading1, heading1)
         expected_heading2 = [
             "Assignment",
-            "Last Name", "First Name", "Student No",
-            "Last Name", "First Name", "Student No",
-            "Feedback Type", "Feedback"
+            "Last Name", "First Name", "Student Number",
+            "Last Name", "First Name", "Student Number",
+            "Feedback Type", "Feedback", "Feedback Character Count"
         ]
         self.assertEqual(expected_heading2, heading2)
 
@@ -793,6 +904,8 @@ class ReportAPITest(ComPAIRAPITestCase):
                     excepted_row += [answer_user.lastname, answer_user.firstname, answer_user.student_number]
 
                 excepted_row += [feedback_type, self._strip_html(answer_comment.content)]
+                char_count = len(self._strip_html(answer_comment.content))
+                excepted_row.append(str(char_count))
 
                 self.assertEqual(row, excepted_row)
         else:


### PR DESCRIPTION
- Added a tab `\t` character if the text (for answer / feedback) starts with a symbol such as `-`, `+`, or `=`. Note that UUID (e.g. answer ID, user ID etc) can start with "-" sign too but is not handled.
- Added logic to remove leading / trailing white spaced for feedbacks in Compiled Peer Feedback Report.
- Participation Report for Research Teams: added Student Number
- Basic Participation Report: rounded overall score
- Participation Report for Research Teams: rounded overall score
- Removed score-by-criterion column from Basic Participation Report
- Basic Participation Report: Changed "Percentage score for answer overall" to "Answer Score"
- Basic Participation Report: Added Participation Grade, Answer Submitted, and Feedback Submitted
- Participation Report for Research Teams: renamed "Replies Submitted" -> "Feedback Submitted"
- Compiled Peer Feedback Report: Added Feedback Character Count
- Participation Report for Research Teams: included inactive (deleted)
answers. Added columns to indicate if answer is deleted and last
modified date

Closes #689 