### PR TITLE
Add self-evaluation dates to course duplication

### DIFF
--- a/compair/api/course.py
+++ b/compair/api/course.py
@@ -255,6 +255,9 @@ class CourseDuplicateAPI(Resource):
                 assignment_copy_data['compare_end'] = datetime.datetime.strptime(
                     assignment_copy_data.get('compare_end'), '%Y-%m-%dT%H:%M:%S.%fZ')
 
+            if 'enable_self_evaluation' not in assignment_copy_data:
+                assignment_copy_data['enable_self_evaluation'] = False
+
             if assignment_copy_data.get('self_eval_start'):
                 assignment_copy_data['self_eval_start'] = datetime.datetime.strptime(
                     assignment_copy_data.get('self_eval_start'), '%Y-%m-%dT%H:%M:%S.%fZ')
@@ -314,13 +317,17 @@ class CourseDuplicateAPI(Resource):
                 compare_start=assignment_copy_data.get('compare_start'),
                 compare_end=assignment_copy_data.get('compare_end'),
 
+                self_eval_start=assignment_copy_data.get('self_eval_start') if assignment_copy_data.get('enable_self_evaluation', False) else None,
+                self_eval_end=assignment_copy_data.get('self_eval_end') if assignment_copy_data.get('enable_self_evaluation', False) else None,
+                self_eval_instructions=assignment.self_eval_instructions if assignment_copy_data.get('enable_self_evaluation', False) else None,
+
                 answer_grade_weight=assignment.answer_grade_weight,
                 comparison_grade_weight=assignment.comparison_grade_weight,
                 self_evaluation_grade_weight=assignment.self_evaluation_grade_weight,
 
                 number_of_comparisons=assignment.number_of_comparisons,
                 students_can_reply=assignment.students_can_reply,
-                enable_self_evaluation=assignment.enable_self_evaluation,
+                enable_self_evaluation=assignment_copy_data.get('enable_self_evaluation', False),
                 enable_group_answers=assignment.enable_group_answers,
                 pairing_algorithm=assignment.pairing_algorithm,
                 scoring_algorithm=assignment.scoring_algorithm,

--- a/compair/static/modules/assignment/assignment-form-partial.html
+++ b/compair/static/modules/assignment/assignment-form-partial.html
@@ -211,7 +211,7 @@
                         <div class="assignment-date">
                             <span class="input-group">
                                 <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.sestart.date"
-                                    is-open="date.sestart.opened" ng-required="assignment.selfEvalCheck"
+                                    is-open="date.sestart.opened" ng-required="assignment.enable_self_evaluation && assignment.selfEvalCheck"
                                     datepicker-options="{ minDate: datePickerMinDate(date.astart.date, course.start_date), maxDate: datePickerMaxDate(date.seend.date, course.end_date) }"
                                     />
                                 <span class="input-group-btn">
@@ -224,11 +224,11 @@
                         </div>
                     </div>
                     <div class="col-md-6 form-group">
-                        <label>Self-Evaluation Ends</label><br />
+                        <label class="required-star">Self-Evaluation Ends</label><br />
                         <div class="assignment-date">
                             <span class="input-group">
                                 <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="date.seend.date"
-                                    is-open="date.seend.opened"
+                                    is-open="date.seend.opened" ng-required="assignment.enable_self_evaluation && assignment.selfEvalCheck"
                                     datepicker-options="{ minDate: datePickerMinDate(date.astart.date, date.sestart.date, course.start_date), maxDate: datePickerMaxDate(course.end_date) }"
                                     />
                                 <span class="input-group-btn">

--- a/compair/static/modules/course/course-duplicate-partial.html
+++ b/compair/static/modules/course/course-duplicate-partial.html
@@ -191,7 +191,68 @@
                     </div>
                 </div>
             </div>
+            <div class="row">
+                <div class="col-md-12 form-group">
+                    <label class="required-star">Self-Evaluation</label>
+                    <br>
+                    <label class="form-check-label not-bold">
+                        <input class="form-check-input" type="radio"
+                                ng-model="assignment.enable_self_evaluation" ng-value="true">
+                        &nbsp;Include self-evaluation for students &nbsp;&nbsp;
+                    </label>
+                    <label class="form-check-label not-bold">
+                        <input class="form-check-input" type="radio"
+                                ng-model="assignment.enable_self_evaluation" ng-value="false">
+                        &nbsp;Do not include self-evaluation
+                    </label>
+                </div>
+            </div>
+            <div class="row" ng-show="assignment.enable_self_evaluation">
+                <div class="col-md-12 form-group">
+                    <input type="checkbox" ng-model="assignment.selfEvalCheck">
+                    <label for="selfEvalCheck">Manually set when students self-evaluate<span ng-show="assignment.selfEvalCheck">:</span></label>
+                    <br /><br />
 
+                    <div ng-show="assignment.selfEvalCheck">
+                        <div class="row">
+                            <div class="col-md-6 form-group">
+                                <label class="required-star">Self-Evaluation Begins</label><br />
+                                <div class="assignment-date">
+                                    <span class="input-group">
+                                        <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="assignment.date.sestart.date"
+                                            is-open="assignment.date.sestart.opened" ng-required="assignment.enable_self_evaluation && assignment.selfEvalCheck"
+                                            datepicker-options="{ minDate: datePickerMinDate(assignment.date.sestart.date, duplicateCourse.date.course_start.date), maxDate: datePickerMaxDate(assignment.date.seend.date, duplicateCourse.date.course_end.date) }"
+                                            />
+                                        <span class="input-group-btn">
+                                            <button type="button" class="btn btn-default" ng-click="datePickerOpen($event, assignment.date.sestart)"><i class="glyphicon glyphicon-calendar"></i></button>
+                                        </span>
+                                    </span>
+                                </div>
+                                <div class="assignment-date">
+                                    <div uib-timepicker ng-model="assignment.date.sestart.time" minute-step="1" mousewheel="false"></div>
+                                </div>
+                            </div>
+                            <div class="col-md-6 form-group">
+                                <label class="required-star">Self-Evaluation Ends</label><br />
+                                <div class="assignment-date">
+                                    <span class="input-group">
+                                        <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="assignment.date.seend.date"
+                                            is-open="assignment.date.seend.opened" ng-required="assignment.enable_self_evaluation && assignment.selfEvalCheck"
+                                            datepicker-options="{ minDate: datePickerMinDate(assignment.date.sestart.date, assignment.date.sestart.date, duplicateCourse.date.course_start.date), maxDate: datePickerMaxDate(duplicateCourse.date.course_end.date) }"
+                                            />
+                                        <span class="input-group-btn">
+                                            <button type="button" class="btn btn-default" ng-click="datePickerOpen($event, assignment.date.seend)"><i class="glyphicon glyphicon-calendar"></i></button>
+                                        </span>
+                                    </span>
+                                </div>
+                                <div class="assignment-date">
+                                    <div uib-timepicker ng-model="assignment.date.seend.time" minute-step="1" mousewheel="false"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </fieldset>
     <p class="text-center text-muted"><span class="required-star "></span> = required (please make sure these areas are filled in)</p>

--- a/compair/static/modules/course/course-module.js
+++ b/compair/static/modules/course/course-module.js
@@ -622,8 +622,11 @@ module.controller(
                         astart: {date: null, time: new Date().setHours(0, 0, 0, 0)},
                         aend: {date: null, time: new Date().setHours(23, 59, 0, 0)},
                         cstart: {date: null, time: new Date().setHours(0, 0, 0, 0)},
-                        cend: {date: null, time: new Date().setHours(23, 59, 0, 0)}
-                    }
+                        cend: {date: null, time: new Date().setHours(23, 59, 0, 0)},
+                        sestart: {date: null, time: new Date().setHours(0, 0, 0, 0)},
+                        seend: {date: null, time: new Date().setHours(23, 59, 0, 0)},
+                    },
+                    enable_self_evaluation: assignment.enable_self_evaluation,
                 }
 
                 duplicate_assignment.date.astart.date = getNewDuplicateDate(assignment.answer_start, weekDelta).toDate();
@@ -644,6 +647,20 @@ module.controller(
 
                 if (assignment.compare_start && assignment.compare_end) {
                     duplicate_assignment.availableCheck = true;
+                }
+
+                if (assignment.self_eval_start) {
+                    duplicate_assignment.date.sestart.date = getNewDuplicateDate(assignment.self_eval_start, weekDelta).toDate();
+                    duplicate_assignment.date.sestart.time = moment(assignment.self_eval_start).toDate();
+                }
+
+                if (assignment.self_eval_start) {
+                    duplicate_assignment.selfEvalCheck = true;
+                }
+
+                if (assignment.self_eval_end) {
+                    duplicate_assignment.date.seend.date =  getNewDuplicateDate(assignment.self_eval_end, weekDelta).toDate();
+                    duplicate_assignment.date.seend.time = moment(assignment.self_eval_end).toDate();
                 }
 
                 $scope.duplicateAssignments.push(duplicate_assignment);
@@ -711,6 +728,9 @@ module.controller(
                     answer_end: combineDateTime(assignment.date.aend),
                     compare_start: combineDateTime(assignment.date.cstart),
                     compare_end: combineDateTime(assignment.date.cend),
+                    enable_self_evaluation: assignment.enable_self_evaluation,
+                    self_eval_start: assignment.enable_self_evaluation && assignment.selfEvalCheck? combineDateTime(assignment.date.sestart) : null,
+                    self_eval_end: assignment.enable_self_evaluation && assignment.selfEvalCheck? combineDateTime(assignment.date.seend) : null,
                 }
 
                 // answer end datetime has to be after answer start datetime
@@ -726,12 +746,21 @@ module.controller(
                     Toaster.warning('Assignment Not Duplicated', 'Please set comparison end time after comparison start time and try again.');
                     $scope.submitted = false;
                     return;
+                } else if (assignment.enable_self_evaluation && assignment.selfEvalCheck && assignment_submit.self_eval_start >= assignment_submit.self_eval_end) {
+                    Toaster.warning('Assignment Not Duplicated', 'Please set self-evaluation end time after self-evaluation start time and try again.');
+                    $scope.submitted = false;
+                    return;
                 }
 
                 // if option is not checked; make sure no compare dates are saved.
                 if (!assignment.availableCheck) {
                     assignment_submit.compare_start = null;
                     assignment_submit.compare_end = null;
+                }
+                // same for self-evaluation dates
+                if (!assignment.selfEvalCheck) {
+                    assignment_submit.self_eval_start = null;
+                    assignment_submit.self_eval_end = null;
                 }
 
                 $scope.duplicateCourse.assignments.push(assignment_submit);

--- a/compair/tests/api/test_courses.py
+++ b/compair/tests/api/test_courses.py
@@ -2,6 +2,8 @@
 from __future__ import unicode_literals
 import datetime
 import json
+from random import choice
+from string import ascii_letters
 from compair import db
 
 from data.fixtures import DefaultFixture
@@ -377,6 +379,7 @@ class CoursesDuplicateComplexAPITests(ComPAIRAPITestCase):
         self.course.end_date = datetime.datetime.utcnow() + datetime.timedelta(days=90)
 
         index = 0
+        self.assertGreaterEqual(self.course.assignments.count(), 4) # make sure we have enough assignments to play with
         for assignment in self.course.assignments:
             assignment.answer_start = self.course.start_date + datetime.timedelta(days=index)
             assignment.answer_end = self.course.start_date + datetime.timedelta(days=index+7)
@@ -384,6 +387,19 @@ class CoursesDuplicateComplexAPITests(ComPAIRAPITestCase):
                 assignment.compare_start = self.course.start_date + datetime.timedelta(days=index+14)
             if assignment.compare_end != None:
                 assignment.compare_end = self.course.start_date + datetime.timedelta(days=index+21)
+            # modify some assignments with self-evaluation
+            if index % 2 == 0:
+                assignment.enable_self_evaluation = True
+            else:
+                assignment.enable_self_evaluation = False
+            if index % 4 == 0:
+                assignment.self_eval_start = assignment.answer_end + datetime.timedelta(days=1)
+                assignment.self_eval_end = assignment.self_eval_start + datetime.timedelta(days=1)
+                assignment.self_eval_instructions = ''.join([choice(ascii_letters) for i in range(10)])
+            else:
+                assignment.self_eval_start = None
+                assignment.self_eval_end = None
+                assignment.self_eval_instructions = None
             index+=1
         db.session.commit()
 
@@ -408,7 +424,11 @@ class CoursesDuplicateComplexAPITests(ComPAIRAPITestCase):
                 'id': assignment.uuid,
                 'name': assignment.name,
                 'answer_start': (assignment.answer_start + self.date_delta).isoformat() + 'Z',
-                'answer_end': (assignment.answer_end + self.date_delta).isoformat() + 'Z'
+                'answer_end': (assignment.answer_end + self.date_delta).isoformat() + 'Z',
+                'enable_self_evaluation': assignment.enable_self_evaluation,
+                'self_eval_start': (assignment.self_eval_start + self.date_delta).isoformat() + 'Z' if assignment.self_eval_start else assignment.self_eval_start,
+                'self_eval_end': (assignment.self_eval_end + self.date_delta).isoformat() + 'Z' if assignment.self_eval_end else assignment.self_eval_end,
+                'self_eval_instructions': assignment.self_eval_instructions,
             }
 
             if assignment.compare_start != None:
@@ -698,6 +718,20 @@ class CoursesDuplicateComplexAPITests(ComPAIRAPITestCase):
                     duplicate_criteria = duplicate_assignment.criteria[index]
                     self.assertEqual(original_criteria.id, duplicate_criteria.id)
 
+                self.assertEqual(original_assignment.enable_self_evaluation,
+                    duplicate_assignment.enable_self_evaluation)
+                if original_assignment.self_eval_start:
+                    self.assertEqual(original_assignment.self_eval_start,
+                        (duplicate_assignment.self_eval_start - self.date_delta))
+                else:
+                    self.assertIsNone(duplicate_assignment.self_eval_start)
+                if original_assignment.self_eval_end:
+                    self.assertEqual(original_assignment.self_eval_end,
+                        (duplicate_assignment.self_eval_end - self.date_delta))
+                else:
+                    self.assertIsNone(duplicate_assignment.self_eval_end)
+                self.assertEqual(original_assignment.self_eval_instructions,
+                    duplicate_assignment.self_eval_instructions)
 
                 original_comparison_examples = original_assignment.comparison_examples.all()
                 duplicate_comparison_examples = duplicate_assignment.comparison_examples.all()


### PR DESCRIPTION
- add self-evaluation related options to course duplication form
- modify course duplication api to store submitted self-eval info
- modify validation logic of self-eval dates on assignment form

Closes #819 