### PR TITLE
fix: restrict assignment search enddate endpoint and route to admins …

### DIFF
--- a/compair/api/assignment_search_enddate.py
+++ b/compair/api/assignment_search_enddate.py
@@ -1,25 +1,18 @@
 import datetime
-import dateutil.parser
-import json
 from flask import jsonify
 import pytz
 
-from bouncer.constants import READ, EDIT, CREATE, DELETE, MANAGE
 from flask import Blueprint, current_app
-from compair.flask_bouncer import can
-from flask_login import login_required, current_user
-from flask_restx import Resource, marshal
+from flask_login import login_required
+from flask_restx import Resource
 from flask_restx.reqparse import RequestParser
-from sqlalchemy import desc, or_, func, and_, text
-from sqlalchemy.orm import joinedload, undefer_group, load_only
+from sqlalchemy import text
 
-from . import dataformat
-from compair.core import db, event, abort
-from compair.authorization import require, is_user_access_restricted
-from compair.models import Assignment, Course, Criterion, AssignmentCriterion, Answer, Comparison, \
-    AnswerComment, AnswerCommentType, PairingAlgorithm, Criterion, File, User, UserCourse, \
-    CourseRole, Group
-from .util import new_restful_api, get_model_changes, pagination_parser
+from bouncer.constants import MANAGE
+from compair.core import db
+from compair.authorization import require
+from compair.models import Course
+from .util import new_restful_api
 
 from datetime import datetime
 import time
@@ -38,6 +31,9 @@ def validate(date_text):
 class AssignmentRootAPI1(Resource):
     @login_required
     def get(self):
+        require(MANAGE, Course,
+            title="Assignments Unavailable",
+            message="Sorry, your system role does not allow you to access this endpoint.")
 
         # get app timezone in settings
         appTimeZone = current_app.config.get('APP_TIMEZONE', time.strftime('%Z') )

--- a/compair/api/assignment_search_enddate.py
+++ b/compair/api/assignment_search_enddate.py
@@ -1,4 +1,3 @@
-import datetime
 from flask import jsonify
 import pytz
 
@@ -11,7 +10,7 @@ from sqlalchemy import text
 from bouncer.constants import MANAGE
 from compair.core import db
 from compair.authorization import require
-from compair.models import Course
+from compair.models import User
 from .util import new_restful_api
 
 from datetime import datetime
@@ -31,7 +30,7 @@ def validate(date_text):
 class AssignmentRootAPI1(Resource):
     @login_required
     def get(self):
-        require(MANAGE, Course,
+        require(MANAGE, User,
             title="Assignments Unavailable",
             message="Sorry, your system role does not allow you to access this endpoint.")
 

--- a/compair/static/compair-config.js
+++ b/compair/static/compair-config.js
@@ -479,7 +479,9 @@ myApp.config(
                 controller: 'AssignmentSearchEndDateController',
                 resolve: {
                     resolvedData: function() {
-                        // no data to preload
+                        return ResolveDeferredRouteData({
+                            canManageUsers: RouteResolves.canManageUsers()
+                        }, []);
                     }
                 }
             })

--- a/compair/static/modules/assignment/assignment-module.js
+++ b/compair/static/modules/assignment/assignment-module.js
@@ -926,7 +926,13 @@ module.filter("notScoredEnd", function () {
 
 /***** Assignment Search EndDate Controllers *****/
 module.controller("AssignmentSearchEndDateController",
-    ["$scope", function($scope){
+    ["$scope", "$location", "resolvedData", function($scope, $location, resolvedData){
+            $scope.canManageUsers = resolvedData.canManageUsers;
+
+            if (!$scope.canManageUsers) {
+                $location.path('/');
+                return;
+            }
 
             $scope.searchDate = function() {
                 var formatDate = new Date($scope.dt);

--- a/compair/static/modules/assignment/assignment-search-partial.html
+++ b/compair/static/modules/assignment/assignment-search-partial.html
@@ -10,7 +10,7 @@
             <div class="form-group">
                 <span class="input-group">
                     <!--calendar-->
-                    <div ng-app="ubc.ctlt.compair.assignment" ng-controller="AssignmentSearchEndDateController as ctrlEndDate" >
+                    <div>
                             <div class="input-group" style="width:200px" >
                                 <input type="text" class="form-control" uib-datepicker-popup="yyyy-MMM-dd" ng-model="dt" is-open="isDatepickerOpen" ng-change="searchDate();"  datepicker-options="datepickerOptions" ng-required="true" ng-readonly="true" close-text="Close" alt-input-formats="altInputFormats"/>
                                 <span class="input-group-btn">


### PR DESCRIPTION
The `/api/assignment/search/enddate` endpoint and its corresponding UI route `/app/#/assignment/search/enddate` were accessible to any authenticated user, including students. The endpoint returns a full list of all assignment dates across all courses, which should be admin-only info.

Changes made:
- Added `require(MANAGE, User)` to `AssignmentRootAPI1.get()`. Non-admins will receive a 403 error
- Added `canManageUsers` check via `ResolveDeferredRouteData` so the permission is verified before the controller loads
- Non-admins are silently redirected to `/`, which is consistent with how other admin-only pages behave

This fixes the issue where any logged-in student could go through assignment end dates across all courses in the system by hitting the API directly or by going to this page, bypassing course enrolment checks entirely.