### PR TITLE
Allow easier adding of groups on Manage Users screen

### DIFF
--- a/alembic/versions/b492a8f2132c_make_course_group_names_unique.py
+++ b/alembic/versions/b492a8f2132c_make_course_group_names_unique.py
@@ -1,0 +1,64 @@
+"""make course group names unique
+
+Revision ID: b492a8f2132c
+Revises: d6c88adfe909
+Create Date: 2018-08-29 15:50:58.479621
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'b492a8f2132c'
+down_revision = 'd6c88adfe909'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import func
+
+from compair.models import convention
+
+group_table = sa.table('group',
+    sa.Column('id', sa.Integer), sa.Column('course_id', sa.Integer),
+    sa.Column('name', sa.String), sa.Column('active', sa.Boolean),
+    sa.Column('modified', sa.DateTime), sa.Column('created', sa.DateTime),
+    sa.Column('uuid', sa.CHAR(22))
+)
+
+def upgrade():
+
+    connection = op.get_bind()
+
+    groups = connection.execute(group_table.select())
+
+    # {course_id}{group_name} - counts how many have been updated so far
+    counter = {}
+
+    for group in groups:
+        counter.setdefault(group.course_id, {})
+        counter[group.course_id].setdefault(group.name, 0)
+
+        counter[group.course_id][group.name] += 1
+
+        if counter[group.course_id][group.name] > 1:
+            count = counter[group.course_id][group.name]
+            new_group_name = "{} [{}]".format(group.name, count)
+            # while loop is necessary in case there is an existing group with the same name and number e.g. Example Group [2]
+            while connection.execute(group_table.count().where(sa.and_(
+                    group_table.c.name == new_group_name,
+                    group_table.c.course_id == group.course_id
+                ))).scalar() > 0:
+                    count += 1
+                    new_group_name = "{} [{}]".format(group.name, count)
+            connection.execute(
+                group_table \
+                .update() \
+                .where(group_table.c.id == group.id) \
+                .values(name=new_group_name)
+            )
+            counter[group.course_id][group.name] = count
+
+    with op.batch_alter_table('group', naming_convention=convention) as batch_op:
+        batch_op.create_unique_constraint('uq_course_and_group_name', ['course_id', 'name'])
+
+def downgrade():
+    with op.batch_alter_table('group', naming_convention=convention) as batch_op:
+        batch_op.drop_constraint('uq_course_and_group_name', type_='unique')

--- a/compair/api/group.py
+++ b/compair/api/group.py
@@ -44,6 +44,19 @@ class GroupRootAPI(Resource):
         params = new_group_parser.parse_args()
 
         new_group.name = params.get("name")
+
+        # check if group name is unique
+        group_name_exists = Group.query \
+            .filter(
+                Group.course_id == course.id,
+                Group.name == new_group.name
+            ) \
+            .first()
+
+        if group_name_exists:
+            abort(400, title="Group Not Added",
+                message="Sorry, the group name you have entered already exists. Please choose a different name.")
+
         db.session.add(new_group)
         db.session.commit()
 
@@ -95,6 +108,19 @@ class GroupIdAPI(Resource):
             message="Sorry, your role in this course does not allow you to save groups.")
 
         params = existing_group_parser.parse_args()
+
+        # check if group name is unique
+        group_name_exists = Group.query \
+            .filter(
+                Group.id != group.id,
+                Group.course_id == group.course_id,
+                Group.name == params.get("name", group.name)
+            ) \
+            .first()
+
+        if group_name_exists:
+            abort(400, title="Group Not Saved",
+                message="Sorry, the group name you have entered already exists. Please choose a different name.")
 
         group.name = params.get("name", group.name)
 

--- a/compair/models/group.py
+++ b/compair/models/group.py
@@ -56,3 +56,8 @@ class Group(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
     @classmethod
     def __declare_last__(cls):
         super(cls, cls).__declare_last__()
+
+    __table_args__ = (
+        db.UniqueConstraint('course_id', 'name', name='uq_course_and_group_name'),
+        DefaultTableMixin.default_table_args
+    )

--- a/compair/static/modules/classlist/classlist-view-partial.html
+++ b/compair/static/modules/classlist/classlist-view-partial.html
@@ -118,7 +118,7 @@
                     <th>
                         <a href="" ng-click="updateTableOrderBy('course_role')">Course Role</a>
                     </th>
-                    <th ng-if="groups.length > 0">
+                    <th>
                         <a href="" ng-click="updateTableOrderBy('group_name')">Course Group</a>
                     </th>
                 </tr>
@@ -145,10 +145,10 @@
                                 ng-change="enrol(user)"></select>
                         <span ng-if="loggedInUserId == user.id && !canManageUsers">{{ user.course_role }}</span>
                     </td>
-                    <td ng-if="groups.length > 0">
-                        <select ng-model="user.group_id" ng-options="group.id as group.name for group in groups"
-                                ng-change="updateGroup(user)">
-                            <option value="">- None -</option>
+                    <td>
+                        <select ng-model="user.group_id" ng-options="group.id as group.name disable when group.disabled for group in groups.concat(groupAddOptions)"
+                                ng-change="updateGroup(user, false, '{{user.group_id}}')">
+                            <option value="">( none )</option>
                         </select>
                     </td>
                 </tr>

--- a/compair/static/modules/group/group-form-partial.html
+++ b/compair/static/modules/group/group-form-partial.html
@@ -1,5 +1,5 @@
 <h1>Add Group</h1>
-<p class="intro-text">Add a group and then add any users from your course to it. Groups can be used to <strong>filter completed student answers and comparisons into smaller subsets</strong> to help with grading.</p>
+<p class="intro-text">Add a group and then add any users from your course to it. Groups can be used to <strong>give group-based assignments</strong> (where students submit one answer per group but complete comparisons and self-evaluations individually) and <strong>filter completed student answers and comparisons into smaller subsets</strong> to help with grading.</p>
 <ng-form name="groupForm" class="form">
     <fieldset>
         <legend>Group Details</legend>

--- a/compair/static/modules/group/group-module.js
+++ b/compair/static/modules/group/group-module.js
@@ -61,8 +61,8 @@ module.factory(
 /***** Controllers *****/
 module.controller(
     'AddGroupModalController',
-    ["$rootScope", "$scope", "$uibModalInstance", "GroupResource",
-    function ($rootScope, $scope, $uibModalInstance, GroupResource) {
+    ["$rootScope", "$scope", "$uibModalInstance", "$filter", "Toaster", "GroupResource",
+    function ($rootScope, $scope, $uibModalInstance, $filter, Toaster, GroupResource) {
         $scope.group = {};
         $scope.modalInstance = $uibModalInstance;
         $scope.submitted = false;
@@ -70,14 +70,22 @@ module.controller(
         $scope.groupSubmit = function () {
             $scope.submitted = true;
 
-            GroupResource.save({'courseId': $scope.courseId}, $scope.group).$promise.then(
-                function (ret) {
-                    $scope.group = ret;
-                    $uibModalInstance.close($scope.group.id);
-                }
-            ).finally(function() {
+            var groupNameExists = $filter('filter')($scope.groups, {'name':$scope.group.name}, true).length > 0;
+
+            if (groupNameExists) {
+                Toaster.warning("Group Not Added", "The group name you have entered already exists. Please enter another group name and press Save.");
                 $scope.submitted = false;
-            });
+            }
+            else {
+                GroupResource.save({'courseId': $scope.courseId}, $scope.group).$promise.then(
+                    function (ret) {
+                        $scope.group = ret;
+                        $uibModalInstance.close($scope.group.id);
+                    }
+                ).finally(function() {
+                    $scope.submitted = false;
+                });
+            }
         }
     }
 ]);

--- a/compair/tests/api/test_groups.py
+++ b/compair/tests/api/test_groups.py
@@ -64,6 +64,10 @@ class GroupsAPITests(ComPAIRAPITestCase):
             'name': 'Group 101',
         }
 
+        invalid_expected = {
+            'name': self.fixtures.groups[1].name,
+        }
+
         # test login required
         rv = self.client.post(url, data=json.dumps(group_expected), content_type='application/json')
         self.assert401(rv)
@@ -91,6 +95,12 @@ class GroupsAPITests(ComPAIRAPITestCase):
             rv = self.client.post(invalid_url, data=json.dumps(group_expected), content_type='application/json')
             self.assert404(rv)
 
+            # test non-unique name
+            rv = self.client.post(url, data=json.dumps(invalid_expected), content_type='application/json')
+            self.assert400(rv)
+            self.assertEqual(rv.json['title'], "Group Not Added")
+            self.assertEqual(rv.json['message'], "Sorry, the group name you have entered already exists. Please choose a different name.")
+
             # test successful query
             rv = self.client.post(url, data=json.dumps(group_expected), content_type='application/json')
             self.assert200(rv)
@@ -105,6 +115,11 @@ class GroupsAPITests(ComPAIRAPITestCase):
         group_expected = {
             'id': group.uuid,
             'name': 'New Group Name',
+        }
+
+        invalid_expected = {
+            'id': group.uuid,
+            'name': self.fixtures.groups[1].name,
         }
 
         # test login required
@@ -138,6 +153,12 @@ class GroupsAPITests(ComPAIRAPITestCase):
             invalid_url = '/api/courses/'+self.fixtures.course.uuid+'/groups/999'
             rv = self.client.post(invalid_url, data=json.dumps(group_expected), content_type='application/json')
             self.assert404(rv)
+
+            # test non-unique name
+            rv = self.client.post(url, data=json.dumps(invalid_expected), content_type='application/json')
+            self.assert400(rv)
+            self.assertEqual(rv.json['title'], "Group Not Saved")
+            self.assertEqual(rv.json['message'], "Sorry, the group name you have entered already exists. Please choose a different name.")
 
             # test successful query
             rv = self.client.post(url, data=json.dumps(group_expected), content_type='application/json')


### PR DESCRIPTION
- Always show the Course Groups column in the class list
- Always have an option 'Add New Group' as the last option
- Selecting 'Add New Group' would allow the user to add a new group to which the user would then be automatically added

Fixes #792