### PR TITLE
Fix utc timestamp used in class property

### DIFF
--- a/compair/models/course.py
+++ b/compair/models/course.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from . import *
 
 from compair.core import db
+from compair.util import sql_utcnow
 
 class Course(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
     __tablename__ = 'course'
@@ -114,8 +115,8 @@ class Course(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
                 Assignment.active == True,
                 Assignment.enable_group_answers == True,
                 or_(
-                    and_(Assignment.compare_start == None, Assignment.answer_end <= datetime.datetime.utcnow()),
-                    and_(Assignment.compare_start != None, Assignment.compare_start <= datetime.datetime.utcnow())
+                    and_(Assignment.compare_start == None, Assignment.answer_end <= sql_utcnow()),
+                    and_(Assignment.compare_start != None, Assignment.compare_start <= sql_utcnow())
                 )
             )),
             deferred=True,
@@ -154,7 +155,7 @@ class Course(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin):
             where(and_(
                 Assignment.course_id == cls.id,
                 Assignment.active == True,
-                Assignment.answer_start <= datetime.datetime.utcnow()
+                Assignment.answer_start <= sql_utcnow()
             )),
             deferred=True,
             group="counts"

--- a/compair/static/modules/classlist/classlist-view-partial.html
+++ b/compair/static/modules/classlist/classlist-view-partial.html
@@ -45,7 +45,7 @@
     </p>
 
     <p class="alert alert-info" ng-show="course.groups_locked">
-        <i class="glyphicon glyphicon-info-sign"></i> One or more group assignments have started or completed their comparison period. You may <strong>no longer remove users from the group they are assigned to</strong>.
+        <i class="glyphicon glyphicon-info-sign"></i> One or more group assignments have started their comparison period. You may <strong>no longer remove users from the group they are assigned to</strong>.
     </p>
 
     <hr />

--- a/compair/util/__init__.py
+++ b/compair/util/__init__.py
@@ -1,0 +1,1 @@
+from .sql_utcnow import sql_utcnow

--- a/compair/util/sql_utcnow.py
+++ b/compair/util/sql_utcnow.py
@@ -1,0 +1,25 @@
+from sqlalchemy.sql import expression
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.types import DateTime
+
+class sql_utcnow(expression.FunctionElement):
+    """ Custom sqlalchemy function to get UTC timestamp.
+    reference: https://docs.sqlalchemy.org/en/latest/core/compiler.html#utc-timestamp-function
+    """
+    type = DateTime()
+
+@compiles(sql_utcnow, 'postgresql')
+def postgresql_utcnow(element, compiler, **kw):
+    return "TIMEZONE('utc', CURRENT_TIMESTAMP)"
+
+@compiles(sql_utcnow, 'mssql')
+def mssql_utcnow(element, compiler, **kw):
+    return "GETUTCDATE()"
+
+@compiles(sql_utcnow, 'sqlite')
+def sqlite_utcnow(element, compiler, **kw):
+    return "DATETIME('NOW')"
+
+@compiles(sql_utcnow, 'mysql')
+def msql_utcnow(element, compiler, **kw):
+    return "UTC_TIMESTAMP()"


### PR DESCRIPTION
Using Python datetime.datetime.utcnow to construct SQL where-clauses for
class property will lead to incorrect result as the statement is
evaluated once when class first loaded.  Instead, use SQL function to
get the UTC timestamp on the fly when the SQL is executed.

Properties affected:
- Course group_locked property
- Course student_assignment_count property

Revised the group locked message.

Closes #854 
Also, the new `compair.util.sql_utcnow` function could potentially be used for #856 