### PR TITLE
Add group management functions

### DIFF
--- a/alembic/versions/1e4cb64dd9b5_remove_group_name_unique_constraint.py
+++ b/alembic/versions/1e4cb64dd9b5_remove_group_name_unique_constraint.py
@@ -1,0 +1,69 @@
+"""remove group name unique constraint
+
+Remove the db unique constraint added by b492a8f2132c.
+Group name can repeat if only one of the records is active.
+Will use program logic to check uniqueness of active group name.
+There maybe a race condition causing duplicate group name in case of concurrent group creation.
+But the chance is small and impact is minimal.
+
+Revision ID: 1e4cb64dd9b5
+Revises: b492a8f2132c
+Create Date: 2019-01-24 20:26:56.722350
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1e4cb64dd9b5'
+down_revision = 'b492a8f2132c'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import func
+
+from compair.models import convention
+
+group_table = sa.table('group',
+    sa.Column('id', sa.Integer), sa.Column('course_id', sa.Integer),
+    sa.Column('name', sa.String), sa.Column('active', sa.Boolean),
+    sa.Column('modified', sa.DateTime), sa.Column('created', sa.DateTime),
+    sa.Column('uuid', sa.CHAR(22))
+)
+
+def upgrade():
+    with op.batch_alter_table('group', naming_convention=convention) as batch_op:
+        batch_op.drop_constraint('uq_course_and_group_name', type_='unique')
+
+def downgrade():
+    connection = op.get_bind()
+
+    groups = connection.execute(group_table.select())
+
+    # {course_id}{group_name} - counts how many have been updated so far
+    counter = {}
+
+    for group in groups:
+        counter.setdefault(group.course_id, {})
+        counter[group.course_id].setdefault(group.name, 0)
+
+        counter[group.course_id][group.name] += 1
+
+        if counter[group.course_id][group.name] > 1:
+            count = counter[group.course_id][group.name]
+            new_group_name = "{} [{}]".format(group.name, count)
+            # while loop is necessary in case there is an existing group with the same name and number e.g. Example Group [2]
+            while connection.execute(group_table.count().where(sa.and_(
+                    group_table.c.name == new_group_name,
+                    group_table.c.course_id == group.course_id
+                ))).scalar() > 0:
+                    count += 1
+                    new_group_name = "{} [{}]".format(group.name, count)
+            connection.execute(
+                group_table \
+                .update() \
+                .where(group_table.c.id == group.id) \
+                .values(name=new_group_name)
+            )
+            counter[group.course_id][group.name] = count
+
+    with op.batch_alter_table('group', naming_convention=convention) as batch_op:
+        batch_op.create_unique_constraint('uq_course_and_group_name', ['course_id', 'name'])

--- a/compair/api/dataformat/__init__.py
+++ b/compair/api/dataformat/__init__.py
@@ -133,6 +133,7 @@ def get_group():
         'course_id': fields.String(attribute="course_uuid"),
         'name': fields.String,
         'avatar': fields.String,
+        'group_answer_exists': fields.Boolean,
         'modified': fields.DateTime(dt_format='iso8601', attribute=lambda x: replace_tzinfo(x.modified)),
         'created': fields.DateTime(dt_format='iso8601', attribute=lambda x: replace_tzinfo(x.created))
     }

--- a/compair/static/modules/classlist/classlist-module.js
+++ b/compair/static/modules/classlist/classlist-module.js
@@ -86,7 +86,8 @@ module.controller(
         $scope.course_roles = [CourseRole.student, CourseRole.teaching_assistant, CourseRole.instructor];
 
         $scope.groupAddOptions = Array( {'id':'-1',  'name':'--------------------', 'disabled':true},
-                                        {'id':'add', 'name':'Add new group'});
+                                        {'id':'add', 'name':'Add new group'},
+                                        {'id':'manage', 'name':'Manage group names'});
 
         if ($scope.course.lti_linked) {
             LTIResource.getMembershipStatus({id: $scope.courseId},
@@ -136,6 +137,20 @@ module.controller(
             }, function () {
                 xAPIStatementHelper.closed_modal("Edit Group");
             });
+        };
+        
+         $scope.manageGroups = function() {
+            var modalScope = $scope.$new();
+            modalScope.courseId = $scope.courseId;
+            
+            var modalInstance = $uibModal.open({
+                animation: true,
+                backdrop: 'static',
+                controller: "ManageGroupsModalController",
+                templateUrl: 'modules/group/groups-manage-modal-partial.html',
+                scope: modalScope
+            });
+        
         };
 
         $scope.addUsersToGroup = function(group_id) {
@@ -218,6 +233,9 @@ module.controller(
         $scope.updateGroup = function(user, reload, original_group_id) {
             if (user.group_id == 'add') {
                 $scope.addUserToNewGroup(user);
+                user.group_id = original_group_id;
+            } else if (user.group_id == 'manage') {
+                $scope.manageGroups();
                 user.group_id = original_group_id;
             } else if (user.group_id) {
                 GroupUserResource.add({'courseId': $scope.courseId, 'userId': user.id, 'groupId': user.group_id}, {},

--- a/compair/static/modules/classlist/classlist-view-partial.html
+++ b/compair/static/modules/classlist/classlist-view-partial.html
@@ -68,13 +68,14 @@
             </div>
             <div class="form-group col-sm-4">
                 <select id="select-group" class="form-control" ng-model="selectedGroup"
-                    ng-options="group.id as group.name for group in groups" ng-disabled="!groups.length">
+                    ng-options="group.id as group.name disable when group.disabled for group in groups.concat(bulkGroupAddOptions)"
+                    ng-disabled="!groups.length" ng-change="bulkGroupSelected(selectedGroup)">
                     <option value="">- Select existing group -</option>
                 </select>
             </div>
             <div class="col-sm-3">
                 <button id="add-select-group" class="btn btn-sm btn-success" ng-click="addUsersToGroup(selectedGroup)"
-                    ng-disabled="!selectedGroup">Apply</button>
+                    ng-disabled="!selectedGroup || selectedGroup=='manage'">Apply</button>
             </div>
         </div>
         <div class="col-sm-9" ng-show="bulkActions == 'drop'">

--- a/compair/static/modules/group/group-form-partial.html
+++ b/compair/static/modules/group/group-form-partial.html
@@ -1,5 +1,7 @@
-<h1>Add Group</h1>
-<p class="intro-text">Add a group and then add any users from your course to it. Groups can be used to <strong>give group-based assignments</strong> (where students submit one answer per group but complete comparisons and self-evaluations individually) and <strong>filter completed student answers and comparisons into smaller subsets</strong> to help with grading.</p>
+<h1 data-ng-if="createNewGroup">Add Group</h1>
+<h1 data-ng-if="!createNewGroup">Edit Group</h1>
+<p class="intro-text" data-ng-if="createNewGroup">Add a group and then add any users from your course to it. Groups can be used to <strong>give group-based assignments</strong> (where students submit one answer per group but complete comparisons and self-evaluations individually) and <strong>filter completed student answers and comparisons into smaller subsets</strong> to help with grading.</p>
+<p class="intro-text" data-ng-if="!createNewGroup">Edit the group name below and it will be updated for all users assigned to it. Groups can be used to <strong>give group-based assignments</strong> (where students submit one answer per group but complete comparisons and self-evaluations individually) and <strong>filter completed student answers and comparisons into smaller subsets</strong> to help with grading.</p>
 <ng-form name="groupForm" class="form">
     <fieldset>
         <legend>Group Details</legend>
@@ -10,6 +12,9 @@
     </fieldset>
     <p class="text-center text-muted"><span class="required-star "></span> = required (please make sure these areas are filled in)</p>
     <div class="text-center">
+        <input data-ng-if="!createNewGroup" type="submit" ng-click="groupCancelEdit()" class="btn btn-default btn-lg"
+               value="&laquo; Back" ng-disabled="groupForm.$invalid || submitted" />
+        &nbsp;&nbsp;
         <input type="submit" ng-click="groupSubmit()" class="btn btn-success btn-lg"
                value="Save" ng-disabled="groupForm.$invalid || submitted" />
     </div>

--- a/compair/static/modules/group/group-module.js
+++ b/compair/static/modules/group/group-module.js
@@ -90,4 +90,16 @@ module.controller(
     }
 ]);
 
+module.controller(
+    'ManageGroupsModalController',
+    ["$rootScope", "$scope", "$uibModalInstance", "Toaster", "GroupResource",
+    function ($rootScope, $scope, $uibModalInstance, Toaster, GroupResource) {
+        $scope.group = {};
+        $scope.modalInstance = $uibModalInstance;
+        $scope.modalDone = function() {
+            $scope.modalInstance.dismiss();
+        };
+    }
+]);
+
 })();

--- a/compair/static/modules/group/groups-manage-modal-partial.html
+++ b/compair/static/modules/group/groups-manage-modal-partial.html
@@ -1,34 +1,32 @@
-<modal-cancel-button modal-instance="modalInstance" ng-show="modalInstance !== undefined"></modal-cancel-button>
+<modal-cancel-button modal-instance="modalInstance" ng-show="modalInstance !== undefined">
+</modal-cancel-button>
 <h1>Manage Group Names</h1>
 <p class="intro-text">Edit or delete existing group names, provided they have not already been used in a group-based assignment. Deleting a group will not delete any students assigned to the group. These students will simply be assigned to no group.</p>
 
 <div class="table-responsive">
-	<table class="table table-striped">
-		<thead>
-			<tr>
-				<th>Actions</th>
-				<th>
-					Group Name
-				</th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr ng-repeat="group in groups">
-				<td class="nowrap">
-					<!-- TO DO: create functionality and link to edit page (see screenshot); saving on edit page should return to this display -->
-					<a href="" target="_blank">Edit</a>
-					<span>&nbsp;|&nbsp;</span>
-					<!-- TO DO: identify group names already used for submitting in any group assignment and gray out the delete option for those -->
-					<!-- TO DO: add actual function to delete group names (and assign those students to no group) and then call it here -->
-					<a href="" confirmation-needed="" keyword="group name and assign the students in it to no group">Delete</a>
-				</td>
-				<td>{{group.name}}</td>
-			</tr>
-		</tbody>
-	</table>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Actions</th>
+                <th>
+                    Group Name
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr ng-repeat="group in groups">
+                <td class="nowrap">
+                    <a href="" data-ng-click="groupEdit(group.id)" target="_blank">Edit</a>
+                    <span>&nbsp;|&nbsp;</span>
+                    <a href="" ng-if="!group.group_answer_exists" confirmation-needed="groupDelete(group.id)" keyword="group name and assign the students in it to no group">Delete</a>
+                    <span ng-if="group.group_answer_exists" uib-tooltip="You cannot remove groups that have submitted answers.">&nbsp;&nbsp;—&nbsp;&nbsp;</span>
+                </td>
+                <td>{{group.name}}</td>
+            </tr>
+        </tbody>
+    </table>
 </div>
 <br />
 <div class="text-center">
-	<input type="submit" ng-click="modalDone()" class="btn btn-success btn-lg" value="Done" />
+    <input type="submit" ng-click="modalDone()" class="btn btn-success btn-lg" value="Done" />
 </div>
-

--- a/compair/static/modules/group/groups-manage-modal-partial.html
+++ b/compair/static/modules/group/groups-manage-modal-partial.html
@@ -1,0 +1,34 @@
+<modal-cancel-button modal-instance="modalInstance" ng-show="modalInstance !== undefined"></modal-cancel-button>
+<h1>Manage Group Names</h1>
+<p class="intro-text">Edit or delete existing group names, provided they have not already been used in a group-based assignment. Deleting a group will not delete any students assigned to the group. These students will simply be assigned to no group.</p>
+
+<div class="table-responsive">
+	<table class="table table-striped">
+		<thead>
+			<tr>
+				<th>Actions</th>
+				<th>
+					Group Name
+				</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr ng-repeat="group in groups">
+				<td class="nowrap">
+					<!-- TO DO: create functionality and link to edit page (see screenshot); saving on edit page should return to this display -->
+					<a href="" target="_blank">Edit</a>
+					<span>&nbsp;|&nbsp;</span>
+					<!-- TO DO: identify group names already used for submitting in any group assignment and gray out the delete option for those -->
+					<!-- TO DO: add actual function to delete group names (and assign those students to no group) and then call it here -->
+					<a href="" confirmation-needed="" keyword="group name and assign the students in it to no group">Delete</a>
+				</td>
+				<td>{{group.name}}</td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+<br />
+<div class="text-center">
+	<input type="submit" ng-click="modalDone()" class="btn btn-success btn-lg" value="Done" />
+</div>
+


### PR DESCRIPTION
Backend:
- Remove db unique constraint on (course id, group name). Group name can be
repeated as long as there is only one active record with that name. Use
program logic to check instead of db constraint. This may introduce a
race condition, but the chance is small and impact is minimal
- Add group_answer_exists attribute to group model and return it in API
- Change logic of group creation API to check duplication for active
records only

Frontend:
- Add UI to edit group name
- Add UI to delete group name if no answer submitted for the group

Closes #806