### PR TITLE
Fix issues with cached user info

### DIFF
--- a/compair/static/modules/navbar/navbar-module.js
+++ b/compair/static/modules/navbar/navbar-module.js
@@ -94,15 +94,15 @@ module.controller(
         $scope.impersonationEnabled = ImpersonationSettings.enabled;
         $scope.getImpersonation = function() {
             Session.getImpersonation().then(function (impersonate_details) {
-                $scope.impersonating = impersonate_details.impersonating;
-                if (impersonate_details.impersonating &&
+                $scope.impersonating = impersonate_details && impersonate_details.impersonating;
+                if ($scope.impersonating &&
                     impersonate_details.original_user && impersonate_details.original_user.displayname) {
                     $scope.impersonate_original_user_name = impersonate_details.original_user.displayname;
                 } else {
                     $scope.impersonate_original_user_name = '';
                 }
 
-                if (impersonate_details.impersonating) {
+                if ($scope.impersonating) {
                     $scope.impersonate_as_user_name = '';
                     Session.getUser().then(function (user) {
                         $scope.impersonate_as_user_name = ((user.firstname || '') + ' ' + (user.lastname || '')).trim();

--- a/compair/static/modules/session/session-service.js
+++ b/compair/static/modules/session/session-service.js
@@ -173,10 +173,13 @@
                 if (this._impersonation) {
                     return $q.when(this._impersonation);
                 } else {
-                    var stored_impersonation = localStorageService.get('impersonation');
-                    if (stored_impersonation) {
-                        return $q.when(stored_impersonation);
-                    }
+                    // impersonation state is based on user info. make sure it is valid first
+                    return session_exports.getUser().then(function(user) {
+                        var stored_impersonation = localStorageService.get('impersonation');
+                        if (stored_impersonation) {
+                            return $q.when(stored_impersonation);
+                        }
+                    });
                 }
                 return $q.when({});
             },
@@ -228,6 +231,12 @@
                         $rootScope.$broadcast(IMPERSONATE_END_EVENT);
                     });
                 });
+            },
+            detect_page_reload_and_flush: function() {
+                if (performance && performance.navigation && performance.navigation.type == 1) {
+                    localStorageService.clearAll();
+                    session_exports.destroy();
+                }
             },
         };
 

--- a/compair/templates/index-dev.html
+++ b/compair/templates/index-dev.html
@@ -181,7 +181,8 @@
                     UserSettings.allow_student_change_email = {{ 'true' if allow_student_change_email else 'false' }};
                 }]);
                 angular.module('ubc.ctlt.compair.session')
-                .run(['ImpersonationSettings', function(ImpersonationSettings) {
+                .run(['ImpersonationSettings', 'Session', function(ImpersonationSettings, Session) {
+                    Session.detect_page_reload_and_flush();
                     ImpersonationSettings.enabled = {{ 'true' if impersonation_enabled else 'false' }};
                 }]);
             })();

--- a/compair/templates/index.html
+++ b/compair/templates/index.html
@@ -96,7 +96,8 @@
                     UserSettings.allow_student_change_email = {{ 'true' if allow_student_change_email else 'false' }};
                 }]);
                 angular.module('ubc.ctlt.compair.session')
-                .run(['ImpersonationSettings', function(ImpersonationSettings) {
+                .run(['ImpersonationSettings', 'Session', function(ImpersonationSettings, Session) {
+                    Session.detect_page_reload_and_flush();
                     ImpersonationSettings.enabled = {{ 'true' if impersonation_enabled else 'false' }};
                 }]);
                 angular.module('ubc.ctlt.compair.common')


### PR DESCRIPTION
When opening multiple tabs and performing tasks with different logins
(e.g. using impersonation), the cached data could be out of sync. That
is because while the session key is shared between tabs, the user info
cached in local storage is not.

- detect if the page is being reloaded. If so, flush the session-service
in memory and clear local storage
- this should force user info to be retrieved from backend again

Closes #846 