### PR TITLE
Hide CSV import in LTI courses

### DIFF
--- a/compair/static/modules/classlist/classlist-view-partial.html
+++ b/compair/static/modules/classlist/classlist-view-partial.html
@@ -4,7 +4,7 @@
             <h1>Manage Users</h1>
         </header>
         <div class="col-md-6 sub-nav">
-            <span ng-show="!lti_membership_enabled">
+            <span ng-show="!course.lti_linked">
                 <a ng-href="#/course/{{courseId}}/user/import" class="btn btn-primary">
                     <i class="fa fa-download"></i>
                     Import Users
@@ -16,10 +16,10 @@
             </span>
         </div>
     </div>
-    <p class="intro-text" ng-if="lti_membership_enabled">
+    <p class="intro-text" ng-if="course.lti_linked">
         Your class list is managed externally. This means users need to enroll themselves by clicking a special link in your existing external course. This link sends registration information from your external course to ComPAIR that confirms the user should be enrolled. To manually update the list below to the latest enrollment numbers, click "Refresh List" below.
     </p>
-    <p class="intro-text" ng-if="!lti_membership_enabled">
+    <p class="intro-text" ng-if="!course.lti_linked">
         <strong>Edit or drop users from the course and manage course groups</strong> below. To make significant changes to the <em>full</em> course user list at once, click "Import Users" above and follow the directions on the next screen. To generate a file with all the currently enrolled users, click "Export Users" above.
     </p>
     <h2>Enrolled in {{course.name}}</h2>
@@ -32,7 +32,7 @@
                     <i class="fa fa-refresh"></i> Refresh List
                 </a>
             </div>
-            <div ng-show="!lti_membership_enabled && canCreateUsers">
+            <div ng-show="!course.lti_linked && canCreateUsers">
                 <enrol-component course-id="courseId"></enrol-component>
             </div>
         </div>
@@ -40,7 +40,7 @@
     <p class="alert alert-info" ng-show="lti_membership_pending > 0">
         <i class="glyphicon glyphicon-info-sign"></i> Currently, <strong>{{lti_membership_pending}} user<span ng-show="lti_membership_pending != 1">s</span></strong> are pending registration (registered in your external course but not yet in ComPAIR). To register, <strong>each student must follow the link from your external course</strong> the first time they access ComPAIR. Once they have followed this link and registered, they may log in through the link or directly at this site.
     </p>
-    <p class="alert alert-info" ng-show="!lti_membership_enabled && course.lti_linked">
+    <p class="alert alert-info" ng-show="course.lti_linked && !lti_membership_enabled">
         <i class="glyphicon glyphicon-info-sign"></i> There may be users pending registration (registered in your external course but not yet in ComPAIR). To register, <strong>each student must follow the link from your external course</strong> the first time they access ComPAIR. Once they have followed this link and registered, they may log in through the link or directly at this site.
     </p>
 


### PR DESCRIPTION
Hides the csv import functionality on the manage users screen for LTI courses (since users will be managed by LTI launches and/or membership service requests)

Closes #828 