### PR TITLE
Prevent users from being able to change comment to self-eval (or vise-versa)

### DIFF
--- a/compair/api/answer_comment.py
+++ b/compair/api/answer_comment.py
@@ -308,9 +308,18 @@ class AnswerCommentAPI(Resource):
             AnswerCommentType.self_evaluation.value
         ]
 
+        eval_comment_types = [
+            AnswerCommentType.evaluation.value,
+            AnswerCommentType.self_evaluation.value
+        ]
+
         comment_type = params.get("comment_type", AnswerCommentType.private.value)
         if comment_type not in comment_types:
             abort(400, title="Feedback Not Saved", message="This feedback type is not recognized. Please contact support for assistance.")
+
+        # do not allow changing a self-eval into a comment or vise-versa
+        if (answer_comment.comment_type.value in eval_comment_types or comment_type in eval_comment_types) and answer_comment.comment_type.value != comment_type:
+            abort(400, title="Feedback Not Saved", message="Feedback type cannot be changed. Please contact support for assistance.")
 
         answer_comment.comment_type = AnswerCommentType(comment_type)
 

--- a/compair/tests/api/test_answer_comments.py
+++ b/compair/tests/api/test_answer_comments.py
@@ -562,6 +562,22 @@ class AnswerCommentAPITests(ComPAIRAPITestCase):
 
         # test author
         with self.login(self.data.get_extra_student(0).username):
+
+            # test student can not change comment to self-eval / eval
+            invalid = content.copy()
+            invalid['comment_type'] = AnswerCommentType.self_evaluation.value
+            rv = self.client.post(url, data=json.dumps(invalid), content_type='application/json')
+            self.assert400(rv)
+            self.assertEqual("Feedback Not Saved", rv.json['title'])
+            self.assertEqual("Feedback type cannot be changed. Please contact support for assistance.", rv.json['message'])
+
+            invalid = content.copy()
+            invalid['comment_type'] = AnswerCommentType.evaluation.value
+            rv = self.client.post(url, data=json.dumps(invalid), content_type='application/json')
+            self.assert400(rv)
+            self.assertEqual("Feedback Not Saved", rv.json['title'])
+            self.assertEqual("Feedback type cannot be changed. Please contact support for assistance.", rv.json['message'])
+
             with mail.record_messages() as outbox:
                 content['content'] = 'I am the author'
                 rv = self.client.post(url, data=json.dumps(content), content_type='application/json')


### PR DESCRIPTION
Fixes #794 