### PR TITLE
Fix ckeditor escaping symbols used in MathJAX

### DIFF
--- a/compair/static/lib_extension/ckeditor/plugins/combinedmath/iframe/mathjax.html
+++ b/compair/static/lib_extension/ckeditor/plugins/combinedmath/iframe/mathjax.html
@@ -18,7 +18,9 @@
     location.search.substr(1).split("&").forEach(function(item) {queryDict[item.split("=")[0]] = item.split("=")[1]})
     var mathDiv = document.getElementById('math');
     var mathexp = decodeURIComponent(queryDict['mathexp']);
-    mathDiv.textContent = mathexp;
+    // undo any escape done by ckeditor
+    var parser = new DOMParser;
+    mathDiv.textContent = parser.parseFromString(mathexp, 'text/html').body.textContent;
     MathJax.Hub.Configured();
     MathJax.Hub.Queue(["Typeset", MathJax.Hub, 'math']);
     var iframe = window.frameElement;

--- a/compair/static/lib_extension/ckeditor/plugins/combinedmath/plugin.js
+++ b/compair/static/lib_extension/ckeditor/plugins/combinedmath/plugin.js
@@ -30,7 +30,10 @@ CKEDITOR.plugins.add( 'combinedmath', {
                         math = math.replace(/\\\(/g, '');
                         math = math.replace(/\\\)/g, '');
                     }
-                    data.mathexp = math;
+                    // undo any escape done by ckeditor
+                    var parser = new DOMParser;
+                    var textContent = parser.parseFromString(math, 'text/html').body.textContent;
+                    data.mathexp = textContent;
                 }
                 return isValidCombinedMath;
             },


### PR DESCRIPTION
- unescape math expressions that have been encoded by ckeditor

ref: INC1511680
