### PR TITLE
Fix cross origin issue for rich content

### DIFF
--- a/compair/static/modules/rich-content/rich-content-directive.js
+++ b/compair/static/modules/rich-content/rich-content-directive.js
@@ -287,7 +287,7 @@ module.directive('richContent',
                     var content = $sanitize($scope.content);
 
                     $scope.embeddableLinks = [];
-                    var matches = [];
+                    var linkMatches = [];
                     var linkRegex = /<a[^>]*>[^<]+<\/a>/ig;
                     var linkMatch = null;
                     while ( (linkMatch = linkRegex.exec(content)) !== null ) {
@@ -298,7 +298,7 @@ module.directive('richContent',
                             var embeddableContent = embeddableRichContent.generateEmbeddableContent(href, $scope.downloadName);
                             if (embeddableContent) {
                                 $scope.embeddableLinks.push(embeddableContent);
-                                matches.push({
+                                linkMatches.push({
                                     contentIndex: linkRegex.lastIndex,
                                     embeddableLinkIndex: $scope.embeddableLinks.length-1
                                 })
@@ -306,15 +306,30 @@ module.directive('richContent',
                         }
                     }
 
-                    for (var count = matches.length-1; count >= 0; --count) {
-                        var contentIndex = matches[count].contentIndex;
-                        var embeddableLinkIndex = matches[count].embeddableLinkIndex;
+                    for (var count = linkMatches.length-1; count >= 0; --count) {
+                        var contentIndex = linkMatches[count].contentIndex;
+                        var embeddableLinkIndex = linkMatches[count].embeddableLinkIndex;
                         var template =
                             '&mdash;<a href="" ng-click="showEmbeddableLinkModal(embeddableLinks['+embeddableLinkIndex+'])" '+
                                 'class="btn btn-info btn-xs">'+
                                 'Open in Pop-up'+
                             '</a>';
                         content = content.substr(0, contentIndex) + template + content.substr(contentIndex);
+                    }
+
+                    var mediaMatches = [];
+                    // image, audio, or video tags
+                    var mediaRegex = /<img[^>]*>|<video[^>]*>|<audio[^>]*>/ig;
+                    var mediaMatch = null;
+                    while ( (mediaMatch = mediaRegex.exec(content)) !== null ) {
+                        mediaMatches.push(mediaRegex.lastIndex);
+                    }
+
+                    // add crossorigin="anonymous" to image, video, and audio tags
+                    for (var count = mediaMatches.length-1; count >= 0; --count) {
+                        var contentIndex = mediaMatches[count];
+                        var template = ' crossorigin="anonymous" ';
+                        content = content.substr(0, contentIndex-1) + template + content.substr(contentIndex-1);
                     }
 
                     // needs to be compiled by dynamic

--- a/compair/static/modules/rich-content/rich-content-embeddable-template.html
+++ b/compair/static/modules/rich-content/rich-content-embeddable-template.html
@@ -2,13 +2,13 @@
     <div ng-bind-html="content.embed"></div>
 </div>
 <div ng-if="content.type == 'image'">
-    <img ng-src="{{content.url}}" ng-alt="{{content.title}}" class="content-item" />
+    <img crossorigin="anonymous" ng-src="{{content.url}}" ng-alt="{{content.title}}" class="content-item" />
 </div>
 <div ng-if="content.type == 'video'" class="embed-responsive embed-responsive-16by9">
-    <video ng-src="{{content.url}}" controls class="content-item embed-responsive-item"></video>
+    <video crossorigin="anonymous" ng-src="{{content.url}}" controls class="content-item embed-responsive-item"></video>
 </div>
 <div ng-if="content.type == 'audio'">
-    <audio ng-src="{{content.url}}" controls class="content-item"></audio>
+    <audio crossorigin="anonymous" ng-src="{{content.url}}" controls class="content-item"></audio>
 </div>
 <div ng-if="content.type == 'youtube'" class="embed-responsive embed-responsive-16by9">
     <div ng-bind-html="content.embed"></div>


### PR DESCRIPTION
Images, videos, and audio will have `crossorigin="anonymous"` added to them to prevent HTTP Basic Authentication from display a prompt for media that requires login to access