### PR TITLE
Add submission date field to answer and utilize it

### DIFF
--- a/alembic/versions/d6c88adfe909_add_submission_date_to_answer.py
+++ b/alembic/versions/d6c88adfe909_add_submission_date_to_answer.py
@@ -1,0 +1,25 @@
+"""Add submission date to answer
+
+Revision ID: d6c88adfe909
+Revises: 8b4e3c1d8c41
+Create Date: 2018-08-09 03:25:24.549790
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd6c88adfe909'
+down_revision = '8b4e3c1d8c41'
+
+from alembic import op
+import sqlalchemy as sa
+
+from compair.models import convention
+
+def upgrade():
+    with op.batch_alter_table('answer', naming_convention=convention) as batch_op:
+        batch_op.add_column(sa.Column('submission_date', sa.DateTime(), nullable=True))
+    op.execute('UPDATE answer SET submission_date=modified')
+
+def downgrade():
+    with op.batch_alter_table('answer', naming_convention=convention) as batch_op:
+        batch_op.drop_column('submission_date')

--- a/compair/api/answer.py
+++ b/compair/api/answer.py
@@ -251,10 +251,6 @@ class AnswerRootAPI(Resource):
                 abort(400, title="Answer Not Submitted",
                     message="You are currently not in any group for this course. Please contact your instructor to be added to a group.")
 
-        # set submission date if answer is being submitted for the first time
-        if not answer.draft and not answer.submission_date:
-            answer.submission_date = datetime.datetime.utcnow()
-
         check_for_existing_answers = False
         if group and assignment.enable_group_answers:
             if group.course_id != course.id:
@@ -308,6 +304,10 @@ class AnswerRootAPI(Resource):
             draft_answers = [prev_answer for prev_answer in prev_answers if prev_answer.draft]
             for draft_answer in draft_answers:
                 draft_answer.active = False
+
+        # set submission date if answer is being submitted for the first time
+        if not answer.draft and not answer.submission_date:
+            answer.submission_date = datetime.datetime.utcnow()
 
         db.session.add(answer)
         db.session.commit()
@@ -404,10 +404,6 @@ class AnswerIdAPI(Resource):
         user = User.get_by_uuid_or_404(user_uuid) if user_uuid else answer.user
         group = Group.get_active_by_uuid_or_404(group_uuid) if group_uuid else answer.group
 
-        # set submission date if answer is being submitted for the first time
-        if not answer.draft and not answer.submission_date:
-            answer.submission_date = datetime.datetime.utcnow()
-
         check_for_existing_answers = False
         if group and assignment.enable_group_answers:
             if group.course_id != course.id:
@@ -477,6 +473,10 @@ class AnswerIdAPI(Resource):
         # non-drafts must have content
         if not answer.draft and not answer.content and not file_uuid:
             abort(400, title="Answer Not Submitted", message="Please provide content in the text editor or upload a file and try submitting again.")
+
+        # set submission date if answer is being submitted for the first time
+        if not answer.draft and not answer.submission_date:
+            answer.submission_date = datetime.datetime.utcnow()
 
         model_changes = get_model_changes(answer)
         db.session.add(answer)

--- a/compair/api/dataformat/__init__.py
+++ b/compair/api/dataformat/__init__.py
@@ -247,6 +247,7 @@ def get_answer(restrict_user=True, include_answer_author=True, include_score=Tru
         'public_comment_count': fields.Integer,
 
         'created': fields.DateTime(dt_format='iso8601', attribute=lambda x: replace_tzinfo(x.created)),
+        'submission_date': fields.DateTime(dt_format='iso8601', attribute=lambda x: replace_tzinfo(x.submission_date)),
         'comparable': fields.Boolean
     }
 

--- a/compair/api/dataformat/__init__.py
+++ b/compair/api/dataformat/__init__.py
@@ -247,7 +247,7 @@ def get_answer(restrict_user=True, include_answer_author=True, include_score=Tru
         'public_comment_count': fields.Integer,
 
         'created': fields.DateTime(dt_format='iso8601', attribute=lambda x: replace_tzinfo(x.created)),
-        'submission_date': fields.DateTime(dt_format='iso8601', attribute=lambda x: replace_tzinfo(x.submission_date)),
+        'submission_date': fields.DateTime(dt_format='iso8601', default=None, attribute=lambda x: replace_tzinfo(x.submission_date)),
         'comparable': fields.Boolean
     }
 

--- a/compair/api/report.py
+++ b/compair/api/report.py
@@ -197,7 +197,7 @@ def participation_stat_report(course, assignments, group, overall):
                     Answer.group_id.in_(group_ids)
                 )
             )) \
-            .order_by(Answer.created) \
+            .order_by(Answer.submission_date) \
             .all()
 
         user_answers = {}   # structure - user_id/[answer list]

--- a/compair/models/answer.py
+++ b/compair/models/answer.py
@@ -28,6 +28,7 @@ class Answer(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
     draft = db.Column(db.Boolean(), default=False, nullable=False, index=True)
     top_answer = db.Column(db.Boolean(), default=False, nullable=False, index=True)
     comparable = db.Column(db.Boolean(), default=True, nullable=False, index=True)
+    submission_date = db.Column(db.DateTime(timezone=True), nullable=True)
 
     # relationships
     # assignment via Assignment Model

--- a/compair/models/assignment.py
+++ b/compair/models/assignment.py
@@ -53,7 +53,7 @@ class Assignment(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
         order_by=AssignmentCriterion.position.asc(), collection_class=ordering_list('position', count_from=0))
 
     answers = db.relationship("Answer", backref="assignment", lazy="dynamic",
-        order_by=Answer.created.desc())
+        order_by=Answer.submission_date.desc())
     comparisons = db.relationship("Comparison", backref="assignment", lazy="dynamic")
     comparison_examples = db.relationship("ComparisonExample", backref="assignment", lazy="dynamic")
     scores = db.relationship("AnswerScore", backref="assignment", lazy="dynamic")

--- a/compair/static/modules/assignment/assignment-view-partial.html
+++ b/compair/static/modules/assignment/assignment-view-partial.html
@@ -177,7 +177,7 @@
                     <div class="each-header clearfix">
                         <compair-answer-avatar answer="answer"></compair-answer-avatar>
                         <span class="label label-default" ng-if="instructors[answer.user_id]">{{instructors[answer.user_id]}}</span>
-                        <strong>said</strong> on {{answer.created | amDateFormat: 'MMM D @ h:mm a'}}:
+                        <strong>said</strong> on {{answer.submission_date | amDateFormat: 'MMM D @ h:mm a'}}:
                         <div class="manager-actions pull-right" ng-if="canManageAssignment">
                             <em>{{instructorLabel(answer.user_id)}} Response</em>
                             <span ng-if="canManageAssignment && !answerFilters.anonymous && answer.score && answer.comparable" class="label label-warning score-tooltip" uib-tooltip="Scores are normalized, so the top-ranked answer or&mdash;in the case of a tie&mdash;answers for the assignment receive 100%. All other answers receive a lower percentage based on how well they did compared to the top-ranked answer." tooltip-trigger tooltip-animation="false" tooltip-placement="left">
@@ -218,7 +218,7 @@
                             ></compair-answer-avatar>
                         <span ng-show="answerFilters.anonymous">Student</span>
                         <span class="label label-default" ng-if="isInstructor(answer.user_id)">{{instructorLabel(answer.user_id)}}</span>
-                        <strong>answered</strong> on {{answer.created | amDateFormat: 'MMM D @ h:mm a'}}:
+                        <strong>answered</strong> on {{answer.submission_date | amDateFormat: 'MMM D @ h:mm a'}}:
                         <div class="manager-actions pull-right">
                             <!-- Student Score (not used for instructor answers) -->
                             <span ng-if="canManageAssignment && !answerFilters.anonymous && answer.score" class="label label-warning score-tooltip" uib-tooltip="Scores are normalized, so the top-ranked answer or&mdash;in the case of a tie&mdash;answers for the assignment receive 100%. All other answers receive a lower percentage based on how well they did compared to the top-ranked answer." tooltip-trigger tooltip-animation="false" tooltip-placement="left">
@@ -362,7 +362,7 @@
                     <div class="each-header clearfix">
                         <compair-answer-avatar answer="answer" skip-name="true" me="true"></compair-answer-avatar>
                         <span class="label label-default" ng-if="isInstructor(answer.user_id)">{{instructorLabel(answer.user_id)}}</span>
-                        <strong>answered</strong> on {{answer.created | amDateFormat: 'MMM D @ h:mm a'}}:
+                        <strong>answered</strong> on {{answer.submission_date | amDateFormat: 'MMM D @ h:mm a'}}:
                         <div class="manager-actions pull-right" ng-if="canManageAssignment || ((answer.user_id == loggedInUserId || (currentUserGroup && answer.group_id == currentUserGroup.id)) && assignment.answer_period && !assignment.compare_period)">
                             <a href="" title="Delete this answer" confirmation-needed="deleteAnswer(answer)" keyword="answer">
                                 <i class="fa fa-trash-o"></i>

--- a/compair/static/modules/comment/answer.html
+++ b/compair/static/modules/comment/answer.html
@@ -1,6 +1,6 @@
 <div ng-if="answer">
     <compair-student-avatar user="answer.user"></compair-student-avatar>
-    <strong>answered</strong> on {{ answer.created | amDateFormat: 'MMM D @ h:mm a'}}:
+    <strong>answered</strong> on {{ answer.submission_date | amDateFormat: 'MMM D @ h:mm a'}}:
     <rich-content content="answer.content" attachment="answer.file"></rich-content>
 </div>
 <div ng-if="!answer"><p><i>(No answer has been submitted by this student.)</i></p></div>

--- a/compair/tests/api/test_answers.py
+++ b/compair/tests/api/test_answers.py
@@ -64,7 +64,7 @@ class AnswersAPITests(ComPAIRAPITestCase):
                     rv = self.client.get(self.base_url)
                     self.assert200(rv)
                     actual_answers = rv.json['objects']
-                    expected_answers = sorted([answer for answer in answers], key=lambda ans: ans.created, reverse=True)
+                    expected_answers = sorted([answer for answer in answers], key=lambda ans: ans.submission_date, reverse=True)
                     expected_answers = sorted(expected_answers, key=lambda ans: ans.comparable)[:20]
                     for i, expected in enumerate(expected_answers):
                         actual = actual_answers[i]
@@ -84,7 +84,7 @@ class AnswersAPITests(ComPAIRAPITestCase):
                         rv = self.client.get(self.base_url + '?page=2')
                         self.assert200(rv)
                         actual_answers = rv.json['objects']
-                        expected_answers = sorted([answer for answer in answers], key=lambda ans: ans.created, reverse=True)
+                        expected_answers = sorted([answer for answer in answers], key=lambda ans: ans.submission_date, reverse=True)
                         expected_answers = sorted(expected_answers, key=lambda ans: ans.comparable)[20:]
                         for i, expected in enumerate(expected_answers):
                             actual = actual_answers[i]
@@ -105,7 +105,7 @@ class AnswersAPITests(ComPAIRAPITestCase):
                     # test the result is paged and sorted
                     expected = sorted(
                         [answer for answer in answers if answer.score],
-                        key=lambda ans: (ans.score.score, ans.created),
+                        key=lambda ans: (ans.score.score, ans.submission_date),
                         reverse=True)[:10]
                     self.assertEqual([a.uuid for a in expected], [a['id'] for a in result])
                     for ans in result:
@@ -126,7 +126,7 @@ class AnswersAPITests(ComPAIRAPITestCase):
                     # test the result is paged and sorted
                     expected = sorted(
                         [answer for answer in answers if answer.score],
-                        key=lambda ans: (ans.score.score, ans.created),
+                        key=lambda ans: (ans.score.score, ans.submission_date),
                         reverse=True)[:20]
                     self.assertEqual([a.uuid for a in expected], [a['id'] for a in result])
                     for ans in result:
@@ -266,7 +266,7 @@ class AnswersAPITests(ComPAIRAPITestCase):
                 # test the result is paged and sorted
                 expected = sorted(
                     [answer for answer in answers if answer.comparable],
-                    key=lambda ans: (ans.score.score if ans.score else float('-inf'), ans.created),
+                    key=lambda ans: (ans.score.score if ans.score else float('-inf'), ans.submission_date),
                     reverse=True)
                 self.assertEqual([a.uuid for a in expected[:20]], [a['id'] for a in result])
                 self.assertEqual(1, rv.json['page'])
@@ -284,7 +284,7 @@ class AnswersAPITests(ComPAIRAPITestCase):
                     result = rv.json['objects']
                     expected = sorted(
                         [answer for answer in answers if answer.comparable],
-                        key=lambda ans: (ans.score.score if ans.score else float('-inf'), ans.created),
+                        key=lambda ans: (ans.score.score if ans.score else float('-inf'), ans.submission_date),
                         reverse=True)
                     self.assertEqual([a.uuid for a in expected[20:]], [a['id'] for a in result])
                     self.assertEqual(2, rv.json['page'])

--- a/data/factories.py
+++ b/data/factories.py
@@ -105,8 +105,9 @@ class AnswerFactory(factory.alchemy.SQLAlchemyModelFactory):
     #group = factory.SubFactory(GroupFactory)
     content = factory.Sequence(lambda n: 'this is some content for post ü %d' % n)
     draft = False
-    # Make sure created dates are unique.
+    # Make sure created / submission dates are unique.
     created = factory.Sequence(lambda n: datetime.datetime.fromtimestamp(1404768528 - n))
+    submission_date = factory.Sequence(lambda n: datetime.datetime.fromtimestamp(1404768528 - n))
 
 class AnswerScoreFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:

--- a/data/fixtures/test_data.py
+++ b/data/fixtures/test_data.py
@@ -685,7 +685,8 @@ class TestFixture:
             for assignment in self.assignments:
                 answer = AnswerFactory(
                     assignment=assignment,
-                    draft=True
+                    draft=True,
+                    submission_date=None
                 )
                 if assignment.enable_group_answers:
                     answer.group = self.draft_group
@@ -943,6 +944,9 @@ class TestFixture:
             group=None,
             draft=draft
         )
+        if (draft):
+            answer.submission_date=None
+
         db.session.commit()
         self.answers.append(answer)
         return self
@@ -954,6 +958,9 @@ class TestFixture:
             user=None,
             draft=draft
         )
+        if (draft):
+            answer.submission_date=None
+
         db.session.commit()
         self.answers.append(answer)
         return self


### PR DESCRIPTION
- Create new column `submission_date` in the answer table
- Populate it with `modified` column content
- When answer is submitted (saved as non-draft), update the submitted date to current date/time
- Wherever answer submitted date is shown, use this new field instead of created / modified
- Change sorting mechanisms to also use this new column when sorting by submitted time

Fixes #812 