### PR TITLE
Avoid LTI grade sync before answer start date

### DIFF
--- a/compair/models/lti_models/lti_outcome.py
+++ b/compair/models/lti_models/lti_outcome.py
@@ -15,6 +15,10 @@ class LTIOutcome(object):
         from compair.models import CourseRole, AssignmentGrade
         from compair.tasks import update_lti_assignment_grades
 
+        # don't update until passed the answer start date
+        if not compair_assignment.available:
+            return
+
         lti_resource_links = compair_assignment.lti_resource_links.all()
 
         # nothing to update if assignment not linked to any lti resources


### PR DESCRIPTION
Modifying these assignment attributes will trigger re-calculation of grades:
- answer grade weight
- comparison grade weight
- enable/disable self eval
- enable/disable group answer

which in-turn will trigger assignment grade sync of all students to LTI consumers.

To avoid zero assignment grades being sent to consumers (which in turn may notify the
students), only push LTI assignment grades when we passed the assignment answer start date.

Assignment grade sync of specific student won't be affected. This kind of sync is usually
triggered by action of answering / comparison / self-eval.

Closes #843 