### PR TITLE
Update AWS readme to fix issue with DB creation

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -41,7 +41,7 @@ You should be logged in with ssh key without password.
 
 Find the app container ID. If nothing showed up, wait for a few minutes.
 ```
-docker ps | grep "ubctlt/compair-app"
+docker ps | grep "\-compair-app"
 ```
 
 Execute the database command:


### PR DESCRIPTION
The current line (44) to retrieve the app container ID is incorrect at it contains the wrong name for the instance.  In addition, just correcting the name retrieves two running containers as they have the same instance name.  I've updated the readme so that it pulls the single running app container instance.