### PR TITLE
Add #1104: Link existing users to CAS/SAML accounts by student number…

### DIFF
--- a/compair/api/classlist.py
+++ b/compair/api/classlist.py
@@ -214,11 +214,30 @@ def import_users(import_type, course, users):
                     u.username = username
                     invalids.append({'user': u, 'message': 'This student number already exists in the file.'})
                     continue
-                # invalid if student number already exists in the system
+                # if student number already exists, link the third party auth to the existing account
                 elif student_number in existing_system_student_numbers:
-                    u.username = username
-                    invalids.append({'user': u, 'message': 'This student number already exists in the system.'})
-                    continue
+                    if import_type == ThirdPartyType.cas.value or import_type == ThirdPartyType.saml.value:
+                        existing_user = existing_system_student_numbers[student_number]
+                        already_linked = existing_user.third_party_auths.filter_by(
+                            third_party_type=ThirdPartyType(import_type)
+                        ).first() is not None
+                        if already_linked:
+                            u.username = username
+                            invalids.append({'user': u, 'message': 'This student number already exists in the system.'})
+                            continue
+                        u = existing_user
+                        u.third_party_auths.append(ThirdPartyUser(
+                            unique_identifier=username,
+                            third_party_type=ThirdPartyType(import_type)
+                        ))
+                        import_usernames.append(username)
+                        import_student_numbers.append(student_number)
+                        imported_users.append((u, user.get('group')))
+                        continue
+                    else:
+                        u.username = username
+                        invalids.append({'user': u, 'message': 'This student number already exists in the system.'})
+                        continue
 
             u.system_role = SystemRole.student
             u.displayname = user.get('displayname') if user.get('displayname') else display_name_generator()
@@ -442,7 +461,7 @@ class ClasslistRootAPI(Resource):
         uploaded_file.save(tmp_name)
         current_app.logger.debug("Importing for course " + str(course.id) + " with " + filename)
         with open(tmp_name, 'rb') as csvfile:
-            spamreader = csv.reader(csvfile)
+            spamreader = csv.reader(csvfile, encoding='utf-8-sig')
             users = []
             for row in spamreader:
                 if row:

--- a/compair/static/modules/classlist/classlist-import-partial.html
+++ b/compair/static/modules/classlist/classlist-import-partial.html
@@ -19,7 +19,7 @@
                 "studentuser1, pass1234, 005678, , ,jane.doe@student.ca, display0001, Group 2</li>
             </ul>
             <ul class="li-spacing" ng-if="importType == ThirdPartyAuthType.cas || importType == ThirdPartyAuthType.saml">
-                <li>Students will log in using their CWL. The usernames in your file must match the students' CWLs.</li>
+                <li>Students will log in using their CWL. However, the usernames in your file must be the students' PUIDs, not their CWL usernames.</li>
                 <li>User information is expected in this order: <strong><span class="required-star">Username</span>, Student Number, First Name, Last Name, Email, Display Name, Group</strong></li>
                 <li>Usernames are required. All other information is optional. Usernames and student numbers must also be unique in the application.</li>
                 <li>To skip non-required information, simply leave a blank space between commas, e.g., to leave out first and last name:<br />

--- a/compair/tests/api/test_classlist.py
+++ b/compair/tests/api/test_classlist.py
@@ -967,6 +967,18 @@ class ClassListAPITest(ComPAIRAPITestCase):
             self.assertIsNotNone(enrollment)
             uploaded_file.close()
 
+            # test new CAS username with student number matching user that already has CAS auth — rejects
+            content = "another_cas_username," + student.student_number
+            uploaded_file = io.BytesIO(content.encode('utf-8'))
+            rv = self.client.post(url, data=dict(file=(uploaded_file, filename), import_type=ThirdPartyType.cas.value))
+            self.assert200(rv)
+            result = rv.json
+            self.assertEqual(0, result['success'])
+            self.assertEqual(1, len(result['invalids']))
+            self.assertEqual("another_cas_username", result['invalids'][0]['user']['username'])
+            self.assertEqual('This student number already exists in the system.', result['invalids'][0]['message'])
+            uploaded_file.close()
+
             # test duplicate student number in file
             content = "".join([
                 cas_student.unique_identifier, ",", student.student_number, "\n",
@@ -1237,6 +1249,18 @@ class ClassListAPITest(ComPAIRAPITestCase):
                 course_role=CourseRole.student
             ).first()
             self.assertIsNotNone(enrollment)
+            uploaded_file.close()
+
+            # test new SAML username with student number matching user that already has SAML auth — rejects
+            content = "another_saml_username," + student.student_number
+            uploaded_file = io.BytesIO(content.encode('utf-8'))
+            rv = self.client.post(url, data=dict(file=(uploaded_file, filename), import_type=ThirdPartyType.saml.value))
+            self.assert200(rv)
+            result = rv.json
+            self.assertEqual(0, result['success'])
+            self.assertEqual(1, len(result['invalids']))
+            self.assertEqual("another_saml_username", result['invalids'][0]['user']['username'])
+            self.assertEqual('This student number already exists in the system.', result['invalids'][0]['message'])
             uploaded_file.close()
 
             # test duplicate student number in file

--- a/compair/tests/api/test_classlist.py
+++ b/compair/tests/api/test_classlist.py
@@ -7,7 +7,7 @@ import unicodecsv as csv
 from compair.core import db
 from data.fixtures.test_data import BasicTestData, ThirdPartyAuthTestData
 from compair.tests.test_compair import ComPAIRAPITestCase, ComPAIRAPIDemoTestCase
-from compair.models import CourseRole, UserCourse, ThirdPartyType, Course, Group
+from compair.models import CourseRole, UserCourse, ThirdPartyType, ThirdPartyUser, Course, Group
 
 
 class ClassListAPITest(ComPAIRAPITestCase):
@@ -939,6 +939,34 @@ class ClassListAPITest(ComPAIRAPITestCase):
             self.assertEqual('This student number already exists in the system.', result['invalids'][0]['message'])
             uploaded_file.close()
 
+            # test new CAS username with student number matching existing local user — links them
+            local_user = self.data.create_normal_user()
+            new_cas_username = 'new_cas_username'
+            content = new_cas_username + "," + local_user.student_number
+            uploaded_file = io.BytesIO(content.encode('utf-8'))
+            rv = self.client.post(url, data=dict(file=(uploaded_file, filename), import_type=ThirdPartyType.cas.value))
+            self.assert200(rv)
+            result = rv.json
+            self.assertEqual(1, result['success'])
+            self.assertEqual(0, len(result['invalids']))
+            linked = ThirdPartyUser.query.filter_by(
+                unique_identifier=new_cas_username,
+                third_party_type=ThirdPartyType.cas
+            ).first()
+            self.assertIsNotNone(linked)
+            self.assertEqual(local_user.id, linked.user_id)
+            self.assertIsNotNone(local_user.third_party_auths.filter_by(
+                third_party_type=ThirdPartyType.cas,
+                unique_identifier=new_cas_username
+            ).first())
+            enrollment = UserCourse.query.filter_by(
+                user_id=local_user.id,
+                course_id=self.data.get_course().id,
+                course_role=CourseRole.student
+            ).first()
+            self.assertIsNotNone(enrollment)
+            uploaded_file.close()
+
             # test duplicate student number in file
             content = "".join([
                 cas_student.unique_identifier, ",", student.student_number, "\n",
@@ -1181,6 +1209,34 @@ class ClassListAPITest(ComPAIRAPITestCase):
             self.assertEqual(1, len(result['invalids']))
             self.assertEqual("username1", result['invalids'][0]['user']['username'])
             self.assertEqual('This student number already exists in the system.', result['invalids'][0]['message'])
+            uploaded_file.close()
+
+            # test new SAML username with student number matching existing local user — links them
+            local_user = self.data.create_normal_user()
+            new_saml_username = 'new_saml_username'
+            content = new_saml_username + "," + local_user.student_number
+            uploaded_file = io.BytesIO(content.encode('utf-8'))
+            rv = self.client.post(url, data=dict(file=(uploaded_file, filename), import_type=ThirdPartyType.saml.value))
+            self.assert200(rv)
+            result = rv.json
+            self.assertEqual(1, result['success'])
+            self.assertEqual(0, len(result['invalids']))
+            linked = ThirdPartyUser.query.filter_by(
+                unique_identifier=new_saml_username,
+                third_party_type=ThirdPartyType.saml
+            ).first()
+            self.assertIsNotNone(linked)
+            self.assertEqual(local_user.id, linked.user_id)
+            self.assertIsNotNone(local_user.third_party_auths.filter_by(
+                third_party_type=ThirdPartyType.saml,
+                unique_identifier=new_saml_username
+            ).first())
+            enrollment = UserCourse.query.filter_by(
+                user_id=local_user.id,
+                course_id=self.data.get_course().id,
+                course_role=CourseRole.student
+            ).first()
+            self.assertIsNotNone(enrollment)
             uploaded_file.close()
 
             # test duplicate student number in file


### PR DESCRIPTION
… on import

Previously, importing a CAS/SAML class list CSV would reject any username whose student number matched an existing user in the system. Now, if the existing user has no third-party auth link of the same type, the import links the new CAS/SAML identity to that user instead of rejecting it.

 Also fixes CSV reader to strip UTF-8 BOM via `encoding='utf-8-sig'`.