### PR TITLE
Fix self eval not shown for students with no comparisons

### DIFF
--- a/compair/api/assignment.py
+++ b/compair/api/assignment.py
@@ -1007,7 +1007,7 @@ class AssignmentUsersComparisonsAPI(Resource):
                         AnswerComment.assignment_id == assignment.id
                 ))
 
-            # get comparison answers and self-evaluation comments
+            # get comparison comments and self-evaluation comments
             answer_comments = AnswerComment.query \
                 .filter_by(assignment_id=assignment.id) \
                 .filter(or_(*conditions)) \

--- a/compair/api/assignment.py
+++ b/compair/api/assignment.py
@@ -1,5 +1,6 @@
 import datetime
 import dateutil.parser
+from collections import defaultdict
 
 from bouncer.constants import READ, EDIT, CREATE, DELETE, MANAGE
 from flask import Blueprint, current_app
@@ -983,57 +984,55 @@ class AssignmentUsersComparisonsAPI(Resource):
                 )) \
                 .all()
 
-            # retrieve the answer comments
+            # map student comparer's user_id to a set of answer IDs they compared
             user_comparison_answers = {}
             for comparison in comparisons:
                 user_answers = user_comparison_answers.setdefault(comparison.user_id, set())
                 user_answers.add(comparison.answer1_id)
                 user_answers.add(comparison.answer2_id)
 
-            conditions = []
+            conditions = [
+                and_(
+                    AnswerComment.comment_type == AnswerCommentType.self_evaluation,
+                    AnswerComment.user_id == user_id,
+                    AnswerComment.assignment_id == assignment.id
+                )
+                for user_id in user_ids
+            ]
             for user_id, answer_set in user_comparison_answers.items():
                 conditions.append(and_(
                         AnswerComment.comment_type == AnswerCommentType.evaluation,
                         AnswerComment.user_id == user_id,
-                        AnswerComment.answer_id.in_(list(answer_set)),
+                        AnswerComment.answer_id.in_(answer_set),
                         AnswerComment.assignment_id == assignment.id
                 ))
-                conditions.append(and_(
-                    AnswerComment.comment_type == AnswerCommentType.self_evaluation,
-                    AnswerComment.user_id == user_id,
-                    AnswerComment.assignment_id == assignment.id
-                ))
 
+            # get comparison answers and self-evaluation comments
             answer_comments = AnswerComment.query \
                 .filter_by(assignment_id=assignment.id) \
                 .filter(or_(*conditions)) \
                 .filter_by(draft=False) \
                 .all()
 
-            # add comparison answer evaluation comments to comparison object
-            for comparison in comparisons:
-                comparison.answer1_feedback = [comment for comment in answer_comments if
-                    comment.user_id == comparison.user_id and
-                    comment.answer_id == comparison.answer1_id and
-                    comment.comment_type == AnswerCommentType.evaluation
-                ]
+            eval_comments = defaultdict(list)
+            self_eval_comments = defaultdict(list)
+            for comment in answer_comments:
+                if comment.comment_type == AnswerCommentType.evaluation:
+                    eval_comments[(comment.user_id, comment.answer_id)].append(comment)
+                elif comment.comment_type == AnswerCommentType.self_evaluation:
+                    self_eval_comments[comment.user_id].append(comment)
 
-                comparison.answer2_feedback = [comment for comment in answer_comments if
-                    comment.user_id == comparison.user_id and
-                    comment.answer_id == comparison.answer2_id and
-                    comment.comment_type == AnswerCommentType.evaluation
-                ]
+            user_comparisons = defaultdict(list)
+            for comparison in comparisons:
+                comparison.answer1_feedback = eval_comments[(comparison.user_id, comparison.answer1_id)]
+                comparison.answer2_feedback = eval_comments[(comparison.user_id, comparison.answer2_id)]
+                user_comparisons[comparison.user_id].append(comparison)
 
             for user in page.items:
                 comparison_sets.append({
                     'user': user,
-                    'comparisons': [comparison for comparison in comparisons if
-                        comparison.user_id == user.id
-                    ],
-                    'self_evaluations': [comment for comment in answer_comments if
-                        comment.user_id == user.id and
-                        comment.comment_type == AnswerCommentType.self_evaluation
-                    ]
+                    'comparisons': user_comparisons[user.id],
+                    'self_evaluations': self_eval_comments[user.id]
                 })
 
 

--- a/compair/tests/api/test_assignment.py
+++ b/compair/tests/api/test_assignment.py
@@ -7,7 +7,7 @@ import mock
 from data.fixtures import DefaultFixture
 from data.fixtures.test_data import SimpleAssignmentTestData, ComparisonTestData, \
     TestFixture, LTITestData, AnswerFactory
-from data.factories import AssignmentFactory
+from data.factories import AssignmentFactory, AnswerCommentFactory
 from compair.models import Assignment, Comparison, PairingAlgorithm, \
     CourseGrade, AssignmentGrade, SystemRole, CourseRole, LTIOutcome, \
     AnswerCommentType, WinningAnswer
@@ -2184,6 +2184,34 @@ class AssignmentUserComparisonsAPITests(ComPAIRAPITestCase):
             self.assertEqual(rv.json['total'], total_number_of_students)
             self.assertEqual(rv.json['comparison_total'], total_comparisons)
             self.assertEqual(rv.json['self_evaluation_total'], total_self_evaluations)
+
+    def test_self_eval_only_student_appears_in_all_comparisons(self):
+        # student with an answer and self-eval but zero comparisons should appear
+        # in the unfiltered "All Comparisons" view with their self-eval populated
+        url = f'/api/courses/{self.fixtures.course.uuid}/assignments/{self.fixtures.assignment.uuid}/users/comparisons'
+
+        # add a new student with only an answer and self-eval, no comparisons
+        new_student = self.fixtures.add_students(1).students[-1]
+        self.fixtures.add_answer(self.fixtures.assignment, new_student)
+        answer = self.fixtures.answers[-1]
+        AnswerCommentFactory(
+            user=new_student,
+            answer=answer,
+            comment_type=AnswerCommentType.self_evaluation,
+            draft=False
+        )
+        db.session.commit()
+
+        with self.login(self.fixtures.instructor.username):
+            rv = self.client.get(url, data=json.dumps({}), content_type='application/json')
+            self.assert200(rv)
+
+            user_ids = [obj['user']['id'] for obj in rv.json['objects']]
+            self.assertIn(new_student.uuid, user_ids)
+
+            new_student_set = next(obj for obj in rv.json['objects'] if obj['user']['id'] == new_student.uuid)
+            self.assertEqual(len(new_student_set['comparisons']), 0)
+            self.assertEqual(len(new_student_set['self_evaluations']), 1)
 
     def test_get_current_user_comparisons(self):
         url = '/api/courses/'+self.fixtures.course.uuid+'/assignments/'+self.fixtures.assignment.uuid+'/user/comparisons'

--- a/compair/tests/api/test_assignment.py
+++ b/compair/tests/api/test_assignment.py
@@ -7,10 +7,9 @@ import mock
 from data.fixtures import DefaultFixture
 from data.fixtures.test_data import SimpleAssignmentTestData, ComparisonTestData, \
     TestFixture, LTITestData, AnswerFactory
-from data.factories import AssignmentFactory, AnswerCommentFactory
+from data.factories import AnswerCommentFactory
 from compair.models import Assignment, Comparison, PairingAlgorithm, \
-    CourseGrade, AssignmentGrade, SystemRole, CourseRole, LTIOutcome, \
-    AnswerCommentType, WinningAnswer
+    CourseGrade, AssignmentGrade, SystemRole, AnswerCommentType, WinningAnswer
 from compair.tests.test_compair import ComPAIRAPITestCase, ComPAIRAPIDemoTestCase
 from compair.core import db
 


### PR DESCRIPTION
Students who submitted a self-evaluation but completed zero comparisons were not appearing in the instructor "All Comparisons" view, causing instructors to miss grading their work.

**Root Cause**
In `AssignmentUsersComparisonsAPI`, the query conditions for fetching `answer_comments` were built only from users who had completed comparisons. Users with only a self-evaluation had no condition added for them, so their self-evaluation was never fetched and the response returned empty for them.

**Changes**
`compair/api/assignment.py`
  - Initialize conditions with a self-evaluation condition for every user on the current page, so users with no comparisons still have their self-eval fetched
  - Refactored O(n²) list comprehensions into O(1) defaultdict lookups when grouping evaluation comments, self-evaluations, and comparisons by user

`compair/tests/api/test_assignment.py`
  - Added test verifying a student with only an answer and self-evaluation (no comparisons) appears in the unfiltered "All Comparisons" response with their self-evaluation populated