### PR TITLE
Change default Celery eagerness and update background tasks section in README

### DIFF
--- a/compair/core.py
+++ b/compair/core.py
@@ -33,8 +33,8 @@ impersonation = Impersonation()
 
 # initialize celery
 celery = Celery(
-    broker=config.get("CELERY_RESULT_BACKEND"),
-    backend=config.get("CELERY_BROKER_URL")
+    backend=config.get("CELERY_RESULT_BACKEND"),
+    broker=config.get("CELERY_BROKER_URL")
 )
 
 # initialize Flask-Mail

--- a/compair/settings.py
+++ b/compair/settings.py
@@ -48,6 +48,7 @@ CELERY_BROKER_URL = None
 CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
 CELERY_IMPORTS = ['compair.tasks']
 CELERY_TIMEZONE = 'America/Vancouver'
+CELERY_ALWAYS_EAGER = True # By default, execute tasks locally
 BROKER_TRANSPORT_OPTIONS = {
     'fanout_prefix': True,
     'fanout_patterns': True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - DB_NAME=compair
       - DEV=1
       - CELERY_BROKER_URL=redis://redis:6379
+      - CELERY_ALWAYS_EAGER=0
       #- GA_TRACKING_ID=12345
       - ENFORCE_SSL=0
       - MAIL_NOTIFICATION_ENABLED=1
@@ -46,7 +47,7 @@ services:
       - SAML_ATTRIBUTE_EMAIL=urn:oid:1.3.6.1.4.1.5923.1.1.1.6
       - SAML_ATTRIBUTE_STUDENT_NUMBER=
       - SAML_SETTINGS_FILE=/code/deploy/development/dev_saml_settings.json
-      - SAML_METADATA_URL=https://www.testshib.org/metadata/testshib-providers.xml
+      - SAML_METADATA_URL=https://idp.testshib.org/metadata/testshib-providers.xml
       - SAML_METADATA_ENTITY_ID=https://idp.testshib.org/idp/shibboleth
       - SAML_EXPOSE_METADATA_ENDPOINT=true
     volumes:
@@ -69,6 +70,7 @@ services:
       - DB_NAME=compair
       - DEV=1
       - CELERY_BROKER_URL=redis://redis:6379
+      - CELERY_ALWAYS_EAGER=0
       - ENFORCE_SSL=0
       - MAIL_NOTIFICATION_ENABLED=1
       - MAIL_SERVER=mail


### PR DESCRIPTION
- set `CELERY_ALWAYS_EAGER` to `1` by default to make tasks run
locally
- update README.md to give a summary on the tasks defined. Also added
instructions on how to setup tasks to run asychronously in background
- update docker-compose.yml to enable background tasks
- update the SAML metadata url in docker-compose.yml. `www.testshib.org`
is not reachable.  Changed to `idp.testshib.org`

Closes #864 