### PR TITLE
Fix/lti link issue from csv import

### DIFF
--- a/compair/api/classlist.py
+++ b/compair/api/classlist.py
@@ -191,6 +191,7 @@ def import_users(import_type, course, users):
             )
             if import_type == ThirdPartyType.cas.value or import_type == ThirdPartyType.saml.value:
                 # CAS/SAML login
+                u.global_unique_identifier = username
                 u.third_party_auths.append(ThirdPartyUser(
                     unique_identifier=username,
                     third_party_type=ThirdPartyType(import_type)

--- a/compair/api/classlist.py
+++ b/compair/api/classlist.py
@@ -180,6 +180,9 @@ def import_users(import_type, course, users):
             # overwrite password if user has not logged in yet
             if u.last_online == None and not password in [None, '*']:
                 set_user_passwords.append((u, password))
+            if (import_type == ThirdPartyType.cas.value or import_type == ThirdPartyType.saml.value) \
+                    and u.global_unique_identifier is None:
+                u.global_unique_identifier = username
         else:
             u = User(
                 username=None,

--- a/compair/api/login.py
+++ b/compair/api/login.py
@@ -279,10 +279,6 @@ def saml_auth():
                 thirdpartyuser.generate_or_link_user_account()
                 db.session.commit()
 
-            if thirdpartyuser.user and thirdpartyuser.user.global_unique_identifier is None:
-                thirdpartyuser.user.global_unique_identifier = unique_identifier
-                db.session.commit()
-
             authenticate(thirdpartyuser.user, login_method=thirdpartyuser.third_party_type.value)
             thirdpartyuser.params = attributes
 

--- a/compair/api/login.py
+++ b/compair/api/login.py
@@ -279,6 +279,10 @@ def saml_auth():
                 thirdpartyuser.generate_or_link_user_account()
                 db.session.commit()
 
+            if thirdpartyuser.user and thirdpartyuser.user.global_unique_identifier is None:
+                thirdpartyuser.user.global_unique_identifier = unique_identifier
+                db.session.commit()
+
             authenticate(thirdpartyuser.user, login_method=thirdpartyuser.third_party_type.value)
             thirdpartyuser.params = attributes
 

--- a/compair/models/lti_models/lti_user.py
+++ b/compair/models/lti_models/lti_user.py
@@ -49,6 +49,13 @@ class LTIUser(DefaultTableMixin, UUIDMixin, WriteTrackingMixin):
                 .filter_by(global_unique_identifier=self.global_unique_identifier) \
                 .one_or_none()
 
+            if not self.compair_user and self.student_number:
+                self.compair_user = User.query \
+                    .filter_by(student_number=self.student_number) \
+                    .one_or_none()
+                if self.compair_user:
+                    self.compair_user.global_unique_identifier = self.global_unique_identifier
+
             if not self.compair_user:
                 self.compair_user = User(
                     username=None,

--- a/compair/models/lti_models/lti_user.py
+++ b/compair/models/lti_models/lti_user.py
@@ -53,7 +53,7 @@ class LTIUser(DefaultTableMixin, UUIDMixin, WriteTrackingMixin):
                 self.compair_user = User.query \
                     .filter_by(student_number=self.student_number) \
                     .one_or_none()
-                if self.compair_user:
+                if self.compair_user and self.compair_user.global_unique_identifier is None:
                     self.compair_user.global_unique_identifier = self.global_unique_identifier
 
             if not self.compair_user:

--- a/compair/tests/test_models.py
+++ b/compair/tests/test_models.py
@@ -7,13 +7,16 @@ import uuid
 
 from compair import db
 from compair.models import User, Comparison, AnswerScore, \
-    AnswerCriterionScore, LTIOutcome, SystemRole
+    AnswerCriterionScore, LTIOutcome, SystemRole, ThirdPartyUser
+from compair.models.lti_models import LTIUser
+from compair.models import ThirdPartyType
 from compair.models.comparison import update_answer_scores, \
     update_answer_criteria_scores
 from compair.tests.test_compair import ComPAIRTestCase
 from compair.algorithms import ComparisonPair, ComparisonWinner
 from compair.algorithms.score import calculate_score
 from data.fixtures.test_data import TestFixture, LTITestData
+from data.factories import LTIConsumerFactory, UserFactory
 
 class TestUsersModel(ComPAIRTestCase):
     user = User()
@@ -114,6 +117,51 @@ class TestUtils(ComPAIRTestCase):
         score = AnswerCriterionScore(answer_id=1, criterion_id=1, id=2)
         scores = update_answer_criteria_scores([score], 1, criterion_comparison_results)
         self.assertEqual(len(scores), 4)
+
+class TestLTIUserGenerateOrLinkAccount(ComPAIRTestCase):
+    def setUp(self):
+        super(TestLTIUserGenerateOrLinkAccount, self).setUp()
+        self.lti_consumer = LTIConsumerFactory(
+            global_unique_identifier_param='custom_puid',
+            student_number_param='custom_student_number'
+        )
+        db.session.commit()
+
+    def test_links_existing_saml_user_by_student_number_when_global_unique_identifier_missing(self):
+        # user created via SAML - has student number but no global_unique_identifier
+        existing_user = UserFactory(
+            system_role=SystemRole.student,
+            student_number='12345678',
+            global_unique_identifier=None,
+            username=None,
+            password=None
+        )
+        ThirdPartyUser(
+            unique_identifier='saml_identifier',
+            third_party_type=ThirdPartyType.saml,
+            user=existing_user
+        )
+        db.session.commit()
+
+        user_count_before = User.query.count()
+
+        lti_user = LTIUser(
+            lti_consumer=self.lti_consumer,
+            user_id='canvas_user_123',
+            system_role=SystemRole.student,
+            global_unique_identifier='puid_abc',
+            student_number='12345678'
+        )
+        db.session.add(lti_user)
+        lti_user.generate_or_link_user_account()
+
+        # no new user should be created
+        self.assertEqual(User.query.count(), user_count_before)
+        # lti_user should be linked to the existing user
+        self.assertEqual(lti_user.compair_user_id, existing_user.id)
+        # global_unique_identifier should be backfilled on the existing user
+        self.assertEqual(existing_user.global_unique_identifier, 'puid_abc')
+
 
 class TestLTIOutcome(ComPAIRTestCase):
 

--- a/compair/tests/test_models.py
+++ b/compair/tests/test_models.py
@@ -162,6 +162,41 @@ class TestLTIUserGenerateOrLinkAccount(ComPAIRTestCase):
         # global_unique_identifier should be backfilled on the existing user
         self.assertEqual(existing_user.global_unique_identifier, 'puid_abc')
 
+    def test_does_not_overwrite_existing_global_unique_identifier_when_linking_by_student_number(self):
+        # user already has a global_unique_identifier set from a prior SAML/CAS login
+        existing_user = UserFactory(
+            system_role=SystemRole.student,
+            student_number='12345678',
+            global_unique_identifier='existing_puid',
+            username=None,
+            password=None
+        )
+        ThirdPartyUser(
+            unique_identifier='saml_identifier',
+            third_party_type=ThirdPartyType.saml,
+            user=existing_user
+        )
+        db.session.commit()
+
+        user_count_before = User.query.count()
+
+        lti_user = LTIUser(
+            lti_consumer=self.lti_consumer,
+            user_id='canvas_user_456',
+            system_role=SystemRole.student,
+            global_unique_identifier='different_puid',
+            student_number='12345678'
+        )
+        db.session.add(lti_user)
+        lti_user.generate_or_link_user_account()
+
+        # no new user should be created
+        self.assertEqual(User.query.count(), user_count_before)
+        # lti_user should be linked to the existing user
+        self.assertEqual(lti_user.compair_user_id, existing_user.id)
+        # existing global_unique_identifier must not be overwritten
+        self.assertEqual(existing_user.global_unique_identifier, 'existing_puid')
+
 
 class TestLTIOutcome(ComPAIRTestCase):
 


### PR DESCRIPTION
Users imported via CSV classlist (CAS/SAML type) were created without global_unique_identifier populated. When these users later attempted to log in via LTI, two things could happen:

  1. `LTIUser` could not match the existing user by `global_unique_identifier` (it was NULL)
  2. If the LTI consumer provided a `student_number`, attempting to create a new user record would fail with a database integrity error due to the unique constraint on `student_number`

  This resulted in an internal server error on LTI login.

  Changes
  `classlist.py` — Root cause fix. When importing users via CSV with CAS/SAML type, set global_unique_identifier to the CAS/SAML identifier at creation time. Prevents the problem for all future imports.

  `lti_models/lti_user.py` — Fallback for existing affected users. During LTI login, if a user cannot be matched by global_unique_identifier, attempt to match by
  student_number. If found, link the LTI user to the existing record and backfill global_unique_identifier.

  `tests/test_models.py` — Adds a test case covering the fallback: a SAML user with a student_number but no global_unique_identifier is correctly linked when logging in via LTI, no duplicate user is created, and global_unique_identifier is backfilled.

  Notes
  - Existing users affected by this issue (created before this fix) will be automatically remediated on their next LTI login via the `student_number` fallback.
  - Grades for any users with duplicate records can be recalculated after merging via flask grades generate --course-id <id>.