### PR TITLE
Upgrade flask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-dist: trusty
+dist: xenial
 
 sudo: required
 
@@ -9,7 +9,7 @@ services:
   - mysql
 
 addons:
-  mariadb: '5.5'
+  mariadb: '10.0'
 
 cache:
   apt: true
@@ -24,6 +24,8 @@ before_cache:
 python:
   - "2.7"
   - "3.6"
+  # there is no binary wheels for 3.7 and compiling it from source will fail
+  #- "3.7"
 
 stages:
   - test
@@ -54,7 +56,7 @@ jobs:
       - docker-compose -f deploy/docker/docker-compose.yml up -d; sleep 10;
       - curl -sSL http://localhost > /dev/null && curl -sS http://localhost/api/healthz > /dev/null
       # copy assets from docker image for s3 deployment
-      - docker cp docker_app_1:/code/compair/static/dist compair/static/dist
+      - docker cp $(docker ps -q --filter "label=com.docker.compose.project=docker" --filter "label=com.docker.compose.service=app"):/code/compair/static/dist compair/static/dist
       after_success:
       - ./scripts/deploy_dockerhub.sh
       - ./scripts/deploy.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==0.12
+Flask==1.0.2
 Flask-Login==0.3.2
 Flask-Restful==0.3.5
 Flask-SQLAlchemy==2.3.2


### PR DESCRIPTION
Upgrade flask version to avoid problem with test cases on Travis since Werkzeug upgraded to 0.15.2. Also changed the Ubuntu dist on Travis to xenial as trusty is reaching EOL by Apr 2019.

- upgrade flask from 0.12 to 1.0.2
- change Travis dist from trusty to xenial
- change Travis maria db from 5.5 to 10.0

Added (but commented out for now) Python 3.7 testing on Travis.  `scipy` binary wheels are not available on Python 3.7 pip yet and trying to compile from source will cause error.

closes #874 