### PR TITLE
Fix/1059: Re-enable BE unit tests for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   unit_test_backend:
     runs-on: ubuntu-latest
-    if: false  # Temporarily disabled
     strategy:
       matrix:
         python-version: [3.8]
@@ -37,10 +36,10 @@ jobs:
         pip install -r requirements.txt -r requirements.dev.txt
     - name: Backend Unit Tests MariaDB
       run: |
-        DATABASE_URI="mysql+pymysql://root@localhost/compair" nosetests
+        DATABASE_URI="mysql+pymysql://root@localhost/compair" pytest
     - name: Backend Unit Tests SQLite
       run: |
-        DATABASE_URI="sqlite:///:memory:" nosetests
+        DATABASE_URI="sqlite:///:memory:" pytest
 
   unit_test_frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.10]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Shutdown Ubuntu MySQL (SUDO)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ['3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/compair/tests/api/test_file.py
+++ b/compair/tests/api/test_file.py
@@ -156,7 +156,8 @@ class FileRetrieveTests(ComPAIRAPITestCase):
 
                 actual_file = rv.json['file']
                 self.files_to_cleanup.append(actual_file['name'])
-                self.assertEqual(actual_file['id']+"."+extension.lower(), actual_file['name'])
+                self.assertTrue(actual_file['id'])
+                self.assertTrue(actual_file['name'])
                 self.assertEqual(filename, actual_file['alias'])
                 self.assertEqual(extension.lower(), actual_file['extension'])
                 self.assertEqual(mimetype, actual_file['mimetype'])
@@ -171,7 +172,6 @@ class FileRetrieveTests(ComPAIRAPITestCase):
 
                 actual_file = rv.json['file']
                 self.files_to_cleanup.append(actual_file['name'])
-                self.assertEqual(actual_file['id']+"."+extension.lower(), actual_file['name'])
                 self.assertEqual(filename, actual_file['alias'])
                 self.assertEqual(extension.lower(), actual_file['extension'])
                 self.assertEqual(mimetype, actual_file['mimetype'])
@@ -236,7 +236,7 @@ class FileRetrieveTests(ComPAIRAPITestCase):
             self.assertIsNone(kaltura_media_items[0].entry_id)
             self.assertIsNone(kaltura_media_items[0].download_url)
 
-            # use global unique identifer (user has no global unique identifer)
+            # use global unique identifier (user has no global unique identifier)
             current_app.config['KALTURA_USE_GLOBAL_UNIQUE_IDENTIFIER'] = True
             mocked_upload_token_add.return_value = {
                 "id": "mocked_upload_token_id2"
@@ -262,8 +262,7 @@ class FileRetrieveTests(ComPAIRAPITestCase):
             self.assertEqual(len(kaltura_media_items), 2)
             self.assertEqual(kaltura_media_items[1].user_id, self.fixtures.instructor.id)
 
-
-            # use global unique identifer (user has global unique identifer)
+            # use global unique identifier (user has global unique identifier)
             self.fixtures.instructor.global_unique_identifier = "1234567890@test.com"
             mocked_upload_token_add.return_value = {
                 "id": "mocked_upload_token_id3"
@@ -408,13 +407,13 @@ class FileRetrieveTests(ComPAIRAPITestCase):
             kaltura_attachment_url = self.base_url + '/attachment/' + rv.json['file']['name'] + '?name=uploaded_audio_file.mp3'
             rv = self.client.get(kaltura_attachment_url)
             self.assertTrue(rv.location.startswith(kaltura_media.download_url))  # redirecting to Kaltura
-            mocked_kaltura_session_start.assert_called_once_with("test@test.com", \
-                expiry=60, \
+            mocked_kaltura_session_start.assert_called_once_with("test@test.com",
+                expiry=60,
                 privileges='sview:'+kaltura_media.entry_id+',urirestrict:/url.com/*'
-                )
+            )
             mocked_kaltura_session_start.reset_mock()
 
-            # use global unique identifer (user has no global unique identifer)
+            # use global unique identifier (user has no global unique identifier)
             current_app.config['KALTURA_USE_GLOBAL_UNIQUE_IDENTIFIER'] = True
             url = '/api/attachment/kaltura/mocked_upload_token_id2'
             mocked_upload_token_get.return_value = {
@@ -453,7 +452,7 @@ class FileRetrieveTests(ComPAIRAPITestCase):
             mocked_kaltura_media_add_content.assert_called_once_with("ks_mock", "mock_entry_id2", "mocked_upload_token_id2")
             mocked_kaltura_media_add_content.reset_mock()
 
-            # use global unique identifer (user has global unique identifer)
+            # use global unique identifier (user has global unique identifier)
             self.fixtures.instructor.global_unique_identifier = "1234567890@test.com"
             url = '/api/attachment/kaltura/mocked_upload_token_id3'
             mocked_upload_token_get.return_value = {

--- a/compair/tests/api/test_login.py
+++ b/compair/tests/api/test_login.py
@@ -699,10 +699,17 @@ class LoginAPITests(ComPAIRAPITestCase):
 
     def test_saml_metadata(self):
         # test saml login enabled
-        self.app.config['SAML_LOGIN_ENABLED'] = True
-        self.app.config['SAML_EXPOSE_METADATA_ENDPOINT'] = True
-        rv = self.client.get('/api/saml/metadata', headers={'Accept': 'text/xml'})
-        self.assert200(rv)
+        with (
+            mock.patch('compair.saml.OneLogin_Saml2_IdPMetadataParser.parse_remote', return_value={}),
+            mock.patch(
+                'compair.saml.OneLogin_Saml2_IdPMetadataParser.merge_settings',
+                side_effect=lambda base_settings, idp_settings: base_settings
+            )
+        ):
+            self.app.config['SAML_LOGIN_ENABLED'] = True
+            self.app.config['SAML_EXPOSE_METADATA_ENDPOINT'] = True
+            rv = self.client.get('/api/saml/metadata', headers={'Accept': 'text/xml'})
+            self.assert200(rv)
 
         # test saml login disabled
         self.app.config['SAML_LOGIN_ENABLED'] = False

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "gulp-inject": "^5.0.5",
         "gulp-less": "^5.0.0",
         "gulp-print": "^5.0.2",
-        "gulp-rev": "^10.0.0",
+        "gulp-rev": "^9.0.0",
         "gulp-sort": "^2.0.0",
         "gulp-uglify": "^3.0.1",
         "less": "~4.1.3",
@@ -79,15 +79,11 @@
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true
     },
-    "node_modules/@types/expect": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
-      "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg=="
-    },
     "node_modules/@types/node": {
       "version": "17.0.31",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q=="
+      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
+      "dev": true
     },
     "node_modules/@types/q": {
       "version": "0.0.32",
@@ -100,15 +96,6 @@
       "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.19.tgz",
       "integrity": "sha512-OFUilxQg+rWL2FMxtmIgCkUDlJB6pskkpvmew7yeXfzzsOBb5rc+y2+DjHm+r3r1ZPPcJefK3DveNSYWGiy68g==",
       "dev": true
-    },
-    "node_modules/@types/vinyl": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.7.tgz",
-      "integrity": "sha512-4UqPv+2567NhMQuMLdKAyK4yzrfCqwaTt6bLhHEs8PFcxbHILsrxaY63n4wgE/BRLDWDQeI+WcTmkXKExh9hQg==",
-      "dependencies": {
-        "@types/expect": "^1.20.4",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
@@ -2053,17 +2040,6 @@
         "object.defaults": "^1.1.0"
       }
     },
-    "node_modules/easy-transform-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/easy-transform-stream/-/easy-transform-stream-1.0.0.tgz",
-      "integrity": "sha512-kIEXvPNtqUQ/lrgkULIP0/l2m88Ahlk2ySZhmuLdRidXBIEPyHuDgDt04b9DvnCy+nIQDjpygVft+Op3PZFUQg==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -2532,11 +2508,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/fast-fifo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
-      "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -2655,14 +2626,45 @@
       }
     },
     "node_modules/first-chunk-stream": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-5.0.0.tgz",
-      "integrity": "sha512-WdHo4ejd2cG2Dl+sLkW79SctU7mUQDfr4s1i26ffOZRs5mgv+BRttIM9gwcq0rDbemo0KlpVPaa3LBVLqPXzcQ==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+      "integrity": "sha512-X8Z+b/0L4lToKYq+lwnKqi9X/Zek0NibLpsJgVsSxpoYq7JtiCtRb5HqKVEjEw/qAb/4AKKRLOwwKHlWNpm2Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/first-chunk-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/first-chunk-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/first-chunk-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/flagged-respawn": {
@@ -2867,14 +2869,14 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2882,14 +2884,14 @@
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
@@ -2898,14 +2900,14 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2914,14 +2916,14 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.1",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2929,26 +2931,26 @@
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "2.6.9",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "ms": "2.0.0"
@@ -2956,8 +2958,8 @@
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=4.0.0"
@@ -2965,14 +2967,14 @@
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "inBundle": true,
+      "license": "Apache-2.0",
       "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
@@ -2983,8 +2985,8 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.5",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "minipass": "^2.2.1"
@@ -2992,14 +2994,14 @@
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
@@ -3014,8 +3016,8 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.3",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -3031,14 +3033,14 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -3049,8 +3051,8 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.1",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
@@ -3058,8 +3060,8 @@
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -3068,15 +3070,14 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.3",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "deprecated": "Please update to ini >=1.3.6 to avoid a prototype pollution issue",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "engines": {
         "node": "*"
@@ -3084,8 +3085,8 @@
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
@@ -3096,14 +3097,14 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -3114,14 +3115,14 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "0.0.8",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.3.5",
-      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
@@ -3130,8 +3131,8 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.2.1",
-      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "minipass": "^2.2.1"
@@ -3139,9 +3140,8 @@
     },
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.1",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "minimist": "0.0.8"
@@ -3152,14 +3152,14 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.0.0",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.2.4",
-      "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "debug": "^2.1.2",
@@ -3175,9 +3175,8 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.10.3",
-      "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
-      "deprecated": "Please upgrade to @mapbox/node-pre-gyp: the non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will recieve updates in the future",
       "inBundle": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
@@ -3197,8 +3196,8 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.1",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "abbrev": "1",
@@ -3210,14 +3209,14 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.0.5",
-      "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.2.0",
-      "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
@@ -3226,8 +3225,8 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
@@ -3238,8 +3237,8 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3247,8 +3246,8 @@
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3256,8 +3255,8 @@
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "wrappy": "1"
@@ -3265,8 +3264,8 @@
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3274,8 +3273,8 @@
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3283,8 +3282,8 @@
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
@@ -3293,8 +3292,8 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3302,14 +3301,14 @@
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.0",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "inBundle": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
@@ -3323,14 +3322,14 @@
     },
     "node_modules/fsevents/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.6",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -3344,8 +3343,8 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.6.3",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -3356,26 +3355,26 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.6.0",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "bin": {
         "semver": "bin/semver"
@@ -3383,20 +3382,20 @@
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -3404,8 +3403,8 @@
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
@@ -3418,8 +3417,8 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -3430,8 +3429,8 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3439,8 +3438,8 @@
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.8",
-      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
@@ -3457,14 +3456,14 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
@@ -3472,14 +3471,14 @@
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.0.3",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/function-bind": {
@@ -4623,79 +4622,37 @@
       }
     },
     "node_modules/gulp-rev": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-rev/-/gulp-rev-10.0.0.tgz",
-      "integrity": "sha512-5mP6oOGp1DUzBQuiy9IrtyAWHWUOz2n1qLUHfo7LU0p111t7sTkUhKW01b70B2MsDWgScTdz6sGLg76KCbqclw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-rev/-/gulp-rev-9.0.0.tgz",
+      "integrity": "sha512-Ytx/uzDA2xNxHlPG8GReS1ut00msd0HlKDk9Ai/0xF2yvg+DAeGRAviCFlQzQmdZtqAoXznYspwWoGEoxDvhyA==",
+      "license": "MIT",
       "dependencies": {
-        "easy-transform-stream": "^1.0.0",
-        "modify-filename": "^2.0.0",
-        "plugin-error": "^2.0.1",
-        "rev-hash": "^4.0.0",
-        "rev-path": "^3.0.0",
-        "sort-keys": "^5.0.0",
-        "vinyl": "^3.0.0",
-        "vinyl-file": "^5.0.0"
+        "modify-filename": "^1.1.0",
+        "plugin-error": "^1.0.1",
+        "rev-hash": "^2.0.0",
+        "rev-path": "^2.0.0",
+        "sort-keys": "^2.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^2.1.0",
+        "vinyl-file": "^3.0.0"
       },
       "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      },
-      "peerDependencies": {
-        "gulp": ">=4"
-      },
-      "peerDependenciesMeta": {
-        "gulp": {
-          "optional": true
-        }
+        "node": ">=6"
       }
-    },
-    "node_modules/gulp-rev/node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/gulp-rev/node_modules/clone-stats": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-      "integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag=="
     },
     "node_modules/gulp-rev/node_modules/plugin-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-2.0.1.tgz",
-      "integrity": "sha512-zMakqvIDyY40xHOvzXka0kUvf40nYIuwRE8dWhti2WtjQZ31xAgBZBhxsK7vK3QbRXS1Xms/LO7B5cuAsfB2Gg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+      "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+      "license": "MIT",
       "dependencies": {
-        "ansi-colors": "^1.0.1"
+        "ansi-colors": "^1.0.1",
+        "arr-diff": "^4.0.0",
+        "arr-union": "^3.1.0",
+        "extend-shallow": "^3.0.2"
       },
       "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/gulp-rev/node_modules/replace-ext": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
-      "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/gulp-rev/node_modules/vinyl": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.0.tgz",
-      "integrity": "sha512-rC2VRfAVVCGEgjnxHUnpIVh3AGuk62rP3tqVrn+yab0YH7UULisC085+NYH+mnqf3Wx4SpSi1RQMwudL89N03g==",
-      "dependencies": {
-        "clone": "^2.1.2",
-        "clone-stats": "^1.0.0",
-        "remove-trailing-separator": "^1.1.0",
-        "replace-ext": "^2.0.0",
-        "teex": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10.13.0"
+        "node": ">= 0.10"
       }
     },
     "node_modules/gulp-sort": {
@@ -5313,14 +5270,12 @@
       }
     },
     "node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-plain-object": {
@@ -6200,17 +6155,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/load-json-file/node_modules/strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dependencies": {
-        "is-utf8": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -6711,14 +6655,12 @@
       "dev": true
     },
     "node_modules/modify-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/modify-filename/-/modify-filename-2.0.0.tgz",
-      "integrity": "sha512-VX9/MdgUN9StpSLImJ0+AyV2dxJJtyojIwRHF/Ja942tW7FTzxXI186jDSTk4k5wj2+59a4bRzFnJUgMSi+ygg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/modify-filename/-/modify-filename-1.1.0.tgz",
+      "integrity": "sha512-EickqnKq3kVVaZisYuCxhtKbZjInCuwgwZWyAmRIp1NTMhri7r3380/uqwrUHfaDiPzLVTuoNy4whX66bxPVog==",
+      "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/mout": {
@@ -8084,11 +8026,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/queue-tick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -8426,28 +8363,24 @@
       }
     },
     "node_modules/rev-hash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rev-hash/-/rev-hash-4.0.0.tgz",
-      "integrity": "sha512-5w/auZRs65pf1AkZIbfICeorQfOCb6XVWaHmDEbkMyjmyRMxck+W0Erdj9zffuBRXxn5cbKfgmWQ9GpgR8dFZQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rev-hash/-/rev-hash-2.0.0.tgz",
+      "integrity": "sha512-U6EkYZI87C3B5KS46HAEy+g+rtueIdfF9Zb6XBlGe3R/RaF3V8drN7nRFm7/swHOK1zQLGvIYwQ4Q6WDAAlynw==",
+      "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
     "node_modules/rev-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rev-path/-/rev-path-3.0.0.tgz",
-      "integrity": "sha512-2fUuv6IC7Z+Vj+DXEunJYJDZuwSsaJJHeLar3n2PGvHSH7j5+Xpd/Xh7PenekH4WQhxFuHtsGwd1dCh/HvT6Gw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rev-path/-/rev-path-2.0.0.tgz",
+      "integrity": "sha512-G5R2L9gYu9kEuqPfIFgO9gO+OhBWOAT83HyauOQmGHO6y9Fsa4acv+XsmNhNDrod0HDh1/VxJRmsffThzeHJlQ==",
+      "license": "MIT",
       "dependencies": {
-        "modify-filename": "^2.0.0"
+        "modify-filename": "^1.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
     "node_modules/rfdc": {
@@ -8941,17 +8874,15 @@
       "dev": true
     },
     "node_modules/sort-keys": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-5.0.0.tgz",
-      "integrity": "sha512-Pdz01AvCAottHTPQGzndktFNdbRA75BgOfeT1hH+AMnJFv8lynkPi42rfeEhpx1saTEI3YNMWxfqu0sFD1G8pw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==",
+      "license": "MIT",
       "dependencies": {
-        "is-plain-obj": "^4.0.0"
+        "is-plain-obj": "^1.0.0"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
     "node_modules/source-map": {
@@ -9273,15 +9204,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/streamx": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.13.0.tgz",
-      "integrity": "sha512-9jD4uoX0juNSIcv4PazT+97FpM4Mww3cp7PM23HRTLANhgb7K7n1mB45guH/kT5F4enl04kApOM3EeoUXSPfvw==",
-      "dependencies": {
-        "fast-fifo": "^1.1.0",
-        "queue-tick": "^1.0.1"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -9316,33 +9238,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-utf8": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-bom-buf": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-3.0.1.tgz",
-      "integrity": "sha512-iJaWw2WroigLHzQysdc5WWeUc99p7ea7AEgB6JkY8CMyiO1yTVAA1gIlJJgORElUIR+lcZJkNl1OGChMhvc2Cw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
+      "integrity": "sha512-1sUIL1jck0T1mhOLP2c696BIznzT525Lkub+n4jjMHjhjhoAQA6Ye659DxdlZBr0aLDMQoTxKIpnlqxgtwjsuQ==",
+      "license": "MIT",
       "dependencies": {
         "is-utf8": "^0.2.1"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
     "node_modules/strip-bom-stream": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-5.0.0.tgz",
-      "integrity": "sha512-Yo472mU+3smhzqeKlIxClre4s4pwtYZEvDNQvY/sJpnChdaxmKuwU28UVx/v1ORKNMxkmj1GBuvxJQyBk6wYMQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+      "integrity": "sha512-yH0+mD8oahBZWnY43vxs4pSinn8SMKAdml/EOGBewoe1Y0Eitd0h2Mg3ZRiXruUW6L4P+lvZiEgbh0NgUGia1w==",
+      "license": "MIT",
       "dependencies": {
-        "first-chunk-stream": "^5.0.0",
-        "strip-bom-buf": "^3.0.0"
+        "first-chunk-stream": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-eof": {
@@ -9492,14 +9422,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/teex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "dependencies": {
-        "streamx": "^2.12.5"
       }
     },
     "node_modules/through": {
@@ -10061,56 +9983,19 @@
       }
     },
     "node_modules/vinyl-file": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-5.0.0.tgz",
-      "integrity": "sha512-MvkPF/yA1EX7c6p+juVIvp9+Lxp70YUfNKzEWeHMKpUNVSnTZh2coaOqLxI0pmOe2V9nB+OkgFaMDkodaJUyGw==",
-      "dependencies": {
-        "@types/vinyl": "^2.0.7",
-        "strip-bom-buf": "^3.0.1",
-        "strip-bom-stream": "^5.0.0",
-        "vinyl": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vinyl-file/node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/vinyl-file/node_modules/clone-stats": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-      "integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag=="
-    },
-    "node_modules/vinyl-file/node_modules/replace-ext": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
-      "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/vinyl-file/node_modules/vinyl": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.0.tgz",
-      "integrity": "sha512-rC2VRfAVVCGEgjnxHUnpIVh3AGuk62rP3tqVrn+yab0YH7UULisC085+NYH+mnqf3Wx4SpSi1RQMwudL89N03g==",
+      "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-3.0.0.tgz",
+      "integrity": "sha512-BoJDj+ca3D9xOuPEM6RWVtWQtvEPQiQYn82LvdxhLWplfQsBzBqtgK0yhCP0s1BNTi6dH9BO+dzybvyQIacifg==",
+      "license": "MIT",
       "dependencies": {
-        "clone": "^2.1.2",
-        "clone-stats": "^1.0.0",
-        "remove-trailing-separator": "^1.1.0",
-        "replace-ext": "^2.0.0",
-        "teex": "^1.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.3.0",
+        "strip-bom-buf": "^1.0.0",
+        "strip-bom-stream": "^2.0.0",
+        "vinyl": "^2.0.1"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=4"
       }
     },
     "node_modules/vinyl-fs": {
@@ -10517,15 +10402,11 @@
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true
     },
-    "@types/expect": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
-      "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg=="
-    },
     "@types/node": {
       "version": "17.0.31",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q=="
+      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
+      "dev": true
     },
     "@types/q": {
       "version": "0.0.32",
@@ -10538,15 +10419,6 @@
       "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.19.tgz",
       "integrity": "sha512-OFUilxQg+rWL2FMxtmIgCkUDlJB6pskkpvmew7yeXfzzsOBb5rc+y2+DjHm+r3r1ZPPcJefK3DveNSYWGiy68g==",
       "dev": true
-    },
-    "@types/vinyl": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.7.tgz",
-      "integrity": "sha512-4UqPv+2567NhMQuMLdKAyK4yzrfCqwaTt6bLhHEs8PFcxbHILsrxaY63n4wgE/BRLDWDQeI+WcTmkXKExh9hQg==",
-      "requires": {
-        "@types/expect": "^1.20.4",
-        "@types/node": "*"
-      }
     },
     "@types/yauzl": {
       "version": "2.10.0",
@@ -12107,11 +11979,6 @@
         "object.defaults": "^1.1.0"
       }
     },
-    "easy-transform-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/easy-transform-stream/-/easy-transform-stream-1.0.0.tgz",
-      "integrity": "sha512-kIEXvPNtqUQ/lrgkULIP0/l2m88Ahlk2ySZhmuLdRidXBIEPyHuDgDt04b9DvnCy+nIQDjpygVft+Op3PZFUQg=="
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -12512,11 +12379,6 @@
         "time-stamp": "^1.0.0"
       }
     },
-    "fast-fifo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
-      "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
-    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -12613,9 +12475,41 @@
       }
     },
     "first-chunk-stream": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-5.0.0.tgz",
-      "integrity": "sha512-WdHo4ejd2cG2Dl+sLkW79SctU7mUQDfr4s1i26ffOZRs5mgv+BRttIM9gwcq0rDbemo0KlpVPaa3LBVLqPXzcQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+      "integrity": "sha512-X8Z+b/0L4lToKYq+lwnKqi9X/Zek0NibLpsJgVsSxpoYq7JtiCtRb5HqKVEjEw/qAb/4AKKRLOwwKHlWNpm2Eg==",
+      "requires": {
+        "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+        },
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "flagged-respawn": {
       "version": "1.0.1",
@@ -12769,25 +12663,21 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "bundled": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "bundled": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "bundled": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -12797,13 +12687,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "bundled": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -12813,37 +12701,31 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "bundled": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "bundled": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "bundled": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "bundled": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "bundled": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -12852,25 +12734,21 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "bundled": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "bundled": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "bundled": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -12879,13 +12757,11 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "bundled": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -12901,7 +12777,6 @@
         },
         "glob": {
           "version": "7.1.3",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -12915,13 +12790,11 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "bundled": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -12930,7 +12803,6 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -12939,7 +12811,6 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -12949,19 +12820,16 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "bundled": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "bundled": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -12970,13 +12838,11 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "bundled": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -12985,13 +12851,11 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "bundled": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13001,7 +12865,6 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13010,7 +12873,6 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13019,13 +12881,11 @@
         },
         "ms": {
           "version": "2.0.0",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "bundled": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.4",
-          "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13036,7 +12896,6 @@
         },
         "node-pre-gyp": {
           "version": "0.10.3",
-          "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13054,7 +12913,6 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13064,13 +12922,11 @@
         },
         "npm-bundled": {
           "version": "1.0.5",
-          "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.2.0",
-          "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13080,7 +12936,6 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13092,19 +12947,16 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "bundled": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "bundled": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13113,19 +12965,16 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "bundled": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "bundled": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13135,19 +12984,16 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "bundled": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "bundled": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13159,7 +13005,6 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "bundled": true,
               "optional": true
             }
@@ -13167,7 +13012,6 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13182,7 +13026,6 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13191,43 +13034,36 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "bundled": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "bundled": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "bundled": true,
           "optional": true
         },
         "semver": {
           "version": "5.6.0",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
           "bundled": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "bundled": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "bundled": true,
           "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13236,7 +13072,6 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13247,7 +13082,6 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13256,13 +13090,11 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "bundled": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13277,13 +13109,11 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "bundled": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -13292,13 +13122,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "bundled": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "bundled": true,
           "optional": true
         }
@@ -14233,53 +14061,29 @@
       }
     },
     "gulp-rev": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-rev/-/gulp-rev-10.0.0.tgz",
-      "integrity": "sha512-5mP6oOGp1DUzBQuiy9IrtyAWHWUOz2n1qLUHfo7LU0p111t7sTkUhKW01b70B2MsDWgScTdz6sGLg76KCbqclw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-rev/-/gulp-rev-9.0.0.tgz",
+      "integrity": "sha512-Ytx/uzDA2xNxHlPG8GReS1ut00msd0HlKDk9Ai/0xF2yvg+DAeGRAviCFlQzQmdZtqAoXznYspwWoGEoxDvhyA==",
       "requires": {
-        "easy-transform-stream": "^1.0.0",
-        "modify-filename": "^2.0.0",
-        "plugin-error": "^2.0.1",
-        "rev-hash": "^4.0.0",
-        "rev-path": "^3.0.0",
-        "sort-keys": "^5.0.0",
-        "vinyl": "^3.0.0",
-        "vinyl-file": "^5.0.0"
+        "modify-filename": "^1.1.0",
+        "plugin-error": "^1.0.1",
+        "rev-hash": "^2.0.0",
+        "rev-path": "^2.0.0",
+        "sort-keys": "^2.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^2.1.0",
+        "vinyl-file": "^3.0.0"
       },
       "dependencies": {
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag=="
-        },
         "plugin-error": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-2.0.1.tgz",
-          "integrity": "sha512-zMakqvIDyY40xHOvzXka0kUvf40nYIuwRE8dWhti2WtjQZ31xAgBZBhxsK7vK3QbRXS1Xms/LO7B5cuAsfB2Gg==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
           "requires": {
-            "ansi-colors": "^1.0.1"
-          }
-        },
-        "replace-ext": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
-          "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug=="
-        },
-        "vinyl": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.0.tgz",
-          "integrity": "sha512-rC2VRfAVVCGEgjnxHUnpIVh3AGuk62rP3tqVrn+yab0YH7UULisC085+NYH+mnqf3Wx4SpSi1RQMwudL89N03g==",
-          "requires": {
-            "clone": "^2.1.2",
-            "clone-stats": "^1.0.0",
-            "remove-trailing-separator": "^1.1.0",
-            "replace-ext": "^2.0.0",
-            "teex": "^1.0.1"
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
           }
         }
       }
@@ -14761,9 +14565,9 @@
       }
     },
     "is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -15447,16 +15251,6 @@
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0",
         "strip-bom": "^2.0.0"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        }
       }
     },
     "locate-path": {
@@ -15889,9 +15683,9 @@
       "dev": true
     },
     "modify-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/modify-filename/-/modify-filename-2.0.0.tgz",
-      "integrity": "sha512-VX9/MdgUN9StpSLImJ0+AyV2dxJJtyojIwRHF/Ja942tW7FTzxXI186jDSTk4k5wj2+59a4bRzFnJUgMSi+ygg=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/modify-filename/-/modify-filename-1.1.0.tgz",
+      "integrity": "sha512-EickqnKq3kVVaZisYuCxhtKbZjInCuwgwZWyAmRIp1NTMhri7r3380/uqwrUHfaDiPzLVTuoNy4whX66bxPVog=="
     },
     "mout": {
       "version": "1.2.3",
@@ -16946,11 +16740,6 @@
         "side-channel": "^1.0.4"
       }
     },
-    "queue-tick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
-    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -17224,16 +17013,16 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "rev-hash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rev-hash/-/rev-hash-4.0.0.tgz",
-      "integrity": "sha512-5w/auZRs65pf1AkZIbfICeorQfOCb6XVWaHmDEbkMyjmyRMxck+W0Erdj9zffuBRXxn5cbKfgmWQ9GpgR8dFZQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rev-hash/-/rev-hash-2.0.0.tgz",
+      "integrity": "sha512-U6EkYZI87C3B5KS46HAEy+g+rtueIdfF9Zb6XBlGe3R/RaF3V8drN7nRFm7/swHOK1zQLGvIYwQ4Q6WDAAlynw=="
     },
     "rev-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rev-path/-/rev-path-3.0.0.tgz",
-      "integrity": "sha512-2fUuv6IC7Z+Vj+DXEunJYJDZuwSsaJJHeLar3n2PGvHSH7j5+Xpd/Xh7PenekH4WQhxFuHtsGwd1dCh/HvT6Gw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rev-path/-/rev-path-2.0.0.tgz",
+      "integrity": "sha512-G5R2L9gYu9kEuqPfIFgO9gO+OhBWOAT83HyauOQmGHO6y9Fsa4acv+XsmNhNDrod0HDh1/VxJRmsffThzeHJlQ==",
       "requires": {
-        "modify-filename": "^2.0.0"
+        "modify-filename": "^1.0.0"
       }
     },
     "rfdc": {
@@ -17639,11 +17428,11 @@
       }
     },
     "sort-keys": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-5.0.0.tgz",
-      "integrity": "sha512-Pdz01AvCAottHTPQGzndktFNdbRA75BgOfeT1hH+AMnJFv8lynkPi42rfeEhpx1saTEI3YNMWxfqu0sFD1G8pw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==",
       "requires": {
-        "is-plain-obj": "^4.0.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "source-map": {
@@ -17924,15 +17713,6 @@
         }
       }
     },
-    "streamx": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.13.0.tgz",
-      "integrity": "sha512-9jD4uoX0juNSIcv4PazT+97FpM4Mww3cp7PM23HRTLANhgb7K7n1mB45guH/kT5F4enl04kApOM3EeoUXSPfvw==",
-      "requires": {
-        "fast-fifo": "^1.1.0",
-        "queue-tick": "^1.0.1"
-      }
-    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -17961,21 +17741,29 @@
         "ansi-regex": "^2.0.0"
       }
     },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
     "strip-bom-buf": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-3.0.1.tgz",
-      "integrity": "sha512-iJaWw2WroigLHzQysdc5WWeUc99p7ea7AEgB6JkY8CMyiO1yTVAA1gIlJJgORElUIR+lcZJkNl1OGChMhvc2Cw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
+      "integrity": "sha512-1sUIL1jck0T1mhOLP2c696BIznzT525Lkub+n4jjMHjhjhoAQA6Ye659DxdlZBr0aLDMQoTxKIpnlqxgtwjsuQ==",
       "requires": {
         "is-utf8": "^0.2.1"
       }
     },
     "strip-bom-stream": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-5.0.0.tgz",
-      "integrity": "sha512-Yo472mU+3smhzqeKlIxClre4s4pwtYZEvDNQvY/sJpnChdaxmKuwU28UVx/v1ORKNMxkmj1GBuvxJQyBk6wYMQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+      "integrity": "sha512-yH0+mD8oahBZWnY43vxs4pSinn8SMKAdml/EOGBewoe1Y0Eitd0h2Mg3ZRiXruUW6L4P+lvZiEgbh0NgUGia1w==",
       "requires": {
-        "first-chunk-stream": "^5.0.0",
-        "strip-bom-buf": "^3.0.0"
+        "first-chunk-stream": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "strip-eof": {
@@ -18091,14 +17879,6 @@
             "safe-buffer": "~5.2.0"
           }
         }
-      }
-    },
-    "teex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "requires": {
-        "streamx": "^2.12.5"
       }
     },
     "through": {
@@ -18567,43 +18347,15 @@
       }
     },
     "vinyl-file": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-5.0.0.tgz",
-      "integrity": "sha512-MvkPF/yA1EX7c6p+juVIvp9+Lxp70YUfNKzEWeHMKpUNVSnTZh2coaOqLxI0pmOe2V9nB+OkgFaMDkodaJUyGw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-3.0.0.tgz",
+      "integrity": "sha512-BoJDj+ca3D9xOuPEM6RWVtWQtvEPQiQYn82LvdxhLWplfQsBzBqtgK0yhCP0s1BNTi6dH9BO+dzybvyQIacifg==",
       "requires": {
-        "@types/vinyl": "^2.0.7",
-        "strip-bom-buf": "^3.0.1",
-        "strip-bom-stream": "^5.0.0",
-        "vinyl": "^3.0.0"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag=="
-        },
-        "replace-ext": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
-          "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug=="
-        },
-        "vinyl": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.0.tgz",
-          "integrity": "sha512-rC2VRfAVVCGEgjnxHUnpIVh3AGuk62rP3tqVrn+yab0YH7UULisC085+NYH+mnqf3Wx4SpSi1RQMwudL89N03g==",
-          "requires": {
-            "clone": "^2.1.2",
-            "clone-stats": "^1.0.0",
-            "remove-trailing-separator": "^1.1.0",
-            "replace-ext": "^2.0.0",
-            "teex": "^1.0.1"
-          }
-        }
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.3.0",
+        "strip-bom-buf": "^1.0.0",
+        "strip-bom-stream": "^2.0.0",
+        "vinyl": "^2.0.1"
       }
     },
     "vinyl-fs": {


### PR DESCRIPTION
Closes #1059

- Unit tests failing:
  - `test_saml_metadata` in `test_login.py`
    - If don't mock, it makes an actual HTTP call to `SAML_METADATA_URL`. Mock it to prevent our unit tests from making real HTTP calls.
    - It passes fine when running locally (`SAML_METADATA_URL=None`) but fails when running inside a container.
    - Fails because `[https://samltest.id/saml/idp`](https://samltest.id/saml/idp%60) no longer exists and therefore returns 410 Gone error.
  
  - `test_create_attachment` in `test_file.py`
    - Remove assert equals statement checking that file name is the same as file id plus file extension, which is no longer the case after 25051fa
- Re-enabled BE unit tests in GitHub actions and changed to use `pytest` instead of `nosetests`