### PR TITLE
Remove trigger deploy step from GitHub actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,14 +97,5 @@ jobs:
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
         repository: ubcctlt/compair-app
         tag_with_ref: true
-    - name: Trigger deploy
-      run: |
-        curl -X POST \
-            --fail \
-            -F token=${{ secrets.DEPLOYMENT_TOKEN }} \
-            -F ref=master \
-            -F "variables[app__image__tag]=${GITHUB_REF##*/}" \
-            -F "variables[worker__image__tag]=${GITHUB_REF##*/}" \
-            https://repo.code.ubc.ca/api/v4/projects/366/trigger/pipeline
 
   # TODO: add acceptance testing (would be easier with a slight rewrite to gulp/generate_index)


### PR DESCRIPTION
Closes #1070 

## Changes
- Removes trigger deploy step from `main.yml`
- Will also remove the `DEPLOYMENT_TOKEN` from the GitHub action secrets once merged