### PR TITLE
Remove #1092: flask-bouncer incompatible with Flask 3, add flask_bouncer.py with fix

### DIFF
--- a/compair/__init__.py
+++ b/compair/__init__.py
@@ -5,7 +5,7 @@ import requests
 import re
 
 from flask import Flask, redirect, session as sess, jsonify, url_for, make_response
-from flask_bouncer import ensure
+from compair.flask_bouncer import ensure
 from markupsafe import Markup
 from flask_login import current_user
 from sqlalchemy.orm import joinedload

--- a/compair/api/answer.py
+++ b/compair/api/answer.py
@@ -2,7 +2,7 @@ import datetime
 
 from bouncer.constants import CREATE, READ, EDIT, MANAGE, DELETE
 from flask import Blueprint, current_app
-from flask_bouncer import can
+from compair.flask_bouncer import can
 from flask_login import login_required, current_user
 from flask_restx import Resource, marshal
 from flask_restx.reqparse import RequestParser

--- a/compair/api/answer_comment.py
+++ b/compair/api/answer_comment.py
@@ -1,6 +1,6 @@
 from bouncer.constants import CREATE, READ, EDIT, DELETE, MANAGE
 from flask import Blueprint
-from flask_bouncer import can
+from compair.flask_bouncer import can
 from flask_login import login_required, current_user
 from flask_restx import Resource, marshal
 from flask_restx.reqparse import RequestParser

--- a/compair/api/assignment.py
+++ b/compair/api/assignment.py
@@ -3,7 +3,7 @@ import dateutil.parser
 
 from bouncer.constants import READ, EDIT, CREATE, DELETE, MANAGE
 from flask import Blueprint, current_app
-from flask_bouncer import can
+from compair.flask_bouncer import can
 from flask_login import login_required, current_user
 from flask_restx import Resource, marshal
 from flask_restx.reqparse import RequestParser

--- a/compair/api/assignment_search_enddate.py
+++ b/compair/api/assignment_search_enddate.py
@@ -6,7 +6,7 @@ import pytz
 
 from bouncer.constants import READ, EDIT, CREATE, DELETE, MANAGE
 from flask import Blueprint, current_app
-from flask_bouncer import can
+from compair.flask_bouncer import can
 from flask_login import login_required, current_user
 from flask_restx import Resource, marshal
 from flask_restx.reqparse import RequestParser

--- a/compair/api/classlist.py
+++ b/compair/api/classlist.py
@@ -4,7 +4,7 @@ import unicodecsv as csv
 
 from bouncer.constants import EDIT, READ, MANAGE
 from flask import Blueprint, request, current_app, make_response
-from flask_bouncer import can
+from compair.flask_bouncer import can
 from flask_login import login_required, current_user
 from flask_restx import Resource, marshal
 from flask_restx.reqparse import RequestParser

--- a/compair/api/comparison.py
+++ b/compair/api/comparison.py
@@ -3,7 +3,7 @@ import datetime
 
 from bouncer.constants import READ, CREATE, EDIT, MANAGE
 from flask import Blueprint, current_app
-from flask_bouncer import can
+from compair.flask_bouncer import can
 from flask_login import login_required, current_user
 from flask_restx import Resource, marshal
 from flask_restx.reqparse import RequestParser

--- a/compair/api/group_user.py
+++ b/compair/api/group_user.py
@@ -1,6 +1,6 @@
 from bouncer.constants import EDIT, READ, CREATE, DELETE, MANAGE
 from flask import Blueprint, current_app, request
-from flask_bouncer import can
+from compair.flask_bouncer import can
 from flask_restx import Resource, marshal
 from flask_restx.reqparse import RequestParser
 from flask_login import login_required

--- a/compair/api/users.py
+++ b/compair/api/users.py
@@ -4,7 +4,7 @@ import pytz
 
 from flask import Blueprint, current_app, session as sess
 from bouncer.constants import MANAGE, EDIT, CREATE, READ
-from flask_bouncer import can
+from compair.flask_bouncer import can
 from flask_restx import Resource, marshal
 from flask_restx.reqparse import RequestParser
 from flask_login import login_required, current_user

--- a/compair/authorization.py
+++ b/compair/authorization.py
@@ -1,5 +1,5 @@
 from bouncer.constants import ALL, MANAGE, EDIT, READ, CREATE, DELETE
-from flask_bouncer import can, ensure
+from compair.flask_bouncer import can, ensure
 from flask_login import current_user
 from werkzeug.exceptions import Forbidden
 from sqlalchemy import and_

--- a/compair/core.py
+++ b/compair/core.py
@@ -4,7 +4,7 @@
 from blinker import Namespace
 from werkzeug.exceptions import HTTPException
 from flask import session as sess, abort as flask_abort
-from flask_bouncer import Bouncer
+from compair.flask_bouncer import Bouncer
 from celery import Celery
 from flask_mail import Mail
 import string

--- a/compair/flask_bouncer.py
+++ b/compair/flask_bouncer.py
@@ -1,0 +1,204 @@
+# Vendored from flask-bouncer==0.3.0 with Flask 3 compatibility fix:
+# _app_ctx_stack was removed in Flask 3; get_app() removed (unused in this codebase).
+from functools import wraps
+
+from flask import request, g, current_app, has_app_context
+from werkzeug.local import LocalProxy
+from werkzeug.exceptions import Forbidden
+from bouncer import Ability
+from bouncer.constants import *
+
+
+# Convenient references
+_bouncer = LocalProxy(lambda: current_app.extensions['bouncer'])
+
+
+def ensure(action, subject):
+    request._authorized = True
+    current_user = _bouncer.get_current_user()
+    ability = Ability(current_user)
+    ability.authorization_method = _bouncer.get_authorization_method()
+    ability.aliased_actions = _bouncer.alias_actions
+    if ability.cannot(action, subject):
+        msg = "{0} does not have {1} access to {2}".format(current_user, action, subject)
+        raise Forbidden(msg)
+
+
+def can(action, subject):
+    request._authorized = True
+    current_user = _bouncer.get_current_user()
+    ability = Ability(current_user)
+    ability.authorization_method = _bouncer.get_authorization_method()
+    ability.aliased_actions = _bouncer.alias_actions
+    return ability.can(action, subject)
+
+
+# alias
+bounce = ensure
+
+
+class Condition(object):
+
+    def __init__(self, action, subject):
+        self.action = action
+        self.subject = subject
+
+    def test(self):
+        ensure(self.action, self.subject)
+
+
+def requires(action, subject):
+    def decorator(f):
+        f._explict_rule_set = True
+
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            Condition(action, subject).test()
+            return f(*args, **kwargs)
+        return decorated_function
+    return decorator
+
+
+def skip_authorization(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        request._authorized = True
+        return f(*args, **kwargs)
+    return decorated_function
+
+
+class Bouncer(object):
+
+    """This class is used to control the Abilities Integration to one or more Flask applications"""
+
+    special_methods = ["get", "put", "patch", "post", "delete", "index"]
+
+    def __init__(self, app=None, **kwargs):
+
+        self.authorization_method_callback = None
+        self._alias_actions = self.default_alias_actions()
+        self._authorization_method = None
+        self.flask_classy_classes = list()
+        self.explict_rules = list()
+        self.get_current_user = self.default_user_loader
+
+        self.app = None
+
+        if app is not None:
+            self.init_app(app, **kwargs)
+
+    def get_app(self, reference_app=None):
+        if reference_app is not None:
+            return reference_app
+
+        if self.app is not None:
+            return self.app
+
+        if has_app_context():
+            return current_app
+
+        raise RuntimeError('Application not registered on Bouncer'
+                           ' instance and no application bound'
+                           ' to current context')
+
+    def init_app(self, app, **kwargs):
+        """ Initializes the Flask-Bouncer extension for the specified application.
+
+        :param app: The application.
+        """
+        self.app = app
+
+        self._init_extension()
+
+        self.app.before_request(self.check_implicit_rules)
+
+        if kwargs.get('ensure_authorization', False):
+            self.app.after_request(self.check_authorization)
+
+    def _init_extension(self):
+        if not hasattr(self.app, 'extensions'):
+            self.app.extensions = dict()
+
+        self.app.extensions['bouncer'] = self
+
+    def check_authorization(self, response):
+        """checks that an authorization call has been made during the request"""
+        if not hasattr(request, '_authorized'):
+            raise Forbidden
+        elif not request._authorized:
+            raise Forbidden
+        return response
+
+    def check_implicit_rules(self):
+        """ if you are using flask classy are using the standard index,new,put,post, etc ... type routes, we will
+            automatically check the permissions for you
+        """
+        if not self.request_is_managed_by_flask_classy():
+            return
+
+        if self.method_is_explictly_overwritten():
+            return
+
+        class_name, action = request.endpoint.split(':')
+        clazz = [classy_class for classy_class in self.flask_classy_classes if classy_class.__name__ == class_name][0]
+        Condition(action, clazz.__target_model__).test()
+
+    def method_is_explictly_overwritten(self):
+        view_func = current_app.view_functions[request.endpoint]
+        return hasattr(view_func, '_explict_rule_set') and view_func._explict_rule_set is True
+
+    def request_is_managed_by_flask_classy(self):
+        if request.endpoint is None:
+            return False
+        if ':' not in request.endpoint:
+            return False
+        class_name, action = request.endpoint.split(':')
+        return any(class_name == classy_class.__name__ for classy_class in self.flask_classy_classes) \
+            and action in self.special_methods
+
+    def default_user_loader(self):
+        if hasattr(g, 'current_user'):
+            return g.current_user
+        elif hasattr(g, 'user'):
+            return g.user
+        else:
+            raise Exception("Excepting current_user on flask's g")
+
+    def user_loader(self, value):
+        """
+        Use this method decorator to overwrite the default user loader
+        """
+        self.get_current_user = value
+        return value
+
+    @property
+    def alias_actions(self):
+        return self._alias_actions
+
+    @alias_actions.setter
+    def alias_actions(self, value):
+        """if you want to override your actions"""
+        self._alias_actions = value
+
+    def default_alias_actions(self):
+        return {
+            READ: [INDEX, SHOW, GET],
+            CREATE: [NEW, PUT, POST],
+            UPDATE: [EDIT, PATCH]
+        }
+
+    def monitor(self, *classy_routes):
+        self.flask_classy_classes.extend(classy_routes)
+
+    def authorization_method(self, value):
+        """
+        the callback for defining user abilities
+        """
+        self._authorization_method = value
+        return self._authorization_method
+
+    def get_authorization_method(self):
+        if self._authorization_method is not None:
+            return self._authorization_method
+        else:
+            raise Exception('Expected authorication method to be set')

--- a/compair/flask_bouncer.py
+++ b/compair/flask_bouncer.py
@@ -1,5 +1,5 @@
 # Vendored from flask-bouncer==0.3.0 with Flask 3 compatibility fix:
-# _app_ctx_stack was removed in Flask 3; get_app() removed (unused in this codebase).
+# _app_ctx_stack was removed in Flask 3
 from functools import wraps
 
 from flask import request, g, current_app, has_app_context
@@ -86,20 +86,6 @@ class Bouncer(object):
 
         if app is not None:
             self.init_app(app, **kwargs)
-
-    def get_app(self, reference_app=None):
-        if reference_app is not None:
-            return reference_app
-
-        if self.app is not None:
-            return self.app
-
-        if has_app_context():
-            return current_app
-
-        raise RuntimeError('Application not registered on Bouncer'
-                           ' instance and no application bound'
-                           ' to current context')
 
     def init_app(self, app, **kwargs):
         """ Initializes the Flask-Bouncer extension for the specified application.

--- a/compair/flask_bouncer.py
+++ b/compair/flask_bouncer.py
@@ -201,4 +201,4 @@ class Bouncer(object):
         if self._authorization_method is not None:
             return self._authorization_method
         else:
-            raise Exception('Expected authorication method to be set')
+            raise Exception('Expected authorization method to be set')

--- a/compair/tests/api/test_demo.py
+++ b/compair/tests/api/test_demo.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import json
 import datetime
 
-from flask_bouncer import ensure
+from compair.flask_bouncer import ensure
 from flask_login import login_user, logout_user
 from werkzeug.exceptions import Unauthorized
 

--- a/compair/tests/api/test_users.py
+++ b/compair/tests/api/test_users.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import json
 import datetime
 
-from flask_bouncer import can, MANAGE, CREATE, EDIT, DELETE, READ
+from compair.flask_bouncer import can, MANAGE, CREATE, EDIT, DELETE, READ
 from flask_login import login_user, logout_user
 from werkzeug.exceptions import Unauthorized
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ SQLAlchemy==1.4.36
 blinker==1.9.0
 bouncer==0.1.12
 factory_boy==3.2.1
-flask-bouncer==0.3.0
 passlib==1.7.4
 python-dateutil==2.8.2
 duration==1.1.1


### PR DESCRIPTION
`_app_ctx_stack` was deprecated in Flask 2.3+ and was removed in Flask 3. We need to fix this if flask-bouncer doesn't support Flask 3. There is an open PR to fix it but it looks like the project isn't active anymore.