### PR TITLE
Fix display names on view assignment page

### DIFF
--- a/compair/static/modules/assignment/assignment-view-partial.html
+++ b/compair/static/modules/assignment/assignment-view-partial.html
@@ -213,10 +213,10 @@
                 <div class="each-answer clearfix" ng-repeat="answer in answers.objects | notScoredEnd | excludeInstr:allInstructors as results" ng-if="(see_answers || canManageAssignment)">
                     <!-- Student Answer Metadata Header -->
                     <div class="each-header clearfix">
-                        <compair-answer-avatar answer="answer"
+                        <compair-answer-avatar answer="answer" skip-name="answerFilters.anonymous"
                             me="!canManageAssignment && (answer.user_id == loggedInUserId || (currentUserGroup && answer.group_id == currentUserGroup.id))"
                             ></compair-answer-avatar>
-                        <span ng-show="answerFilters.anonymous">Student</span>
+                        <span ng-show="answerFilters.anonymous && !isInstructor(answer.user_id)">Student</span>
                         <span class="label label-default" ng-if="isInstructor(answer.user_id)">{{instructorLabel(answer.user_id)}}</span>
                         <strong>answered</strong> on {{answer.submission_date | amDateFormat: 'MMM D @ h:mm a'}}:
                         <div class="manager-actions pull-right">

--- a/compair/static/modules/session/session-service.js
+++ b/compair/static/modules/session/session-service.js
@@ -30,9 +30,9 @@
      */
     module.factory('Session',
             ["$rootScope",  "$http", "$q", "localStorageService", "$log", "UserResource",
-            "$route", "$window", "$location", "ImpersonateResource",
+            "$route", "$window", "$location", "$cacheFactory", "ImpersonateResource",
             function ($rootScope, $http, $q, localStorageService, $log, UserResource,
-                $route, $window, $location, ImpersonateResource) {
+                $route, $window, $location, $cacheFactory, ImpersonateResource) {
         var PERMISSION_REFRESHED_EVENT = "event:Session-refreshPermissions";
         var IMPERSONATE_START_EVENT = "event:Session-startImpersonation";
         var IMPERSONATE_END_EVENT = "event:Session-endImpersonation";
@@ -199,6 +199,13 @@
                     // Destroy the session first. In case the refresh failed (e.g. network issue), 
                     // a success reload of the page will show the correct student view.
                     session_exports.destroy();
+                    // clear angularjs cache
+                    _.each(['$http', 'classlist'], function(id) {
+                        var cache = $cacheFactory.get(id);
+                        if (cache) {
+                            cache.removeAll();
+                        }
+                    });
                     return session_exports.refresh(false).then(function () {
                         if (courseId) {
                             var newPath = '/course/' + courseId;
@@ -217,6 +224,13 @@
             stop_impersonate: function(courseId) {
                 return ImpersonateResource.stop_impersonate({}).$promise.then(function(ret) {
                     session_exports.destroy();
+                    // clear angularjs cache
+                    _.each(['$http', 'classlist'], function(id) {
+                        var cache = $cacheFactory.get(id);
+                        if (cache) {
+                            cache.removeAll();
+                        }
+                    });
                     session_exports.refresh(false).then(function () {
                         if (courseId) {
                             var newPath = '/course/' + courseId;


### PR DESCRIPTION
On "All Answers" tab:
- hide student name in anonymized mode
- dont show the "Student" label for comparable answers submitted by instructors
- clear AngularJS cache when starting / ending impersonation. This is to
prevent answers and user names being cached

Closes #870 