### PR TITLE
Enhance /api/healthz with DB connectivity check

### DIFF
--- a/compair/api/healthz.py
+++ b/compair/api/healthz.py
@@ -1,8 +1,25 @@
 from flask import Blueprint, jsonify
+from sqlalchemy import text
+
+from compair.core import db
 
 healthz_api = Blueprint("healthz_api", __name__, url_prefix='/api')
 
 
 @healthz_api.route('/healthz', methods=['GET'])
 def healthz():
-    return jsonify({'status': 'OK'})
+    checks = {}
+
+    try:
+        db.session.execute(text('SELECT 1'))
+        checks['db'] = 'ok'
+    except Exception as e:
+        checks['db'] = 'error'
+
+    healthy = all(v == 'ok' for v in checks.values())
+    status_code = 200 if healthy else 503
+
+    return jsonify({
+        'status': 'ok' if healthy else 'error',
+        'checks': checks,
+    }), status_code

--- a/compair/tests/api/test_healthz.py
+++ b/compair/tests/api/test_healthz.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import mock
+
+from compair.tests.test_compair import ComPAIRAPITestCase
+
+
+class HealthzAPITests(ComPAIRAPITestCase):
+    def test_healthz_returns_200_when_db_is_up(self):
+        rv = self.client.get('/api/healthz')
+        self.assert200(rv)
+        data = rv.json
+        self.assertEqual(data['status'], 'ok')
+        self.assertEqual(data['checks']['db'], 'ok')
+
+    def test_healthz_returns_503_when_db_is_down(self):
+        from compair.core import db
+        with mock.patch.object(db.session, 'execute', side_effect=Exception('DB unavailable')):
+            rv = self.client.get('/api/healthz')
+            self.assertEqual(rv.status_code, 503)
+            data = rv.json
+            self.assertEqual(data['status'], 'error')
+            self.assertEqual(data['checks']['db'], 'error')
+
+    def test_healthz_requires_no_authentication(self):
+        # endpoint must be reachable without logging in
+        rv = self.client.get('/api/healthz')
+        self.assert200(rv)


### PR DESCRIPTION
## Summary

- Replace static `{'status': 'OK'}` response with a real health check that verifies database connectivity
- Return `503 Service Unavailable` (with error detail) when any check fails, so monitoring services can detect outages
- Add tests covering the healthy path, DB-down path, and unauthenticated access

## Changes

**`compair/api/healthz.py`**
- Execute `SELECT 1` against the database to confirm connectivity
- Response body now includes a `checks` map (`{"db": "ok"|"error"}`) for granular visibility
- HTTP status is `200` when all checks pass, `503` otherwise

**`compair/tests/api/test_healthz.py`** _(new)_
- `test_healthz_returns_200_when_db_is_up` — happy path
- `test_healthz_returns_503_when_db_is_down` — DB failure mocked via `mock.patch`
- `test_healthz_requires_no_authentication` — confirms endpoint is publicly reachable

## Test plan

- [x] Run `docker exec -it compair_app_1 python -m pytest compair/tests/api/test_healthz.py -v`
- [x] Hit `GET /api/healthz` on a running instance and confirm `200 {"status": "ok", "checks": {"db": "ok"}}`
- [x] Confirm monitoring service receives `503` when the DB is unreachable