### PR TITLE
ci: modernize pipeline (branch builds, hardened deploys, multi-arch)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,15 @@ name: Test and Deploy
 
 on:
   push:
-    branches: [ 'master' ]
+    branches: [ '**' ]
     tags: [ '*' ]
   pull_request:
     branches: [ 'master' ]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   unit_test_backend:
@@ -59,8 +63,6 @@ jobs:
   deploy_assets:
     runs-on: ubuntu-latest
     needs: [ unit_test_backend, unit_test_frontend ]
-    # only deploy master and tagged releases
-    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
@@ -85,9 +87,7 @@ jobs:
 
   deploy_docker_image:
     runs-on: ubuntu-latest
-    needs: [ deploy_assets ]
-    # only deploy master and tagged releases
-    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
+    needs: [ unit_test_backend, unit_test_frontend ]
     steps:
     - uses: actions/checkout@v3
     - name: Publish to Registry

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,7 @@ jobs:
         tags: |
           type=ref,event=branch
           type=ref,event=tag
+          type=sha
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,7 @@ jobs:
   deploy_assets:
     runs-on: ubuntu-latest
     needs: [ unit_test_backend, unit_test_frontend ]
+    if: github.event_name != 'pull_request'
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
@@ -75,27 +76,42 @@ jobs:
     - name: Generate assets
       run: |
         node_modules/gulp/bin/gulp.js prod
-    - uses: shallwefootball/s3-upload-action@master
-      name: Upload S3
-      id: S3
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws_key_id: ${{ secrets.AWS_KEY_ID }}
-        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws_bucket: compair-assets
-        source_dir: compair/static/dist
-        destination_dir: dist
+        aws-access-key-id: ${{ secrets.AWS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
+    - name: Upload to S3
+      run: aws s3 sync compair/static/dist s3://compair-assets/dist
 
   deploy_docker_image:
     runs-on: ubuntu-latest
     needs: [ unit_test_backend, unit_test_frontend ]
+    if: github.event_name != 'pull_request'
     steps:
     - uses: actions/checkout@v3
-    - name: Publish to Registry
-      uses: docker/build-push-action@v1
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ubcctlt/compair-app
+        tags: |
+          type=ref,event=branch
+          type=ref,event=tag
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-        repository: ubcctlt/compair-app
-        tag_with_ref: true
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
 
   # TODO: add acceptance testing (would be easier with a slight rewrite to gulp/generate_index)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ vars.AWS_REGION }}
     - name: Upload to S3
-      run: aws s3 sync compair/static/dist s3://compair-assets/dist
+      run: aws s3 cp compair/static/dist s3://compair-assets/dist --recursive
 
   deploy_docker_image:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,8 @@ jobs:
         tags: |
           type=ref,event=branch
           type=ref,event=tag
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Log in to Docker Hub
@@ -111,7 +113,10 @@ jobs:
       with:
         context: .
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
   # TODO: add acceptance testing (would be easier with a slight rewrite to gulp/generate_index)


### PR DESCRIPTION
## Summary

Modernize the GitHub Actions pipeline so feature branches build and publish container images, deprecated/abandoned third-party actions are replaced with maintained ones, and Docker images are produced for both `linux/amd64` and `linux/arm64`.

## Changes

### Trigger and concurrency
- `push` now matches all branches (`'**'`), not just `master`.
- Top-level `concurrency` block keyed on `head_ref || ref` with `cancel-in-progress: true` so a `push` and a `pull_request` for the same ref no longer double-run.

### Deploy gating
- Dropped the master/tag `if:` from `deploy_assets` and `deploy_docker_image`.
- Replaced with `if: github.event_name != 'pull_request'` so fork PRs cannot pull secrets, while every internal branch push still produces artifacts.

### Asset upload
- Removed `shallwefootball/s3-upload-action@master` (abandoned, mutable `@master` ref).
- Replaced with `aws-actions/configure-aws-credentials@v4` + `aws s3 cp --recursive` (matches the existing IAM policy which lacks `s3:ListBucket`).

### Docker publish
- Upgraded `docker/build-push-action@v1` (deprecated) to the modern stack:
  - `docker/metadata-action@v5` for tag computation
  - `docker/setup-qemu-action@v3` for cross-arch emulation
  - `docker/setup-buildx-action@v3` for the BuildKit builder
  - `docker/login-action@v3` for Docker Hub auth
  - `docker/build-push-action@v6`
- `platforms: linux/amd64,linux/arm64` produces a single multi-arch manifest list per tag.
- GitHub Actions cache (`type=gha`, `mode=max`) offsets the cost of arm64 emulation.
- Tags published per build:
  - `ubcctlt/compair-app:<branch>` (e.g. `ci-modernize-pipeline`)
  - `ubcctlt/compair-app:<tag>` on tag pushes
  - `ubcctlt/compair-app:sha-<short>` immutable per-commit

## Required repo configuration

Before merging, add a repository **variable** (Settings → Secrets and variables → Actions → Variables tab):

- `AWS_REGION` — set to the region of the `compair-assets` bucket (`ca-central-1`).

The new `aws-actions/configure-aws-credentials` action requires this; the previous action did not.

## Validation

Verified end-to-end on `feat/dragonballz` (https://github.com/ubc/compair/actions/runs/25510207296):
- backend tests, frontend tests, asset upload, and multi-arch Docker push all green
- image manifest contains both `linux/amd64` and `linux/arm64`
- `sha-<short>` tag confirmed alongside the branch tag

## Notes / follow-ups

- Frontend `gulp-bower` flake (`Error: calling transform done when ws.length != 0`) is pre-existing on master and reproduces sporadically on this pipeline too — not introduced here. Worth a separate ticket to serialize the bower tasks or migrate off Bower.
- `actions/checkout@v2/v3` and `setup-python@v4` / `setup-node@v3` are flagged as Node 20-deprecated by GitHub (forced to Node 24 from June 2026). A clean follow-up is to bump those to `@v4`/`@v5`.

## Test plan

- [ ] CI passes on this PR (PR run will exercise the test jobs only — deploy jobs gated to non-PR events).
- [ ] After setting `AWS_REGION`, push to a non-master branch and confirm `deploy_assets` succeeds.
- [ ] Confirm `deploy_docker_image` publishes a multi-arch manifest: `docker buildx imagetools inspect ubcctlt/compair-app:<branch>`.
- [ ] Confirm `sha-<short>` tag exists on Docker Hub for the latest commit.
- [ ] After merge, push to `master` and confirm assets land at `s3://compair-assets/dist/` and the `master` tag is published.