### PR TITLE
Convert charset to utf8mb4 for mysql

### DIFF
--- a/alembic/versions/fd7aab93104b_migrate_from_utf8_to_utf8mb4.py
+++ b/alembic/versions/fd7aab93104b_migrate_from_utf8_to_utf8mb4.py
@@ -1,0 +1,389 @@
+"""migrate charset from utf8 to utf8mb4 for mysql
+
+Revision ID: fd7aab93104b
+Revises: 153384f69a82
+Create Date: 2020-06-08 17:50:54.948692
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'fd7aab93104b'
+down_revision = '153384f69a82'
+
+from alembic import op
+import sqlalchemy as sa
+
+from compair.models import convention
+
+"""
+This revision is targeted for MySQL/MariaDB only and hence with lots of SQLs that are MySQL-specific.
+"""
+
+def _check_data_legnth(conn, test_tuples):
+    # check data for field length
+    for (table, column, length) in test_tuples:
+        query = 'select count(1) from `{}` where char_length(`{}`) > {}'.format(table, column, length)
+        res = conn.execute(query)
+        results = res.fetchone()
+        res.close()
+        if results[0] > 0:
+            raise Exception('Data in column `{}` of table `{}` is longer than {}. Aborting migration'.format(column, table, length))
+
+def upgrade():
+    conn = op.get_bind()
+
+    # this change is for mysql only
+    if not conn.dialect.name == 'mysql':
+        return
+
+    # make sure we are not truncating any existing data.
+    # possible race-condition. better run during system is offline.
+    # TINYTEXT will be auto-promoted to TEXT.  TEXT will be auto-promoted to MEDIUMTEXT.
+    # So no checks needed for TEXT-based columns.
+    test_tuples = [
+        # tuples of (table, column name, max number of characters)
+        ('file', 'name', 191),
+        ('kaltura_media', 'upload_token_id', 191),
+        ('lti_consumer', 'oauth_consumer_key', 191),
+        ('lti_consumer', 'tool_consumer_instance_guid', 191),
+        ('lti_context', 'context_id', 191),
+        ('lti_nonce', 'oauth_nonce', 191),
+        ('lti_resource_link', 'resource_link_id', 191),
+        ('lti_user', 'user_id', 191),
+        ('third_party_user', 'unique_identifier', 191),
+        ('user', 'username', 191),
+        ('user', 'global_unique_identifier', 191),
+    ]
+    _check_data_legnth(conn, test_tuples)
+
+    # ref: https://mathiasbynens.be/notes/mysql-utf8mb4
+    """
+    We needed to resize some varchar/char columns to be less than or equal to 191 if they are used in indexes.
+    That is because MySQL has a limit of max bytes of indexed columns.
+    """
+
+    """
+    -- Generate code for tables
+    SELECT CONCAT('conn.execute(sa.sql.text("ALTER TABLE `',
+      T.table_name,
+      '` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))')
+    FROM information_schema.`TABLES` T,
+      information_schema.`COLLATION_CHARACTER_SET_APPLICABILITY` CCSA
+    WHERE CCSA.collation_name = T.table_collation
+      AND T.table_schema = "compair"
+      AND CCSA.character_set_name='utf8';
+    """
+    conn.execute(sa.sql.text("ALTER TABLE `activity_log` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer_comment` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer_criterion_score` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer_score` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `assignment` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `assignment_criterion` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `assignment_grade` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `caliper_log` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `comparison` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `comparison_criterion` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `comparison_example` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `course` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `course_grade` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `criterion` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    with op.batch_alter_table('file', naming_convention=convention) as batch_op:
+        batch_op.alter_column('name', type_=sa.String(length=191))
+    conn.execute(sa.sql.text("ALTER TABLE `file` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `group` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    with op.batch_alter_table('kaltura_media', naming_convention=convention) as batch_op:
+        batch_op.alter_column('upload_token_id', type_=sa.String(length=191))
+    conn.execute(sa.sql.text("ALTER TABLE `kaltura_media` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    with op.batch_alter_table('lti_consumer', naming_convention=convention) as batch_op:
+        batch_op.alter_column('oauth_consumer_key', type_=sa.String(length=191))
+        batch_op.alter_column('tool_consumer_instance_guid', type_=sa.String(length=191))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_consumer` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    with op.batch_alter_table('lti_context', naming_convention=convention) as batch_op:
+        batch_op.alter_column('context_id', type_=sa.String(length=191))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_context` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_membership` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    with op.batch_alter_table('lti_nonce', naming_convention=convention) as batch_op:
+        batch_op.alter_column('oauth_nonce', type_=sa.String(length=191))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_nonce` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    with op.batch_alter_table('lti_resource_link', naming_convention=convention) as batch_op:
+        batch_op.alter_column('resource_link_id', type_=sa.String(length=191))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_resource_link` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    with op.batch_alter_table('lti_user', naming_convention=convention) as batch_op:
+        batch_op.alter_column('user_id', type_=sa.String(length=191))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user_resource_link` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    with op.batch_alter_table('third_party_user', naming_convention=convention) as batch_op:
+        batch_op.alter_column('unique_identifier', type_=sa.String(length=191))
+    conn.execute(sa.sql.text("ALTER TABLE `third_party_user` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    with op.batch_alter_table('user', naming_convention=convention) as batch_op:
+        batch_op.alter_column('username', type_=sa.String(length=191))
+        batch_op.alter_column('global_unique_identifier', type_=sa.String(length=191))
+    conn.execute(sa.sql.text("ALTER TABLE `user` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `user_course` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `xapi_log` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"))
+
+    # repair and optimize tables
+    conn.execute(sa.sql.text("REPAIR TABLE `activity_log`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `activity_log`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `answer`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `answer`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `answer_comment`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `answer_comment`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `answer_criterion_score`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `answer_criterion_score`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `answer_score`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `answer_score`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `assignment`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `assignment`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `assignment_criterion`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `assignment_criterion`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `assignment_grade`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `assignment_grade`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `caliper_log`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `caliper_log`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `comparison`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `comparison`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `comparison_criterion`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `comparison_criterion`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `comparison_example`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `comparison_example`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `course`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `course`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `course_grade`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `course_grade`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `criterion`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `criterion`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `file`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `file`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `group`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `group`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `kaltura_media`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `kaltura_media`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `lti_consumer`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `lti_consumer`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `lti_context`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `lti_context`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `lti_membership`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `lti_membership`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `lti_nonce`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `lti_nonce`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `lti_resource_link`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `lti_resource_link`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `lti_user`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `lti_user`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `lti_user_resource_link`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `lti_user_resource_link`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `third_party_user`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `third_party_user`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `user`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `user`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `user_course`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `user_course`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `xapi_log`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `xapi_log`"))
+
+def downgrade():
+    conn = op.get_bind()
+
+    # this change is for mysql only
+    if not conn.dialect.name == 'mysql':
+        return
+
+    # revert changes to tables
+    conn.execute(sa.sql.text("ALTER TABLE `activity_log` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer_comment` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer_criterion_score` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer_score` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `assignment` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `assignment_criterion` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `assignment_grade` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `caliper_log` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `comparison` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `comparison_criterion` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `comparison_example` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `course` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `course_grade` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `criterion` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `file` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `group` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `kaltura_media` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_consumer` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_context` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_membership` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_nonce` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_resource_link` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user_resource_link` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `third_party_user` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `user` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `user_course` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `xapi_log` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+
+    # revert changes to columns
+    conn.execute(sa.sql.text("ALTER TABLE `activity_log` CHANGE `event` `event` varchar(50) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `activity_log` CHANGE `data` `data` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `activity_log` CHANGE `status` `status` varchar(20) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `activity_log` CHANGE `message` `message` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `activity_log` CHANGE `session_id` `session_id` varchar(100) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer` CHANGE `uuid` `uuid` char(22) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer` CHANGE `content` `content` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer` CHANGE `attempt_uuid` `attempt_uuid` char(36) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer_comment` CHANGE `uuid` `uuid` char(22) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer_comment` CHANGE `content` `content` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer_comment` CHANGE `comment_type` `comment_type` enum('Public','Private','Evaluation','Self Evaluation') CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer_comment` CHANGE `attempt_uuid` `attempt_uuid` char(36) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer_criterion_score` CHANGE `scoring_algorithm` `scoring_algorithm` enum('comparative_judgement','elo_rating','true_skill_rating') CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `answer_score` CHANGE `scoring_algorithm` `scoring_algorithm` enum('comparative_judgement','elo_rating','true_skill_rating') CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `assignment` CHANGE `uuid` `uuid` char(22) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `assignment` CHANGE `name` `name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `assignment` CHANGE `description` `description` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `assignment` CHANGE `self_eval_instructions` `self_eval_instructions` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `assignment` CHANGE `scoring_algorithm` `scoring_algorithm` enum('comparative_judgement','elo_rating','true_skill_rating') CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `assignment` CHANGE `pairing_algorithm` `pairing_algorithm` enum('adaptive','random','adaptive_min_delta') CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `assignment` CHANGE `peer_feedback_prompt` `peer_feedback_prompt` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `caliper_log` CHANGE `event` `event` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `comparison` CHANGE `uuid` `uuid` char(22) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `comparison` CHANGE `winner` `winner` enum('answer1','answer2','draw') CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `comparison` CHANGE `pairing_algorithm` `pairing_algorithm` enum('adaptive','random','adaptive_min_delta') CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `comparison` CHANGE `attempt_uuid` `attempt_uuid` char(36) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `comparison_criterion` CHANGE `uuid` `uuid` char(22) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `comparison_criterion` CHANGE `winner` `winner` enum('answer1','answer2','draw') CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `comparison_criterion` CHANGE `content` `content` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `comparison_example` CHANGE `uuid` `uuid` char(22) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `course` CHANGE `uuid` `uuid` char(22) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `course` CHANGE `name` `name` varchar(255) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `course` CHANGE `term` `term` varchar(255) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `criterion` CHANGE `uuid` `uuid` char(22) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `criterion` CHANGE `name` `name` varchar(255) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `criterion` CHANGE `description` `description` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `file` CHANGE `uuid` `uuid` char(22) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `file` CHANGE `name` `name` varchar(255) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `group` CHANGE `uuid` `uuid` char(22) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `group` CHANGE `name` `name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `kaltura_media` CHANGE `service_url` `service_url` varchar(255) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `kaltura_media` CHANGE `upload_ks` `upload_ks` varchar(1024) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `kaltura_media` CHANGE `upload_token_id` `upload_token_id` varchar(255) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `kaltura_media` CHANGE `file_name` `file_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `kaltura_media` CHANGE `entry_id` `entry_id` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `kaltura_media` CHANGE `download_url` `download_url` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_consumer` CHANGE `uuid` `uuid` char(22) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_consumer` CHANGE `oauth_consumer_key` `oauth_consumer_key` varchar(255) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_consumer` CHANGE `oauth_consumer_secret` `oauth_consumer_secret` varchar(255) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_consumer` CHANGE `lti_version` `lti_version` varchar(20) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_consumer` CHANGE `tool_consumer_instance_guid` `tool_consumer_instance_guid` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_consumer` CHANGE `tool_consumer_instance_name` `tool_consumer_instance_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_consumer` CHANGE `tool_consumer_instance_url` `tool_consumer_instance_url` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_consumer` CHANGE `lis_outcome_service_url` `lis_outcome_service_url` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_consumer` CHANGE `global_unique_identifier_param` `global_unique_identifier_param` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_consumer` CHANGE `student_number_param` `student_number_param` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_context` CHANGE `uuid` `uuid` char(22) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_context` CHANGE `context_id` `context_id` varchar(255) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_context` CHANGE `context_type` `context_type` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_context` CHANGE `context_title` `context_title` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_context` CHANGE `ext_ims_lis_memberships_id` `ext_ims_lis_memberships_id` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_context` CHANGE `ext_ims_lis_memberships_url` `ext_ims_lis_memberships_url` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_context` CHANGE `custom_context_memberships_url` `custom_context_memberships_url` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_context` CHANGE `lis_course_offering_sourcedid` `lis_course_offering_sourcedid` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_context` CHANGE `lis_course_section_sourcedid` `lis_course_section_sourcedid` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_membership` CHANGE `roles` `roles` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_membership` CHANGE `lis_result_sourcedid` `lis_result_sourcedid` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_membership` CHANGE `lis_result_sourcedids` `lis_result_sourcedids` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_membership` CHANGE `course_role` `course_role` enum('Dropped','Instructor','Teaching Assistant','Student') CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_nonce` CHANGE `oauth_nonce` `oauth_nonce` varchar(255) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_resource_link` CHANGE `resource_link_id` `resource_link_id` varchar(255) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_resource_link` CHANGE `resource_link_title` `resource_link_title` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_resource_link` CHANGE `launch_presentation_return_url` `launch_presentation_return_url` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_resource_link` CHANGE `custom_param_assignment_id` `custom_param_assignment_id` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user` CHANGE `uuid` `uuid` char(22) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user` CHANGE `user_id` `user_id` varchar(255) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user` CHANGE `lis_person_name_given` `lis_person_name_given` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user` CHANGE `lis_person_name_family` `lis_person_name_family` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user` CHANGE `lis_person_name_full` `lis_person_name_full` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user` CHANGE `lis_person_contact_email_primary` `lis_person_contact_email_primary` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user` CHANGE `global_unique_identifier` `global_unique_identifier` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user` CHANGE `system_role` `system_role` enum('Student','Instructor','System Administrator') CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user` CHANGE `student_number` `student_number` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user` CHANGE `lis_person_sourcedid` `lis_person_sourcedid` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user_resource_link` CHANGE `roles` `roles` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user_resource_link` CHANGE `lis_result_sourcedid` `lis_result_sourcedid` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `lti_user_resource_link` CHANGE `course_role` `course_role` enum('Dropped','Instructor','Teaching Assistant','Student') CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `third_party_user` CHANGE `uuid` `uuid` char(22) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `third_party_user` CHANGE `third_party_type` `third_party_type` enum('CAS','SAML') CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `third_party_user` CHANGE `unique_identifier` `unique_identifier` varchar(255) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `third_party_user` CHANGE `_params` `_params` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `user` CHANGE `uuid` `uuid` char(22) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `user` CHANGE `global_unique_identifier` `global_unique_identifier` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `user` CHANGE `username` `username` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `user` CHANGE `_password` `_password` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `user` CHANGE `system_role` `system_role` enum('Student','Instructor','System Administrator') CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `user` CHANGE `displayname` `displayname` varchar(255) CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `user` CHANGE `email` `email` varchar(254) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `user` CHANGE `firstname` `firstname` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `user` CHANGE `lastname` `lastname` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `user` CHANGE `student_number` `student_number` varchar(50) CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `user` CHANGE `email_notification_method` `email_notification_method` enum('enable','disable') CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci DEFAULT 'enable'"))
+    conn.execute(sa.sql.text("ALTER TABLE `user_course` CHANGE `course_role` `course_role` enum('Dropped','Instructor','Teaching Assistant','Student') CHARACTER SET utf8 NOT NULL COLLATE utf8_unicode_ci"))
+    conn.execute(sa.sql.text("ALTER TABLE `xapi_log` CHANGE `statement` `statement` text CHARACTER SET utf8 COLLATE utf8_unicode_ci"))
+
+    # repair and optimize tables
+    conn.execute(sa.sql.text("REPAIR TABLE `activity_log`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `activity_log`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `answer`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `answer`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `answer_comment`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `answer_comment`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `answer_criterion_score`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `answer_criterion_score`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `answer_score`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `answer_score`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `assignment`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `assignment`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `assignment_criterion`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `assignment_criterion`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `assignment_grade`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `assignment_grade`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `caliper_log`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `caliper_log`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `comparison`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `comparison`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `comparison_criterion`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `comparison_criterion`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `comparison_example`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `comparison_example`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `course`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `course`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `course_grade`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `course_grade`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `criterion`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `criterion`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `file`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `file`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `group`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `group`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `kaltura_media`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `kaltura_media`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `lti_consumer`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `lti_consumer`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `lti_context`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `lti_context`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `lti_membership`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `lti_membership`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `lti_nonce`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `lti_nonce`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `lti_resource_link`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `lti_resource_link`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `lti_user`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `lti_user`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `lti_user_resource_link`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `lti_user_resource_link`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `third_party_user`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `third_party_user`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `user`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `user`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `user_course`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `user_course`"))
+    conn.execute(sa.sql.text("REPAIR TABLE `xapi_log`"))
+    conn.execute(sa.sql.text("OPTIMIZE TABLE `xapi_log`"))
+

--- a/compair/models/file.py
+++ b/compair/models/file.py
@@ -17,8 +17,8 @@ class File(DefaultTableMixin, UUIDMixin, WriteTrackingMixin):
         nullable=False)
     kaltura_media_id = db.Column(db.Integer, db.ForeignKey('kaltura_media.id', ondelete="SET NULL"),
         nullable=True)
-    name = db.Column(db.String(255), unique=True, nullable=False)
-    alias = db.Column(db.String(255), nullable=False)
+    name = db.Column(db.String(191), unique=True, nullable=False)
+    alias = db.Column(db.String(191), nullable=False)
 
     # relationships
     # user via User Model

--- a/compair/models/kaltura_models/kaltura_media.py
+++ b/compair/models/kaltura_models/kaltura_media.py
@@ -23,7 +23,7 @@ class KalturaMedia(DefaultTableMixin, WriteTrackingMixin):
     player_id = db.Column(db.Integer, default=0, nullable=False)
 
     upload_ks = db.Column(db.String(1024), nullable=False)
-    upload_token_id = db.Column(db.String(255), nullable=False, index=True)
+    upload_token_id = db.Column(db.String(191), nullable=False, index=True)
     file_name = db.Column(db.String(255), nullable=True)
 
     entry_id = db.Column(db.String(255), nullable=True)

--- a/compair/models/lti_models/lti_consumer.py
+++ b/compair/models/lti_models/lti_consumer.py
@@ -10,10 +10,10 @@ class LTIConsumer(DefaultTableMixin, UUIDMixin, ActiveMixin, WriteTrackingMixin)
     __tablename__ = 'lti_consumer'
 
     # table columns
-    oauth_consumer_key = db.Column(db.String(255), unique=True, nullable=False)
+    oauth_consumer_key = db.Column(db.String(191), unique=True, nullable=False)
     oauth_consumer_secret = db.Column(db.String(255), nullable=False)
     lti_version = db.Column(db.String(20), nullable=True)
-    tool_consumer_instance_guid = db.Column(db.String(255), unique=True, nullable=True)
+    tool_consumer_instance_guid = db.Column(db.String(191), unique=True, nullable=True)
     tool_consumer_instance_name = db.Column(db.String(255), nullable=True)
     tool_consumer_instance_url = db.Column(db.Text, nullable=True)
     lis_outcome_service_url = db.Column(db.Text, nullable=True)

--- a/compair/models/lti_models/lti_context.py
+++ b/compair/models/lti_models/lti_context.py
@@ -13,7 +13,7 @@ class LTIContext(DefaultTableMixin, UUIDMixin, WriteTrackingMixin):
     # table columns
     lti_consumer_id = db.Column(db.Integer, db.ForeignKey("lti_consumer.id", ondelete="CASCADE"),
         nullable=False)
-    context_id = db.Column(db.String(255), nullable=False)
+    context_id = db.Column(db.String(191), nullable=False)
     context_type = db.Column(db.String(255), nullable=True)
     context_title = db.Column(db.String(255), nullable=True)
     ext_ims_lis_memberships_id = db.Column(db.String(255), nullable=True)

--- a/compair/models/lti_models/lti_nonce.py
+++ b/compair/models/lti_models/lti_nonce.py
@@ -14,7 +14,7 @@ class LTINonce(DefaultTableMixin, WriteTrackingMixin):
     # table columns
     lti_consumer_id = db.Column(db.Integer, db.ForeignKey("lti_consumer.id", ondelete="CASCADE"),
         nullable=False)
-    oauth_nonce = db.Column(db.String(255), nullable=False)
+    oauth_nonce = db.Column(db.String(191), nullable=False)
     oauth_timestamp = db.Column(db.TIMESTAMP, nullable=False)
 
     # relationships

--- a/compair/models/lti_models/lti_resource_link.py
+++ b/compair/models/lti_models/lti_resource_link.py
@@ -15,7 +15,7 @@ class LTIResourceLink(DefaultTableMixin, WriteTrackingMixin):
         nullable=False)
     lti_context_id = db.Column(db.Integer, db.ForeignKey("lti_context.id", ondelete="CASCADE"),
         nullable=True)
-    resource_link_id = db.Column(db.String(255), nullable=False)
+    resource_link_id = db.Column(db.String(191), nullable=False)
     resource_link_title = db.Column(db.String(255), nullable=True)
     launch_presentation_return_url = db.Column(db.Text, nullable=True)
     custom_param_assignment_id = db.Column(db.String(255), nullable=True)

--- a/compair/models/lti_models/lti_user.py
+++ b/compair/models/lti_models/lti_user.py
@@ -15,7 +15,7 @@ class LTIUser(DefaultTableMixin, UUIDMixin, WriteTrackingMixin):
     # table columns
     lti_consumer_id = db.Column(db.Integer, db.ForeignKey("lti_consumer.id", ondelete="CASCADE"),
         nullable=False)
-    user_id = db.Column(db.String(255), nullable=False)
+    user_id = db.Column(db.String(191), nullable=False)
     lis_person_name_given = db.Column(db.String(255), nullable=True)
     lis_person_name_family = db.Column(db.String(255), nullable=True)
     lis_person_name_full = db.Column(db.String(255), nullable=True)

--- a/compair/models/mixins/default_table_mixin.py
+++ b/compair/models/mixins/default_table_mixin.py
@@ -6,9 +6,9 @@ class DefaultTableMixin(db.Model):
     __abstract__ = True
 
     default_table_args = {
-        'mysql_charset': 'utf8',
+        'mysql_charset': 'utf8mb4',
         'mysql_engine': 'InnoDB',
-        'mysql_collate': 'utf8_unicode_ci'
+        'mysql_collate': 'utf8mb4_unicode_ci'
     }
 
     __table_args__ = default_table_args

--- a/compair/models/third_party_user.py
+++ b/compair/models/third_party_user.py
@@ -23,7 +23,7 @@ class ThirdPartyUser(DefaultTableMixin, UUIDMixin, WriteTrackingMixin):
 
     # table columns
     third_party_type = db.Column(EnumType(ThirdPartyType), nullable=False)
-    unique_identifier = db.Column(db.String(255), nullable=False)
+    unique_identifier = db.Column(db.String(191), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id", ondelete="CASCADE"), nullable=False)
     _params = db.Column(db.Text)
 

--- a/compair/models/user.py
+++ b/compair/models/user.py
@@ -30,8 +30,8 @@ class User(DefaultTableMixin, UUIDMixin, WriteTrackingMixin, UserMixin):
     __tablename__ = 'user'
 
     # table columns
-    global_unique_identifier = db.Column(db.String(255), nullable=True) #should be treated as write once and only once
-    username = db.Column(db.String(255), unique=True, nullable=True)
+    global_unique_identifier = db.Column(db.String(191), nullable=True) #should be treated as write once and only once
+    username = db.Column(db.String(191), unique=True, nullable=True)
     _password = db.Column(db.String(255), unique=False, nullable=True)
     system_role = db.Column(EnumType(SystemRole), nullable=False, index=True)
     displayname = db.Column(db.String(255), nullable=False)

--- a/compair/settings.py
+++ b/compair/settings.py
@@ -13,6 +13,7 @@ DATABASE = {
     'username': 'compair',
     'password': 'compaircompair',
     'database': 'compair',
+    'query': {'charset': 'utf8mb4'},
 }
 
 # enable sessions by setting the secret key

--- a/compair/static/modules/lti_consumer/lti-consumer-form-partial.html
+++ b/compair/static/modules/lti_consumer/lti-consumer-form-partial.html
@@ -9,7 +9,7 @@
             <label for="oauth_consumer_key" class="required-star">Consumer Key</label>
             <input class="form-control" id="oauth_consumer_key" type="text"
                 name="oauth_consumer_key" ng-model="consumer.oauth_consumer_key"
-                ng-minlength="10" ng-maxlength="255"
+                ng-minlength="10" ng-maxlength="191"
                 required />
             <!-- if the field is empty AND a save attempted -->
             <p ng-if="consumerForm.oauth_consumer_key.$invalid && saveAttempted" class="alert alert-warning">What key did you get from the LTI consumer? (This should be at least 10 characters long.)</p>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - DB_HOST=db
       - DB_PORT=3306
       - DB_NAME=compair
+      - DB_CONN_OPTIONS={"charset":"utf8mb4"}
       - DEV=1
       - CELERY_BROKER_URL=redis://redis:6379
       - CELERY_ALWAYS_EAGER=0
@@ -69,6 +70,7 @@ services:
       - DB_HOST=db
       - DB_PORT=3306
       - DB_NAME=compair
+      - DB_CONN_OPTIONS={"charset":"utf8mb4"}
       - DEV=1
       - CELERY_BROKER_URL=redis://redis:6379
       - CELERY_ALWAYS_EAGER=0


### PR DESCRIPTION
- change from charset utf8 to utf8mb4.  utf8 can only store char up to
  3-byte long.  many emoji characters / symbols can't be stored
- resize indexed char/varchar columns to not longer than 191.  mysql has
  limits on index size

Closes #908 