### PR TITLE
Access control hardening for answer submission, user list, and page routing

### DIFF
--- a/compair/api/answer.py
+++ b/compair/api/answer.py
@@ -562,6 +562,11 @@ class AnswerIdAPI(Resource):
         course = Course.get_active_by_uuid_or_404(course_uuid)
         assignment = Assignment.get_active_by_uuid_or_404(assignment_uuid)
         answer = Answer.get_active_by_uuid_or_404(answer_uuid)
+
+        # ensure assignment and answer belong to the course in the URL, not just any course
+        if assignment.course_id != course.id or answer.assignment_id != assignment.id:
+            abort(403, title="Answer Not Deleted", message="Sorry, this answer could not be deleted. Please try again.")
+
         require(DELETE, answer,
             title="Answer Not Deleted",
             message="Sorry, your role in this course does not allow you to delete this answer.")

--- a/compair/api/answer.py
+++ b/compair/api/answer.py
@@ -395,6 +395,9 @@ class AnswerIdAPI(Resource):
 
         answer = Answer.get_active_by_uuid_or_404(answer_uuid)
 
+        if answer.assignment_id != assignment.id:
+            abort(403, title="Answer Not Saved", message="Sorry, this answer could not be saved. Please try again.")
+
         old_file = answer.file
 
         require(EDIT, answer,

--- a/compair/api/answer.py
+++ b/compair/api/answer.py
@@ -395,6 +395,7 @@ class AnswerIdAPI(Resource):
 
         answer = Answer.get_active_by_uuid_or_404(answer_uuid)
 
+        # ensure answer belongs to the assignment in the URL, not just any assignment
         if answer.assignment_id != assignment.id:
             abort(403, title="Answer Not Saved", message="Sorry, this answer could not be saved. Please try again.")
 

--- a/compair/api/answer.py
+++ b/compair/api/answer.py
@@ -203,6 +203,10 @@ class AnswerRootAPI(Resource):
         course = Course.get_active_by_uuid_or_404(course_uuid)
         assignment = Assignment.get_active_by_uuid_or_404(assignment_uuid)
 
+        # ensure assignment belongs to the course in the URL, not just any course
+        if assignment.course_id != course.id:
+            abort(403, title="Answer Not Submitted", message="Sorry, this answer could not be submitted. Please try again.")
+
         if not assignment.answer_grace and not can(MANAGE, assignment):
             abort(403, title="Answer Not Submitted", message="Sorry, the answer deadline has passed. No answers can be submitted after the deadline unless the instructor submits the answer for you.")
 
@@ -381,6 +385,10 @@ class AnswerIdAPI(Resource):
     def post(self, course_uuid, assignment_uuid, answer_uuid):
         course = Course.get_active_by_uuid_or_404(course_uuid)
         assignment = Assignment.get_active_by_uuid_or_404(assignment_uuid)
+
+        # ensure assignment belongs to the course in the URL, not just any course
+        if assignment.course_id != course.id:
+            abort(403, title="Answer Not Saved", message="Sorry, this answer could not be saved. Please try again.")
 
         if not assignment.answer_grace and not can(MANAGE, assignment):
             abort(403, title="Answer Not Submitted", message="Sorry, the answer deadline has passed. No answers can be submitted after the deadline unless the instructor submits the answer for you.")

--- a/compair/api/answer_comment.py
+++ b/compair/api/answer_comment.py
@@ -300,8 +300,8 @@ class AnswerCommentAPI(Resource):
         answer = Answer.get_active_by_uuid_or_404(answer_uuid)
         answer_comment = AnswerComment.get_active_by_uuid_or_404(answer_comment_uuid)
 
-        # ensure assignment and answer belong to the course in the URL, not just any course
-        if assignment.course_id != course.id or answer.assignment_id != assignment.id:
+        # ensure assignment, answer, and comment belong to the course in the URL, not just any course
+        if assignment.course_id != course.id or answer.assignment_id != assignment.id or answer_comment.answer_id != answer.id:
             abort(403, title="Feedback Not Saved",
                 message="Sorry, this feedback could not be saved. Please try again.")
 
@@ -393,8 +393,8 @@ class AnswerCommentAPI(Resource):
         answer = Answer.get_active_by_uuid_or_404(answer_uuid)
         answer_comment = AnswerComment.get_active_by_uuid_or_404(answer_comment_uuid)
 
-        # ensure assignment and answer belong to the course in the URL, not just any course
-        if assignment.course_id != course.id or answer.assignment_id != assignment.id:
+        # ensure assignment, answer, and comment belong to the course in the URL, not just any course
+        if assignment.course_id != course.id or answer.assignment_id != assignment.id or answer_comment.answer_id != answer.id:
             abort(403, title="Feedback Not Deleted", message="Sorry, this feedback could not be deleted. Please try again.")
 
         require(DELETE, answer_comment,

--- a/compair/api/answer_comment.py
+++ b/compair/api/answer_comment.py
@@ -390,7 +390,13 @@ class AnswerCommentAPI(Resource):
         """
         course = Course.get_active_by_uuid_or_404(course_uuid)
         assignment = Assignment.get_active_by_uuid_or_404(assignment_uuid)
+        answer = Answer.get_active_by_uuid_or_404(answer_uuid)
         answer_comment = AnswerComment.get_active_by_uuid_or_404(answer_comment_uuid)
+
+        # ensure assignment and answer belong to the course in the URL, not just any course
+        if assignment.course_id != course.id or answer.assignment_id != assignment.id:
+            abort(403, title="Feedback Not Deleted", message="Sorry, this feedback could not be deleted. Please try again.")
+
         require(DELETE, answer_comment,
             title="Feedback Not Deleted",
             message="Sorry, your role in this course does not allow you to delete feedback for this answer.")

--- a/compair/api/answer_comment.py
+++ b/compair/api/answer_comment.py
@@ -299,6 +299,12 @@ class AnswerCommentAPI(Resource):
         assignment = Assignment.get_active_by_uuid_or_404(assignment_uuid)
         answer = Answer.get_active_by_uuid_or_404(answer_uuid)
         answer_comment = AnswerComment.get_active_by_uuid_or_404(answer_comment_uuid)
+
+        # ensure assignment and answer belong to the course in the URL, not just any course
+        if assignment.course_id != course.id or answer.assignment_id != assignment.id:
+            abort(403, title="Feedback Not Saved",
+                message="Sorry, this feedback could not be saved. Please try again.")
+
         require(EDIT, answer_comment,
             title="Feedback Not Saved",
             message="Sorry, your role in this course does not allow you to save feedback for this answer.")

--- a/compair/api/answer_comment.py
+++ b/compair/api/answer_comment.py
@@ -188,6 +188,12 @@ class AnswerCommentListAPI(Resource):
         course = Course.get_active_by_uuid_or_404(course_uuid)
         assignment = Assignment.get_active_by_uuid_or_404(assignment_uuid)
         answer = Answer.get_active_by_uuid_or_404(answer_uuid)
+
+        # ensure assignment and answer belong to the course in the URL, not just any course
+        if assignment.course_id != course.id or answer.assignment_id != assignment.id:
+            abort(403, title="Feedback Not Saved",
+                message="Sorry, this feedback could not be saved. Please try again.")
+
         require(CREATE, AnswerComment(course_id=course.id),
             title="Feedback Not Saved",
             message="Sorry, your role in this course does not allow you to save feedback for this answer.")

--- a/compair/api/users.py
+++ b/compair/api/users.py
@@ -797,6 +797,10 @@ class UserUpdatePasswordAPI(Resource):
             title="Password Not Saved",
             message="Sorry, your system role does not allow you to update passwords for this user.")
 
+        if current_user.id != user.id and not can(MANAGE, User):
+            abort(403, title="Password Not Saved",
+                message="Sorry, your system role does not allow you to update passwords for this user.")
+
         if not user.uses_compair_login:
             abort(400, title="Password Not Saved",
                 message="Sorry, you cannot update the password since this user does not use the ComPAIR account login method.")

--- a/compair/api/users.py
+++ b/compair/api/users.py
@@ -232,7 +232,7 @@ class UserAPI(Resource):
 class UserListAPI(Resource):
     @login_required
     def get(self):
-        require(READ, USER_IDENTITY,
+        require(MANAGE, User,
             title="User List Unavailable",
             message="Sorry, your system role does not allow you to view the list of users.")
 

--- a/compair/static/compair-config.js
+++ b/compair/static/compair-config.js
@@ -341,6 +341,7 @@ myApp.config(
                     resolvedData: function() {
                         return ResolveDeferredRouteData({
                             loggedInUser: RouteResolves.loggedInUser(),
+                            canAddCourse: RouteResolves.canAddCourse(),
                         }, ['course']);
                     }
                 }

--- a/compair/static/modules/course/course-module.js
+++ b/compair/static/modules/course/course-module.js
@@ -1133,6 +1133,11 @@ module.controller(
         $scope.saveAttempted = false;
 
         $scope.method = $scope.course.id ? "edit" : "create";
+
+        if ($scope.method == "create" && !resolvedData.canAddCourse) {
+            $location.path('/');
+            return;
+        }
         // unlike for assignments, course dates initially blank
         $scope.format = 'dd-MMMM-yyyy';
         $scope.date = {

--- a/compair/static/modules/course/course-module_spec.js
+++ b/compair/static/modules/course/course-module_spec.js
@@ -131,7 +131,16 @@ describe('course-module', function () {
                 beforeEach(function () {
                     controller = createController({}, {
                         loggedInUser: angular.copy(mockUser),
+                        canAddCourse: true,
                     });
+                });
+
+                it('should redirect to home when not authorized', function () {
+                    createController({}, {
+                        loggedInUser: angular.copy(mockUser),
+                        canAddCourse: false,
+                    });
+                    expect($location.path()).toBe('/');
                 });
 
                 it('should be correctly initialized', function () {

--- a/compair/static/modules/route/route-provider_spec.js
+++ b/compair/static/modules/route/route-provider_spec.js
@@ -123,7 +123,7 @@ describe('user-module', function () {
                 $httpBackend.flush();
 
                 expect(Session.getUser).toHaveBeenCalled();
-                expect(Authorize.can).not.toHaveBeenCalled();
+                expect(Authorize.can).toHaveBeenCalledWith(Authorize.CREATE, "Course");
 
                 expect(toaster.error).not.toHaveBeenCalled();
                 expect($rootScope.routeResolveLoadError).toBeUndefined();

--- a/compair/static/modules/user/user-module.js
+++ b/compair/static/modules/user/user-module.js
@@ -115,6 +115,11 @@ module.controller("UserWriteController",
             $scope.system_roles.pop()
         }
 
+        if (!$scope.canManageUsers && ($scope.method == 'create' || !$scope.ownProfile)) {
+            $location.path('/');
+            return;
+        }
+
         if ($scope.method == 'edit') {
             breadcrumbs.options = {'View User': "{0}'s Profile".format($scope.user.displayname)};
         } else if ($scope.method == 'create') {

--- a/compair/static/modules/user/user-module_spec.js
+++ b/compair/static/modules/user/user-module_spec.js
@@ -86,6 +86,14 @@ describe('user-module', function () {
                 });
             });
 
+            it('should redirect to home when not authorized', function () {
+                createController({}, {
+                    canManageUsers: false,
+                    loggedInUser: angular.copy(mockUser),
+                });
+                expect($location.path()).toBe('/');
+            });
+
             it('should be correctly initialized', function () {
                 expect($rootScope.password).toEqual({});
                 expect($rootScope.ownProfile).toBe(false);
@@ -123,6 +131,15 @@ describe('user-module', function () {
                     canManageUsers: true,
                     loggedInUser: angular.copy(mockUser),
                 });
+            });
+
+            it('should redirect to home when not authorized to edit another user', function () {
+                createController({userId: editUser.id}, {
+                    user: editUser,
+                    canManageUsers: false,
+                    loggedInUser: angular.copy(mockUser),
+                });
+                expect($location.path()).toBe('/');
             });
 
             it('should be correctly initialized', function () {

--- a/compair/tests/api/test_answer_comments.py
+++ b/compair/tests/api/test_answer_comments.py
@@ -475,7 +475,7 @@ class AnswerCommentAPITests(ComPAIRAPITestCase):
         comment = self.data.get_answer_comments_by_assignment(self.assignment)[0]
         url = self.get_url(
             course_uuid=self.course.uuid, assignment_uuid=self.assignment.uuid,
-            answer_uuid=self.answers[self.assignment.id][0].uuid, answer_comment_uuid=comment.uuid
+            answer_uuid=self.answers[self.assignment.id][1].uuid, answer_comment_uuid=comment.uuid
         )
 
         content = {
@@ -765,7 +765,7 @@ class AnswerCommentAPITests(ComPAIRAPITestCase):
         comment = self.data.get_answer_comments_by_assignment(self.assignment)[0]
         url = self.get_url(
             course_uuid=self.course.uuid, assignment_uuid=self.assignment.uuid,
-            answer_uuid=self.answers[self.assignment.id][0].uuid, answer_comment_uuid=comment.uuid)
+            answer_uuid=self.answers[self.assignment.id][1].uuid, answer_comment_uuid=comment.uuid)
 
         # test login required
         rv = self.client.delete(url)
@@ -794,7 +794,7 @@ class AnswerCommentAPITests(ComPAIRAPITestCase):
         with self.impersonate(self.data.get_authorized_instructor(), student):
             url = self.get_url(
                 course_uuid=self.course.uuid, assignment_uuid=self.assignment.uuid,
-                answer_uuid=self.answers[self.assignment.id][0].uuid, answer_comment_uuid=comment.uuid)
+                answer_uuid=self.answers[self.assignment.id][1].uuid, answer_comment_uuid=comment.uuid)
             rv = self.client.delete(url)
             self.assert403(rv)
             self.assertTrue(rv.json['disabled_by_impersonation'])

--- a/compair/tests/api/test_answers.py
+++ b/compair/tests/api/test_answers.py
@@ -330,6 +330,14 @@ class AnswersAPITests(ComPAIRAPITestCase):
                     data=json.dumps(expected_answer), content_type='application/json')
                 self.assert404(rv)
 
+                # test assignment from a different course
+                second_fixtures = TestFixture().add_course(num_students=1)
+                rv = self.client.post(
+                    self._build_url(self.fixtures.course.uuid, second_fixtures.assignment.uuid),
+                    data=json.dumps(expected_answer), content_type='application/json')
+                self.assert403(rv)
+                self.assertEqual("Answer Not Submitted", rv.json['title'])
+
             # check that students can only submit answers when they are enrolled in a group for group assignments
             if assignment == self.group_assignment.id:
                 self.fixtures.add_students(1)
@@ -781,6 +789,21 @@ class AnswersAPITests(ComPAIRAPITestCase):
                     data=json.dumps(expected), content_type='application/json')
                 self.assert404(rv)
 
+                # test assignment from a different course
+                second_fixtures = TestFixture().add_course(num_students=1)
+                rv = self.client.post(
+                    self._build_url(self.fixtures.course.uuid, second_fixtures.assignment.uuid, '/' + answer.uuid),
+                    data=json.dumps(expected), content_type='application/json')
+                self.assert403(rv)
+                self.assertEqual("Answer Not Saved", rv.json['title'])
+
+                # test answer from a different assignment (use second_fixtures answer which is always active)
+                rv = self.client.post(
+                    self._build_url(self.fixtures.course.uuid, assignment.uuid, '/' + second_fixtures.answers[0].uuid),
+                    data=json.dumps(expected), content_type='application/json')
+                self.assert403(rv)
+                self.assertEqual("Answer Not Saved", rv.json['title'])
+
             # test unmatched answer id
             self.fixtures.add_students(1)
             self.fixtures.add_group(self.fixtures.course)
@@ -1075,6 +1098,19 @@ class AnswersAPITests(ComPAIRAPITestCase):
                 # test invalid answer id
                 rv = self.client.delete(self.base_url + '/999')
                 self.assert404(rv)
+
+                # test assignment from a different course
+                second_fixtures = TestFixture().add_course(num_students=1)
+                rv = self.client.delete(
+                    self._build_url(self.fixtures.course.uuid, second_fixtures.assignment.uuid, '/' + answer.uuid))
+                self.assert403(rv)
+                self.assertEqual("Answer Not Deleted", rv.json['title'])
+
+                # test answer from a different assignment (use second_fixtures answer which is always active)
+                rv = self.client.delete(
+                    self._build_url(self.fixtures.course.uuid, assignment.uuid, '/' + second_fixtures.answers[0].uuid))
+                self.assert403(rv)
+                self.assertEqual("Answer Not Deleted", rv.json['title'])
 
                 course_grade = CourseGrade.get_user_course_grade(self.fixtures.course, student).grade
                 assignment_grade = AssignmentGrade.get_user_assignment_grade(assignment, student).grade

--- a/compair/tests/api/test_users.py
+++ b/compair/tests/api/test_users.py
@@ -1534,12 +1534,12 @@ class UsersAPITests(ComPAIRAPITestCase):
             rv = self.client.post(url.format("999"), data=json.dumps(data), content_type='application/json')
             self.assert404(rv)
 
-            # test instructor changes the password of a student in the course
+            # test instructor cannot change the password of a student in the course
             rv = self.client.post(
                 url.format(self.data.get_authorized_student().uuid), data=json.dumps(data),
                 content_type='application/json')
-            self.assert200(rv)
-            self.assertEqual(self.data.get_authorized_student().uuid, rv.json['id'])
+            self.assert403(rv)
+            self.assertEqual("Password Not Saved", rv.json['title'])
 
             # test changing own password
             rv = self.client.post(

--- a/compair/tests/api/test_users.py
+++ b/compair/tests/api/test_users.py
@@ -126,26 +126,8 @@ class UsersAPITests(ComPAIRAPITestCase):
             self.assertEqual(1, rv.json['total'])
 
         with self.login(self.data.authorized_instructor.username):
-            expected = sorted(
-                [user for user in self.data.users],
-                key=lambda user: (user.lastname, user.firstname)
-            )[:20]
             rv = self.client.get('/api/users')
-            self.assert200(rv)
-            result = rv.json['objects']
-            self.assertEqual([u.uuid for u in expected], [u['id'] for u in result])
-            self.assertEqual(1, rv.json['page'])
-            self.assertEqual(1, rv.json['pages'])
-            self.assertEqual(20, rv.json['per_page'])
-            self.assertEqual(len(expected), rv.json['total'])
-
-            rv = self.client.get('/api/users?search='+self.data.get_unauthorized_instructor().firstname)
-            self.assert200(rv)
-            self.assertEqual(self.data.get_unauthorized_instructor().uuid, rv.json['objects'][0]['id'])
-            self.assertEqual(1, rv.json['page'])
-            self.assertEqual(1, rv.json['pages'])
-            self.assertEqual(20, rv.json['per_page'])
-            self.assertEqual(1, rv.json['total'])
+            self.assert403(rv)
 
     def test_create_user(self):
         url = '/api/users'


### PR DESCRIPTION
A few broken access control issues found:

**Cross-course answer/comment submission**
  - Reject answers and comments where the assignment or answer does not belong to the course in the URL, across all write paths (create, edit, delete)
- Previously, a student enrolled in any course could submit, edit, or delete answers/comments to assignments in courses they were not enrolled in by passing in a mismatched course UUID in the request URL. These answers would get added to the database and would show up in the answer pairing phase
-   Grade recalculations and activity logs use the course and assignment objects resolved from the URL, so mismatched UUIDs could corrupt grade data and audit logs even when the user only affects their own resources

**User list over-grant**
- Restrict `GET /api/users` to admins only (`MANAGE, User`)
- Previously, any instructor could call this endpoint directly and get names and student numbers for all users in the system


**Instructor password reset**
- Restrict `POST /api/users/<uuid>/password` so only admins can reset another user's password
- Previously, instructors could reset student passwords without knowing the old password via direct API call
- Git history never showed that this was a "feature" and the reset password was always only showed for your own user or for admins

**Frontend missing redirects**
- Add authorization checks in `UserWriteController` and `CourseController` to redirect unauthorized users away from the Add User, Edit User, and Add Course pages
- Add `canAddCourse` to the `/course/create` route resolve
