### PR TITLE
Test python upgrade to 3.10, remove clean_html jinja env global, add notifications.py unit tests

### DIFF
--- a/compair/__init__.py
+++ b/compair/__init__.py
@@ -3,7 +3,6 @@ import os
 import ssl
 import requests
 import re
-import nh3
 
 from flask import Flask, redirect, session as sess, jsonify, url_for, make_response
 from flask_bouncer import ensure
@@ -153,7 +152,6 @@ def create_app(conf=config, settings_override=None, skip_endpoints=False, skip_a
 
     # add include_raw to jinja templates
     app.jinja_env.globals['include_raw'] = lambda filename : Markup(app.jinja_loader.get_source(app.jinja_env, filename)[0])
-    app.jinja_env.globals['clean_html'] = lambda html_string : nh3.clean(html_string) if html_string else ''
     if not skip_assets and not app.debug and not app.config.get('TESTING', False):
         assets = get_asset_names(app)
         app.config.update(assets)

--- a/compair/notifications/notification.py
+++ b/compair/notifications/notification.py
@@ -1,3 +1,5 @@
+import nh3
+
 from compair.core import celery, db
 from compair.models import User, UserCourse, CourseRole, \
     AnswerCommentType, EmailNotificationMethod
@@ -63,6 +65,7 @@ class Notification(object):
             comment=answer_comment,
             instructor_label=instructor_label,
             answer_comment_types=AnswerCommentType,
+            sanitized_comment_content=nh3.clean(answer_comment.content) if answer_comment.content else '',
         )
         text_body = render_template(
             'notification_new_answer_comment.txt',
@@ -79,5 +82,5 @@ class Notification(object):
             recipients=[recipient.email],
             subject=subject,
             html_body=html_body,
-            text_body=text_body
+            text_body=text_body,
         )

--- a/compair/saml.py
+++ b/compair/saml.py
@@ -33,9 +33,12 @@ def _get_saml_settings():
     idp_metadata_url = current_app.config.get('SAML_METADATA_URL')
     idp_metadata_entity_id = current_app.config.get('SAML_METADATA_ENTITY_ID', None)
     if idp_metadata_url:
+        # Pass validate_cert based on ENFORCE_SSL config (default to True for security)
+        validate_cert = current_app.config.get('ENFORCE_SSL', True)
         idp_settings = OneLogin_Saml2_IdPMetadataParser.parse_remote(
             idp_metadata_url,
-            entity_id=idp_metadata_entity_id
+            entity_id=idp_metadata_entity_id,
+            validate_cert=validate_cert
         )
 
         settings = OneLogin_Saml2_IdPMetadataParser.merge_settings(settings, idp_settings)

--- a/compair/templates/notification_new_answer_comment.html
+++ b/compair/templates/notification_new_answer_comment.html
@@ -22,5 +22,5 @@
     on {{ comment.created.strftime('%b %d @ %I:%M %p') }}:
 </div>
 
-<div class="content">{{ clean_html(comment.content) | safe }}</div>
+<div class="content">{{ sanitized_comment_content | safe }}</div>
 {% endblock %}

--- a/compair/tests/test_notifications.py
+++ b/compair/tests/test_notifications.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-import mock
+from unittest import mock
 import nh3
 
 from compair.notifications.notification import Notification
@@ -17,6 +16,12 @@ class NotificationTests(ComPAIRTestCase):
         self.assignment = self.data.get_assignments()[0]
         self.answer_comment = self.data.get_non_draft_answer_comments_by_assignment(self.assignment)[0]
         self.answer = self.answer_comment.answer
+        self.mock_send_message = mock.patch('compair.notifications.notification.send_message').start()
+        self.mock_render_template = mock.patch('compair.notifications.notification.render_template').start()
+
+    def tearDown(self):
+        super(NotificationTests, self).tearDown()
+        mock.patch.stopall()
 
     def _get_html_render_call(self, mock_render_template):
         return next(
@@ -24,63 +29,52 @@ class NotificationTests(ComPAIRTestCase):
             if c.args[0] == 'notification_new_answer_comment.html'
         )
 
-    @mock.patch('compair.notifications.notification.send_message')
-    def test_no_notification_sent_when_mail_notification_disabled(self, mock_send_message):
+    def test_no_notification_sent_when_mail_notification_disabled(self):
         self.app.config['MAIL_NOTIFICATION_ENABLED'] = False
 
         Notification.send_new_answer_comment(self.answer_comment)
 
-        mock_send_message.delay.assert_not_called()
+        self.mock_send_message.delay.assert_not_called()
 
-    @mock.patch('compair.notifications.notification.send_message')
-    def test_no_notification_sent_when_no_recipient(self, mock_send_message):
+    def test_no_notification_sent_when_no_recipient(self):
         self.answer.user.email_notification_method = EmailNotificationMethod.disable
         db.session.commit()
 
         Notification.send_new_answer_comment(self.answer_comment)
 
-        mock_send_message.delay.assert_not_called()
+        self.mock_send_message.delay.assert_not_called()
 
-    @mock.patch('compair.notifications.notification.send_message')
-    def test_send_message_called_with_correct_recipient_and_subject(self, mock_send_message):
+    def test_send_message_called_with_correct_recipient_and_subject(self):
         Notification.send_new_answer_comment(self.answer_comment)
 
-        mock_send_message.delay.assert_called_once()
-        call_kwargs = mock_send_message.delay.call_args.kwargs
+        self.mock_send_message.delay.assert_called_once()
+        call_kwargs = self.mock_send_message.delay.call_args.kwargs
         self.assertEqual(call_kwargs['recipients'], [self.answer.user.email])
         self.assertIn(self.assignment.course.name, call_kwargs['subject'])
 
-    @mock.patch('compair.notifications.notification.send_message')
-    @mock.patch('compair.notifications.notification.render_template')
-    def test_instructor_label_set_for_instructor(self, mock_render_template, mock_send_message):
+    def test_instructor_label_set_for_instructor(self):
         answer_comment = self.data.create_answer_comment(self.data.get_authorized_instructor(), self.answer)
 
         Notification.send_new_answer_comment(answer_comment)
 
-        html_render_call = self._get_html_render_call(mock_render_template)
+        html_render_call = self._get_html_render_call(self.mock_render_template)
         self.assertEqual(html_render_call.kwargs['instructor_label'], CourseRole.instructor.value)
 
-    @mock.patch('compair.notifications.notification.send_message')
-    @mock.patch('compair.notifications.notification.render_template')
-    def test_instructor_label_set_for_teaching_assistant(self, mock_render_template, mock_send_message):
+    def test_instructor_label_set_for_teaching_assistant(self):
         answer_comment = self.data.create_answer_comment(self.data.get_authorized_ta(), self.answer)
 
         Notification.send_new_answer_comment(answer_comment)
 
-        html_render_call = self._get_html_render_call(mock_render_template)
+        html_render_call = self._get_html_render_call(self.mock_render_template)
         self.assertEqual(html_render_call.kwargs['instructor_label'], CourseRole.teaching_assistant.value)
 
-    @mock.patch('compair.notifications.notification.send_message')
-    @mock.patch('compair.notifications.notification.render_template')
-    def test_instructor_label_none_for_student_author(self, mock_render_template, mock_send_message):
+    def test_instructor_label_none_for_student_author(self):
         Notification.send_new_answer_comment(self.answer_comment)
 
-        html_render_call = self._get_html_render_call(mock_render_template)
+        html_render_call = self._get_html_render_call(self.mock_render_template)
         self.assertIsNone(html_render_call.kwargs['instructor_label'])
 
-    @mock.patch('compair.notifications.notification.send_message')
-    @mock.patch('compair.notifications.notification.render_template')
-    def test_sanitized_content_passed_to_template(self, mock_render_template, mock_send_message):
+    def test_sanitized_content_passed_to_template(self):
         self.answer_comment.content = '<p>hello</p><script>alert("xss")</script>'
 
         with mock.patch('compair.notifications.notification.nh3.clean', wraps=nh3.clean) as mock_clean:
@@ -88,17 +82,15 @@ class NotificationTests(ComPAIRTestCase):
 
         mock_clean.assert_called_once_with(self.answer_comment.content)
 
-        html_render_call = self._get_html_render_call(mock_render_template)
+        html_render_call = self._get_html_render_call(self.mock_render_template)
         sanitized = html_render_call.kwargs['sanitized_comment_content']
         self.assertNotIn('<script>', sanitized)
         self.assertIn('<p>hello</p>', sanitized)
 
-    @mock.patch('compair.notifications.notification.send_message')
-    @mock.patch('compair.notifications.notification.render_template')
-    def test_none_content_passes_empty_string_to_template(self, mock_render_template, mock_send_message):
+    def test_none_content_passes_empty_string_to_template(self):
         self.answer_comment.content = None
 
         Notification.send_new_answer_comment(self.answer_comment)
 
-        html_render_call = self._get_html_render_call(mock_render_template)
+        html_render_call = self._get_html_render_call(self.mock_render_template)
         self.assertEqual(html_render_call.kwargs['sanitized_comment_content'], '')

--- a/compair/tests/test_notifications.py
+++ b/compair/tests/test_notifications.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import mock
+import nh3
+
+from compair.notifications.notification import Notification
+from compair.models import CourseRole, EmailNotificationMethod
+from compair.core import db
+from compair.tests.test_compair import ComPAIRTestCase
+from data.fixtures.test_data import AnswerCommentsTestData
+
+
+class NotificationTests(ComPAIRTestCase):
+    def setUp(self):
+        super(NotificationTests, self).setUp()
+        self.data = AnswerCommentsTestData()
+        self.assignment = self.data.get_assignments()[0]
+        self.answer_comment = self.data.get_non_draft_answer_comments_by_assignment(self.assignment)[0]
+        self.answer = self.answer_comment.answer
+
+    def _get_html_render_call(self, mock_render_template):
+        return next(
+            c for c in mock_render_template.call_args_list
+            if c.args[0] == 'notification_new_answer_comment.html'
+        )
+
+    @mock.patch('compair.notifications.notification.send_message')
+    def test_no_notification_sent_when_mail_notification_disabled(self, mock_send_message):
+        self.app.config['MAIL_NOTIFICATION_ENABLED'] = False
+
+        Notification.send_new_answer_comment(self.answer_comment)
+
+        mock_send_message.delay.assert_not_called()
+
+    @mock.patch('compair.notifications.notification.send_message')
+    def test_no_notification_sent_when_no_recipient(self, mock_send_message):
+        self.answer.user.email_notification_method = EmailNotificationMethod.disable
+        db.session.commit()
+
+        Notification.send_new_answer_comment(self.answer_comment)
+
+        mock_send_message.delay.assert_not_called()
+
+    @mock.patch('compair.notifications.notification.send_message')
+    def test_send_message_called_with_correct_recipient_and_subject(self, mock_send_message):
+        Notification.send_new_answer_comment(self.answer_comment)
+
+        mock_send_message.delay.assert_called_once()
+        call_kwargs = mock_send_message.delay.call_args.kwargs
+        self.assertEqual(call_kwargs['recipients'], [self.answer.user.email])
+        self.assertIn(self.assignment.course.name, call_kwargs['subject'])
+
+    @mock.patch('compair.notifications.notification.send_message')
+    @mock.patch('compair.notifications.notification.render_template')
+    def test_instructor_label_set_for_instructor(self, mock_render_template, mock_send_message):
+        answer_comment = self.data.create_answer_comment(self.data.get_authorized_instructor(), self.answer)
+
+        Notification.send_new_answer_comment(answer_comment)
+
+        html_render_call = self._get_html_render_call(mock_render_template)
+        self.assertEqual(html_render_call.kwargs['instructor_label'], CourseRole.instructor.value)
+
+    @mock.patch('compair.notifications.notification.send_message')
+    @mock.patch('compair.notifications.notification.render_template')
+    def test_instructor_label_set_for_teaching_assistant(self, mock_render_template, mock_send_message):
+        answer_comment = self.data.create_answer_comment(self.data.get_authorized_ta(), self.answer)
+
+        Notification.send_new_answer_comment(answer_comment)
+
+        html_render_call = self._get_html_render_call(mock_render_template)
+        self.assertEqual(html_render_call.kwargs['instructor_label'], CourseRole.teaching_assistant.value)
+
+    @mock.patch('compair.notifications.notification.send_message')
+    @mock.patch('compair.notifications.notification.render_template')
+    def test_instructor_label_none_for_student_author(self, mock_render_template, mock_send_message):
+        Notification.send_new_answer_comment(self.answer_comment)
+
+        html_render_call = self._get_html_render_call(mock_render_template)
+        self.assertIsNone(html_render_call.kwargs['instructor_label'])
+
+    @mock.patch('compair.notifications.notification.send_message')
+    @mock.patch('compair.notifications.notification.render_template')
+    def test_sanitized_content_passed_to_template(self, mock_render_template, mock_send_message):
+        self.answer_comment.content = '<p>hello</p><script>alert("xss")</script>'
+
+        with mock.patch('compair.notifications.notification.nh3.clean', wraps=nh3.clean) as mock_clean:
+            Notification.send_new_answer_comment(self.answer_comment)
+
+        mock_clean.assert_called_once_with(self.answer_comment.content)
+
+        html_render_call = self._get_html_render_call(mock_render_template)
+        sanitized = html_render_call.kwargs['sanitized_comment_content']
+        self.assertNotIn('<script>', sanitized)
+        self.assertIn('<p>hello</p>', sanitized)
+
+    @mock.patch('compair.notifications.notification.send_message')
+    @mock.patch('compair.notifications.notification.render_template')
+    def test_none_content_passes_empty_string_to_template(self, mock_render_template, mock_send_message):
+        self.answer_comment.content = None
+
+        Notification.send_new_answer_comment(self.answer_comment)
+
+        html_render_call = self._get_html_render_call(mock_render_template)
+        self.assertEqual(html_render_call.kwargs['sanitized_comment_content'], '')


### PR DESCRIPTION
- Test app after Python 3.10 upgrade. Checked:
     - General app functionality
     - Unit tests are fine
     - Celery job queue getting tasks (`send_message`, `set_passwords` `update_lti_course_grades`/`update_lti_assignment_grades`, `emit_lrs_xapi_statement`/`emit_lrs_caliper_event`)
- `clean_html` removed from jinja env globals because it's currently just used in one template. Changed it to pass in the cleaned html using `nh3.clean` as a template variable instead
     - It's only being used in this template because on the UI, Angular directive `rich-content` calls `$sanitize` to sanitize the displayed values
     - Need to call `nh3.clean` to sanitize this just in case
- Added tests for notifications to ensure `nh3.clean` is called and we're getting `sanitized_comment_content` as expected
- `python3-saml`'s `parse_remote` to take `ENFORCE_SSL` into account