### PR TITLE
Fix pip dependency vulnerabilities: urllib3, idna, scipy, numpy

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,3 @@
 scipy>=1.10.0
-numpy>=1.22.0
+numpy>=1.22.2
 pillow==12.2.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,3 @@
-# scipy 1.8 seems to be missing packages for python 3.7, so we'll stay with
-# 1.7.3 until python 3.7 is dropped
-scipy==1.7.3
-# numpy 1.22 seems to be missing packages for python 3.7, so we'll stay with
-# 1.21.6 until python 3.7 is dropped
-numpy==1.22.0
+scipy>=1.10.0
+numpy>=1.22.0
 pillow==12.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,9 @@ Werkzeug==3.1.6
 # required for the lti library
 oauthlib==3.2.2
 requests==2.33.0
+# security floor pins for transitive deps pulled in by requests (CVEs fixed in these versions)
+urllib3>=2.7.0
+idna>=3.15
 requests-oauthlib==1.3.1
 markupsafe==2.1.5
 itsdangerous==2.2.0


### PR DESCRIPTION
Summary
  - Add minimum version pins for `urllib3>=2.7.0` and `idna>=3.15` in `requirements.txt` to address known CVEs in transitive dependencies pulled in by requests
  - Upgrade `scipy>=1.10.0` and remove the hard Python 3.7 version pins for `scipy` and `numpy` in `requirements.dev.txt`

Notes
- `urllib3` and `idna` are not direct dependencies but are pulled in by `requests`. Without explicit floor pins, older vulnerable versions could be resolved. These pins enforce the patched minimum without locking to an exact version.
- The `scipy==1.7.3` and `numpy==1.22.0` pins existed solely to work around missing packages for Python 3.7. Now that we're not on Python 3.7, those workarounds are removed and both packages are allowed to resolve to current versions.

Changes
  - urllib3 2.6.3 -> 2.7.0: PYSEC-2026-141, PYSEC-2026-142
  - idna 3.13 -> 3.15: PYSEC-2026-215
  - scipy 1.7.3 -> 1.10.0: PYSEC-2023-102
  - scipy 1.7.3 -> 1.8.0: PYSEC-2023-114